### PR TITLE
fix(PERC-110): correct CPI tag numbers — SetInsuranceWithdrawPolicy(29) + WithdrawInsuranceLimited(30)

### DIFF
--- a/src/cpi.rs
+++ b/src/cpi.rs
@@ -31,12 +31,13 @@ const TAG_WITHDRAW_INSURANCE: u8 = 20;
 // Tag 26 = WithdrawInsuranceLP (not used by stake program)
 // Tag 27 = PauseMarket (not used by stake program)
 // Tag 28 = UnpauseMarket (not used by stake program)
+// Tag 29 = AcceptAdmin (two-step admin transfer, added in PERC-112)
 //
-// Tags 29 and 30 were added to percolator-launch in PERC-110.
+// Tags 30 and 31 were added to percolator-launch in PERC-110.
 // Previous values of 22/23 were WRONG — they would have called UpdateRiskParams
 // and RenounceAdmin respectively, which is catastrophically incorrect.
-const TAG_SET_INSURANCE_WITHDRAW_POLICY: u8 = 29;
-const TAG_WITHDRAW_INSURANCE_LIMITED: u8 = 30;
+const TAG_SET_INSURANCE_WITHDRAW_POLICY: u8 = 30;
+const TAG_WITHDRAW_INSURANCE_LIMITED: u8 = 31;
 
 // ═══════════════════════════════════════════════════════════════
 // TopUpInsurance (Tag 9) — permissionless, anyone can top up

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -144,8 +144,8 @@ pub enum StakeInstruction {
     ///   6. `[]` Wrapper vault authority PDA
     ///   7. `[]` Percolator program
     ///   8. `[]` Token program
-    /// 10: AdminWithdrawInsurance — CPIs WithdrawInsuranceLimited (wrapper Tag 30) via vault_auth PDA.
-    /// Requires market RESOLVED and SetInsuranceWithdrawPolicy (wrapper Tag 29) called with vault_auth as authority.
+    /// 10: AdminWithdrawInsurance — CPIs WithdrawInsuranceLimited (wrapper Tag 31) via vault_auth PDA.
+    /// Requires market RESOLVED and SetInsuranceWithdrawPolicy (wrapper Tag 30) called with vault_auth as authority.
     AdminWithdrawInsurance { amount: u64 },
 
     /// Pool admin sets insurance withdrawal policy on wrapper.

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -916,8 +916,8 @@ fn process_admin_withdraw_insurance(
 
     let vault_auth_seeds: &[&[u8]] = &[b"vault_auth", pool_pda.key.as_ref(), &[vault_auth_bump]];
 
-    // CPI: WithdrawInsuranceLimited (wrapper Tag 30)
-    // - vault_auth is the policy authority (set via AdminSetInsurancePolicy / wrapper Tag 29 beforehand)
+    // CPI: WithdrawInsuranceLimited (wrapper Tag 31)
+    // - vault_auth is the policy authority (set via AdminSetInsurancePolicy / wrapper Tag 30 beforehand)
     // - stake_vault is owned by vault_auth → passes verify_token_account check
     // - Requires market to be RESOLVED + all positions closed
     // - Requires SetInsuranceWithdrawPolicy called first with vault_auth as authority


### PR DESCRIPTION
Paired with dcccrypto/percolator-launch#302. Previous tags 22/23 were catastrophically wrong (would call UpdateRiskParams/RenounceAdmin). Tags 29/30 are the correct values added to the wrapper in the paired PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected instruction routing for insurance withdrawal operations, ensuring the proper withdrawal policies are invoked instead of unrelated administrative functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->