### PR TITLE
fix: validate user_ata in process_withdraw to block vault self-transfer

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -726,6 +726,33 @@ fn process_withdraw(
         }
     }
 
+    // Validate user_ata (collateral destination) is not the vault itself and
+    // holds the correct mint.  Without the vault check, an attacker can pass
+    // vault.key as user_ata — the SPL Transfer becomes a no-op self-transfer,
+    // but LP is still burned and total_withdrawn still increments, desyncing
+    // pool accounting from the actual vault balance.
+    // NOTE: owner check is deliberately omitted — on withdrawal the user burns
+    // their own LP and should be free to direct collateral to any address
+    // (cold wallet, multisig, etc.).  This differs from process_deposit where
+    // the owner check prevents draining a delegated victim's ATA.
+    if user_ata.key == vault.key {
+        msg!("Error: user_ata cannot be the pool vault — self-transfer blocked");
+        return Err(StakeError::InvalidAccount.into());
+    }
+    {
+        let ata_data = user_ata.try_borrow_data()?;
+        if ata_data.len() < crate::spl_token::state::ACCOUNT_LEN {
+            return Err(StakeError::InvalidAccount.into());
+        }
+        let mint_bytes: &[u8; 32] = ata_data[0..32]
+            .try_into()
+            .map_err(|_| StakeError::InvalidAccount)?;
+        if mint_bytes != &pool.collateral_mint {
+            msg!("Error: user_ata mint does not match pool collateral_mint");
+            return Err(StakeError::InvalidMint.into());
+        }
+    }
+
     // I5: Validate vault_auth PDA derivation
     let (expected_vault_auth, _) = derive_vault_authority(program_id, pool_pda.key);
     if *vault_auth.key != expected_vault_auth {


### PR DESCRIPTION
## Summary
- `process_withdraw` had **zero validation** on `user_ata` (collateral destination, account[5])
- `process_deposit` (lines 480-504) and `process_deposit_junior` (lines 1856-1877) both validate user_ata's mint and owner — `process_withdraw` was the only handler that skipped this
- An attacker can pass `vault.key` as `user_ata`, causing an SPL Token self-transfer (vault→vault, no-op on balance) while LP tokens are still burned and `total_withdrawn` is incremented
- This desyncs pool accounting from actual vault balance (`vault_balance > total_pool_value()`)

## Attack Impact
- Pool accounting undervalues actual vault holdings
- Subsequent depositors get more LP per collateral than they should (LP pricing based on deflated pool_value)
- HWM floor calculations use the wrong TVL
- Deposit cap checks use the wrong pool value
- The attacker sacrifices their own LP (self-griefing), but could profit if they hold positions via other accounts

## Fix
Added before any CPI calls (after line 727, before vault_auth PDA derivation):

1. **Vault aliasing check:** `user_ata.key != vault.key` — blocks the self-transfer attack vector
2. **Mint check:** `user_ata` mint must match `pool.collateral_mint` — defense-in-depth, fail-fast with clear error

**Owner check deliberately omitted** — on withdrawal, the user burns their own LP and should be free to direct collateral to any address (cold wallet, multisig, etc.). This differs from `process_deposit` where the owner check prevents a delegation attack that drains a victim's ATA.

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy` — zero warnings
- [x] 3 independent agents confirmed the bug and agreed on the fix approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)