### PR TITLE
fix: add validate_pool_version to Withdraw, Flush, AccrueFees, DepositJunior

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -635,6 +635,7 @@ fn process_withdraw(
     if !pool.validate_discriminator() {
         return Err(StakeError::InvalidAccount.into());
     }
+    validate_pool_version(pool)?;
     if pool.lp_mint != lp_mint.key.to_bytes() {
         return Err(StakeError::InvalidMint.into());
     }
@@ -880,6 +881,7 @@ fn process_flush_to_insurance(
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
     }
+    validate_pool_version(pool)?;
 
     // CRITICAL (C10): FlushToInsurance must be admin-only.
     // Without this, ANY signer can drain the stake vault to wrapper insurance,
@@ -1343,6 +1345,7 @@ fn process_accrue_fees(_program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     if pool.is_initialized != 1 {
         return Err(ProgramError::UninitializedAccount);
     }
+    validate_pool_version(pool)?;
 
     // Only trading LP mode pools accrue fees
     if pool.pool_mode != 1 {
@@ -1552,6 +1555,7 @@ fn process_deposit_junior(
     if !pool.validate_discriminator() {
         return Err(StakeError::InvalidAccount.into());
     }
+    validate_pool_version(pool)?;
     if !pool.tranche_enabled() {
         return Err(StakeError::TrancheNotEnabled.into());
     }


### PR DESCRIPTION
## Summary
- `validate_pool_version` was only called in `process_deposit` (line 403)
- `process_withdraw`, `process_flush_to_insurance`, `process_accrue_fees`, and `process_deposit_junior` all skip it
- After a future program upgrade that bumps `CURRENT_VERSION`, un-migrated pools would block deposits (correct) but still allow withdrawals, flushes, fee accrual, and junior deposits against a potentially incompatible state layout

## Severity
**MEDIUM** — latent forward-compatibility bug; not exploitable today (only version 1 exists) but will cause silent state corruption on the first schema migration

## Fix
Added `validate_pool_version(pool)?;` to all four handlers, placed after the discriminator/initialized checks, consistent with `process_deposit`.

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy` — zero warnings
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)