### PR TITLE
fix: junior withdrawal ordering unfairness during active insurance loss

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -905,17 +905,24 @@ fn process_withdraw(
             // (supply=0 but value>0) and locks tokens permanently in the vault.
             pool.set_junior_balance(0);
         } else {
-            // Proportional decrease of the RAW junior_balance based on LP share,
-            // not the loss-adjusted withdrawal_amount.  This keeps the raw balance
-            // in sync with the remaining LP holders' proportional claim.
-            let jb = pool.junior_balance();
-            let raw_decrease = (lp_amount as u128)
-                .checked_mul(jb as u128)
-                .and_then(|v| v.checked_div(junior_lp_before as u128))
-                .map(|v| v as u64)
-                .ok_or(StakeError::Overflow)?;
+            // Decrease junior_balance by withdrawal_amount (the loss-adjusted
+            // collateral actually leaving the vault), NOT by a proportional share
+            // of the raw balance.
+            //
+            // During active insurance loss, withdrawal_amount < proportional raw
+            // share because it is based on effective_junior_balance (post-loss).
+            // Using the larger proportional raw decrease causes gross_senior
+            // (= gross_pool - junior_balance) to inflate after each junior
+            // withdrawal, making distribute_loss over-penalize remaining juniors.
+            // The last junior withdrawer can receive zero even though they hold
+            // a fair share of the effective pool.
+            //
+            // By subtracting withdrawal_amount from both total_withdrawn (above)
+            // and junior_balance here, gross_senior stays constant across partial
+            // junior withdrawals, preserving per-LP effective value.
             pool.set_junior_balance(
-                jb.checked_sub(raw_decrease)
+                pool.junior_balance()
+                    .checked_sub(withdrawal_amount)
                     .ok_or(StakeError::Overflow)?,
             );
         }


### PR DESCRIPTION
## Summary
During active insurance loss (`total_flushed > total_returned`), partial junior withdrawals used a proportional share of the **raw** `junior_balance` as the decrease amount. But `withdrawal_amount` was computed from the **loss-adjusted** `effective_junior_balance`, which is smaller. This mismatch caused `gross_senior` (`= gross_pool - junior_balance`) to inflate after each junior withdrawal, making `distribute_loss` over-penalize remaining junior holders.

## Reproduction
Initial state: `junior_balance=1000`, `junior_total_lp=2`, `total_flushed=500`, 1 senior LP.

| Step | User | withdrawal_amount | raw_decrease (old) | junior_balance after | effective_jb after |
|------|------|------------------|--------------------|---------------------|--------------------|
| 1 | A | 250 | 500 | 500 | **0** |
| 2 | B | **0 (BLOCKED)** | — | — | — |

**Fair outcome:** A gets 250, B gets 250. **Actual (buggy):** A gets 250, B gets 0.

## Root Cause
`raw_decrease = lp_amount * junior_balance / junior_lp_before` removes a proportional share of the gross balance (500), but `total_withdrawn` only increases by `withdrawal_amount` (250). The 250 discrepancy shifts into `gross_senior`, causing `distribute_loss` to re-apply the full `net_loss` against the diminished junior balance.

## Fix
Subtract `withdrawal_amount` from `junior_balance` instead of the proportional raw share. Since `total_withdrawn` also increases by `withdrawal_amount`, `gross_senior = (deposited - withdrawn) - junior_balance` stays constant across partial junior withdrawals.

**Verification with fix:**
| Step | User | withdrawal_amount | junior_balance after | effective_jb after |
|------|------|------------------|---------------------|--------------------|
| 1 | A | 250 | 750 | 250 |
| 2 | B | 250 | 500 | 0 (then zeroed by new_junior_lp==0 branch) |

Both get 250. Fair.

## Severity
**MEDIUM** — first-mover advantage for junior tranche holders during loss periods; last withdrawer can receive zero and have funds permanently locked

## Test plan
- [x] `cargo build` — compiles cleanly
- [x] `cargo clippy` — zero warnings
- [x] 3 independent agents confirmed the bug with exact arithmetic traces
- [x] 3 independent agents unanimously agreed on the fix approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withdrawal accounting accuracy by updating how withdrawal amounts are calculated and applied to balance reconciliation. Withdrawal processing now correctly reflects the actual amounts withdrawn from the vault, ensuring more precise balance tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->