### PR TITLE
fix: add missing refresh_hwm call in process_deposit_junior

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1947,6 +1947,16 @@ fn process_deposit_junior(
     );
 
     let clock = Clock::from_account_info(clock_sysvar)?;
+
+    // PERC-313: Refresh high-water mark after junior deposit (TVL increased).
+    // Matches the pattern in process_deposit (lines 564-569). Without this,
+    // junior deposits raise TVL without ratcheting the epoch HWM, leaving the
+    // withdrawal floor calculated against a stale (lower) peak.
+    if pool.hwm_enabled() {
+        let current_tvl = pool.total_pool_value().ok_or(StakeError::Overflow)?;
+        pool.refresh_hwm(clock.epoch, current_tvl);
+    }
+
     let (expected_deposit_pda, deposit_bump) =
         state::derive_deposit_pda(program_id, pool_pda.key, user.key);
     if *deposit_pda.key != expected_deposit_pda {


### PR DESCRIPTION
## Summary
- `process_deposit` refreshes the epoch high-water mark after updating pool state (lines 564-569, PERC-313)
- `process_deposit_junior` does **not**, despite also increasing TVL via `total_deposited`, `total_lp_supply`, `junior_total_lp`, and `junior_balance`
- Junior deposits raise `total_pool_value()` without ratcheting `epoch_high_water_tvl`, leaving the HWM-based withdrawal floor calculated against a stale (lower) peak
- If a loss event occurs before the next senior deposit or withdrawal, the peak TVL from the junior deposit is permanently lost from HWM tracking

## Severity
**MEDIUM** — weakens HWM drain protection asymmetrically (senior deposits refresh HWM, junior deposits do not)

## Fix
Added the same `refresh_hwm` block after pool state updates, matching `process_deposit` exactly:
```rust
if pool.hwm_enabled() {
    let current_tvl = pool.total_pool_value().ok_or(StakeError::Overflow)?;
    pool.refresh_hwm(clock.epoch, current_tvl);
}
```

Placement: after all 4 pool state mutations (lines 1930-1947), before deposit PDA logic (line 1960). Uses the `clock` already read at line 1949.

## Verification
- 3 independent agents confirmed the fix is correct, safe, and introduces no new issues
- Identical pattern to `process_deposit` (lines 564-569)
- `total_pool_value()` cannot realistically return None at this point (deposit just increased it)
- HWM writes to `_reserved[16..31]` — no byte conflicts with tranche state (`_reserved[32+]`)

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pool high-water mark synchronization for junior tranche deposits to align with standard deposit operations, ensuring accurate tracking throughout the deposit process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->