### PR TITLE
fix(PERC-111): Fix open audit findings H1 + M2 struct versioning

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -290,6 +290,14 @@ fn process_deposit(
         return Err(StakeError::InvalidPda.into());
     }
 
+    // H1: Require admin transfer before accepting deposits.
+    // Without this, users can deposit into a pool where the stake program
+    // doesn't yet have admin control over the wrapper — their funds would
+    // be unprotected by the stake program's safety mechanisms.
+    if pool.admin_transferred != 1 {
+        return Err(StakeError::AdminNotTransferred.into());
+    }
+
     // I7: Block deposits after market resolution
     if pool._reserved[0] != 0 {
         return Err(StakeError::MarketResolved.into());

--- a/src/state.rs
+++ b/src/state.rs
@@ -153,9 +153,19 @@ impl StakePool {
         Pubkey::new_from_array(self.percolator_program)
     }
 
-    /// Set discriminator in first 8 bytes of _reserved. Call on init.
+    /// Current struct version. Increment when layout changes.
+    pub const CURRENT_VERSION: u8 = 1;
+
+    /// Set discriminator in first 8 bytes of _reserved and version in byte 8.
+    /// Call on init.
     pub fn set_discriminator(&mut self) {
         self._reserved[..8].copy_from_slice(&STAKE_POOL_DISCRIMINATOR);
+        self._reserved[8] = Self::CURRENT_VERSION;
+    }
+
+    /// Read the struct version (byte 8 of _reserved). Returns 0 for pre-versioning accounts.
+    pub fn version(&self) -> u8 {
+        self._reserved[8]
     }
 
     /// Validate discriminator. Accepts zeroed (pre-upgrade accounts) or correct value.


### PR DESCRIPTION
## Changes

### H1: Block deposits before admin transfer
Users could deposit into a pool where the stake program doesn't yet have admin control over the wrapper. Their funds would bypass all stake program safety mechanisms.

Fix: Added `admin_transferred != 1` check in `process_deposit`.

### M2: Add struct versioning  
96-byte `_reserved` field had discriminator but no version byte. Without versioning, layout changes after first mainnet account creation would break existing accounts permanently.

Fix: Byte 8 of `_reserved` now holds struct version (currently 1). `set_discriminator()` writes both discriminator + version. `version()` accessor added.

### Tests
- ✅ 39 unit tests pass
- ✅ 17 proptests pass

Resolves PERC-111