### PR TITLE
docs: fix 8 stale CPI tag comments referencing old values 30/31/21

### DIFF
--- a/src/cpi.rs
+++ b/src/cpi.rs
@@ -21,8 +21,8 @@ use solana_program::{
 // VERSION BINDING:
 //   Corresponds to percolator-prog instruction layout as of PERC-110 / PERC-112.
 //   Last verified against percolator-prog commit that introduced:
-//     - Tag 30: SetInsuranceWithdrawPolicy (PERC-110)
-//     - Tag 31: WithdrawInsuranceLimited (PERC-110)
+//     - Tag 22: SetInsuranceWithdrawPolicy (PERC-110)
+//     - Tag 23: WithdrawInsuranceLimited (PERC-110)
 //     - Tag 29: AcceptAdmin two-step transfer (PERC-112)
 //
 // If the wrapper ever renumbers instructions, update these constants AND increment
@@ -316,7 +316,7 @@ pub fn cpi_withdraw_insurance<'a>(
 }
 
 // ═══════════════════════════════════════════════════════════════
-// SetInsuranceWithdrawPolicy (Tag 21) — admin only, requires RESOLVED
+// SetInsuranceWithdrawPolicy (Tag 22) — admin only, requires RESOLVED
 // ═══════════════════════════════════════════════════════════════
 // Accounts: [admin(signer), slab(w)]
 // Data: tag(1) + authority(32) + min_withdraw_base(8) + max_withdraw_bps(2) + cooldown_slots(8)
@@ -351,7 +351,7 @@ pub fn cpi_set_insurance_withdraw_policy<'a>(
 }
 
 // ═══════════════════════════════════════════════════════════════
-// WithdrawInsuranceLimited (Tag 31) — policy authority, requires RESOLVED
+// WithdrawInsuranceLimited (Tag 23) — policy authority, requires RESOLVED
 // ═══════════════════════════════════════════════════════════════
 // Accounts (7): [authority(signer), slab(w), authority_ata(w), vault(w),
 //                token_program, vault_pda, clock]

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -145,8 +145,8 @@ pub enum StakeInstruction {
     ///   7. `[]` Percolator program
     ///   8. `[]` Token program
     ///
-    /// 10: AdminWithdrawInsurance — CPIs WithdrawInsuranceLimited (wrapper Tag 31) via vault_auth PDA.
-    /// Requires market RESOLVED and SetInsuranceWithdrawPolicy (wrapper Tag 30) called with vault_auth as authority.
+    /// 10: AdminWithdrawInsurance — CPIs WithdrawInsuranceLimited (wrapper Tag 23) via vault_auth PDA.
+    /// Requires market RESOLVED and SetInsuranceWithdrawPolicy (wrapper Tag 22) called with vault_auth as authority.
     AdminWithdrawInsurance { amount: u64 },
 
     /// Pool admin sets insurance withdrawal policy on wrapper.

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1422,8 +1422,8 @@ fn process_admin_withdraw_insurance(
 
     let vault_auth_seeds: &[&[u8]] = &[b"vault_auth", pool_pda.key.as_ref(), &[vault_auth_bump]];
 
-    // CPI: WithdrawInsuranceLimited (wrapper Tag 31)
-    // - vault_auth is the policy authority (set via AdminSetInsurancePolicy / wrapper Tag 30 beforehand)
+    // CPI: WithdrawInsuranceLimited (wrapper Tag 23)
+    // - vault_auth is the policy authority (set via AdminSetInsurancePolicy / wrapper Tag 22 beforehand)
     // - stake_vault is owned by vault_auth → passes verify_token_account check
     // - Requires market to be RESOLVED + all positions closed
     // - Requires SetInsuranceWithdrawPolicy called first with vault_auth as authority

--- a/tests/cpi_tags.rs
+++ b/tests/cpi_tags.rs
@@ -20,8 +20,8 @@
 ///   Tag 19: ResolveMarket
 ///   Tag 20: WithdrawInsurance
 ///   Tag 21: AdminForceCloseAccount  <-- NOT used by stake program
-///   Tag 30: SetInsuranceWithdrawPolicy  (PERC-110; previously wrong value 22)
-///   Tag 31: WithdrawInsuranceLimited    (PERC-110; previously wrong value 23)
+///   Tag 22: SetInsuranceWithdrawPolicy  (PERC-110; previously wrong value 30)
+///   Tag 23: WithdrawInsuranceLimited    (PERC-110; previously wrong value 31)
 // Re-export the production constants so the tests below compare against them.
 // If a constant is ever changed in src/cpi.rs, this module will fail to compile
 // (name mismatch) or the assertion will catch the wrong value — not a silent pass.


### PR DESCRIPTION
## Summary
The production constants `TAG_SET_INSURANCE_WITHDRAW_POLICY` (22) and `TAG_WITHDRAW_INSURANCE_LIMITED` (23) are correct, but comments in **8 locations across 4 files** still reference old pre-fix values (30, 31, or 21):

| File | Line(s) | Comment Said | Correct Value |
|------|---------|-------------|---------------|
| `src/cpi.rs` | 24-25 | Tag 30/31 | Tag 22/23 |
| `src/cpi.rs` | 319 | Tag 21 | Tag 22 |
| `src/cpi.rs` | 354 | Tag 31 | Tag 23 |
| `src/instruction.rs` | 148 | Tag 31 | Tag 23 |
| `src/instruction.rs` | 149 | Tag 30 | Tag 22 |
| `src/processor.rs` | 1425 | Tag 31 | Tag 23 |
| `src/processor.rs` | 1426 | Tag 30 | Tag 22 |
| `tests/cpi_tags.rs` | 23-24 | Tag 30/31 (with inverted history note) | Tag 22/23 |

## Risk
The old values 30/31 map to `ForceCloseResolved` and an unrecognized tag in the percolator wrapper. A developer reading these stale comments could "correct" the constants back to 30/31, causing a **catastrophic regression** — the stake program would invoke completely wrong wrapper instructions.

## Severity
**MEDIUM** — no runtime impact (comment-only change), but high regression risk for future maintenance

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy` — zero warnings
- [x] Verified diff is comment-only (10 insertions, 10 deletions, zero code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CPI instruction tag constants for insurance-related operations. Updated documentation and test expectations throughout the codebase to reflect accurate tag identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->