### PR TITLE
ci: Add CI workflow — build, clippy, fmt, Kani proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build + Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo build --features no-entrypoint
+      - run: cargo test --features no-entrypoint,test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+      - run: cargo clippy --features no-entrypoint -- -D warnings -A clippy::too_many_arguments -A clippy::needless_borrow -A clippy::op_ref -A clippy::collapsible_if -A clippy::doc_lazy_continuation
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+      - run: cargo fmt -- --check
+
+  kani:
+    name: Kani Proofs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Kani
+        uses: model-checking/kani-github-action@v1.1
+        with:
+          kani-version: '0.67.0'
+      - name: Run Kani proofs
+        run: cargo kani --tests --output-format terse
+        timeout-minutes: 60


### PR DESCRIPTION
## PERC-235: Add CI for percolator-stake

This repo ships on-chain staking code with 60 Kani harnesses but had **zero automated testing**.

### CI Jobs
- **Build + Test**: `cargo build/test --features no-entrypoint`
- **Clippy**: with allowances for pre-existing lints (too_many_arguments, op_ref, collapsible_if, doc_lazy_continuation)
- **Format**: `cargo fmt --check`
- **Kani**: Runs all 60 formal verification proofs (60min timeout)

### Notes
- Uses `no-entrypoint` feature to avoid SBF-specific code on native CI runners
- Kani job uses kani-github-action v1.1 with Kani 0.67.0
- Pre-existing clippy lints allowed to unblock CI; can be fixed incrementally