### PR TITLE
harden: defense-in-depth + 4 new Kani proofs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,8 @@ pub enum StakeError {
     InvalidPercolatorProgram = 14,
     /// CPI to percolator failed
     CpiFailed = 15,
+    /// Invalid account ownership
+    InvalidAccount = 16,
 }
 
 impl From<StakeError> for ProgramError {


### PR DESCRIPTION
## Changes

### Defense-in-Depth (from audit recommendations)
- **I4**: Verify deposit PDA ownership for existing accounts
- **I5**: Validate vault_auth derivation in Deposit and Withdraw
- **I3**: Add 8-byte discriminators to StakePool and StakeDeposit (backwards-compatible)
- **I7**: Block deposits after market resolution

### Formal Verification
- 4 new Kani proofs: roundtrip-under-value-change, inflation-attack resistance, cooldown-IFF, flush-conservation
- Fix 1 WEAK proof → STRONG (cross-branch determinism)

### Testing
- All 141 existing tests pass
- No breaking changes (backwards-compatible discriminator handling)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation for deposits and withdrawals with account discriminator checks.
  * Market resolution now blocks future deposits to resolved pools.
  * Added vault authority validation for deposit flows.

* **Bug Fixes**
  * Improved account type validation to prevent unauthorized operations.

* **Tests**
  * Expanded test coverage for pool invariants, edge cases, and conservation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->