### PR TITLE
fix(kani): add non-zero preconditions to proof_equal_deposits_equal_lp

### DIFF
--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -195,14 +195,19 @@ mod kani_proofs {
     // ═══════════════════════════════════════════════════════════
 
     /// PROOF: Equal deposits get equal LP tokens (deterministic).
+    ///
+    /// Previous version allowed supply=0, pv=0, amount=0 which made the proof
+    /// vacuously pass (None == None) without exercising any pro-rata arithmetic.
+    /// Now requires supply > 0, pv > 0, and amount > 0 so CBMC must verify the
+    /// actual proportional calculation path, not just the None-return early exits.
     #[kani::proof]
     fn proof_equal_deposits_equal_lp() {
         let supply: u64 = kani::any();
         let pv: u64 = kani::any();
         let amount: u64 = kani::any();
-        kani::assume(supply <= 1_000_000_000);
-        kani::assume(pv <= 1_000_000_000);
-        kani::assume(amount <= 1_000_000_000);
+        kani::assume(supply > 0 && supply <= 1_000_000_000);
+        kani::assume(pv > 0 && pv <= 1_000_000_000);
+        kani::assume(amount > 0 && amount <= 1_000_000_000);
 
         let lp1 = calc_lp_for_deposit(supply, pv, amount);
         let lp2 = calc_lp_for_deposit(supply, pv, amount);


### PR DESCRIPTION
## Summary

- **MEDIUM:** The Kani proof `proof_equal_deposits_equal_lp` allowed `supply=0, pv=0, amount=0` which caused `calc_lp_for_deposit` to return `None` in both calls. The assertion `None == None` passed trivially — CBMC never explored the actual proportional LP arithmetic (the u128 multiply-and-divide path).

## Changes

- Add `kani::assume(supply > 0)`, `kani::assume(pv > 0)`, `kani::assume(amount > 0)` to force CBMC through the pro-rata calculation path
- Add doc comment explaining the fix and why the preconditions are needed
- Zero-amount and empty-pool cases are already covered by unit tests and `proof_first_depositor_exact`

## Test plan

- [x] 207 total tests pass, 0 clippy warnings
- [x] Kani proofs are not run in CI (local only), but the `#[cfg(kani)]` gating compiles cleanly
- [x] Verified `proof_first_depositor_exact` (line 88) already covers the `amount > 0, supply=0, pv=0` case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>