### PR TITLE
docs: fix AdminWithdrawInsurance account order to match processor

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -138,12 +138,13 @@ pub enum StakeInstruction {
     ///   0. `[signer]` Pool admin
     ///   1. `[writable]` Pool PDA (wrapper admin, signs CPI; state updated)
     ///   2. `[writable]` Slab account
-    ///   3. `[writable]` Pool vault token account (receives insurance — "admin_ata" for CPI)
-    ///   4. `[]` Vault authority PDA (owner of pool vault)
+    ///   3. `[]` Vault authority PDA (signer for CPI; owner of pool vault)
+    ///   4. `[writable]` Pool vault token account (receives insurance — "admin_ata" for CPI)
     ///   5. `[writable]` Wrapper vault token account (source)
     ///   6. `[]` Wrapper vault authority PDA
     ///   7. `[]` Percolator program
     ///   8. `[]` Token program
+    ///   9. `[]` Clock sysvar (required by wrapper Tag 23 for post-resolution timing checks)
     ///
     /// 10: AdminWithdrawInsurance — CPIs WithdrawInsuranceLimited (wrapper Tag 23) via vault_auth PDA.
     /// Requires market RESOLVED and SetInsuranceWithdrawPolicy (wrapper Tag 22) called with vault_auth as authority.


### PR DESCRIPTION
## Summary
The doc comment for `AdminWithdrawInsurance` in [src/instruction.rs:137-146](src/instruction.rs#L137-L146) listed **9 accounts** with positions 3 and 4 (pool vault and vault_auth) **swapped** relative to `process_admin_withdraw_insurance`'s actual read order, and **omitted the clock sysvar** at position 9 entirely.

## Impact
Any SDK, keeper, or API client constructing the instruction from the public spec would be broken:

| Position | Doc said | Code reads |
|----------|----------|------------|
| 3 | pool vault token account | **vault_auth PDA** |
| 4 | vault_auth PDA | **pool vault token account** |
| 9 | — (not documented) | **clock sysvar** |

A spec-following client would either:
1. Pass 9 accounts → `NotEnoughAccountKeys` when code reads `clock` at `processor.rs:1406`
2. Even with 10 accounts in docs' order, hit `InvalidPda` on the `pool.vault` check at `processor.rs:1435` after the swapped position reads

**Fails closed — no fund risk** — but the instruction is unusable by any client building from the public spec. This breaks integration with percolator-sdk, percolator-keeper, and percolator-api.

## Fix
Updated docs to match the processor's actual read order. Code is unchanged since it's functionally correct — changing the code would break any already-built client.

Verified: `clock` is forwarded to `cpi_withdraw_insurance_limited` at `processor.rs:1472` where the wrapper's Tag 23 requires it for post-resolution timing enforcement.

## Severity
**LOW-MEDIUM** — documentation defect; spec-conformant clients cannot call this instruction. No on-chain funds at risk.

## Verification
- 3 independent agents confirmed the bug via exact line quotes
- 3 agents unanimously chose "update docs" over "update code" (non-breaking fix)
- `cargo check` (via sbpf toolchain) passes cleanly
- Docs-only change: `1 file changed, 3 insertions(+), 2 deletions(-)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated account documentation for the `AdminWithdrawInsurance` operation to clarify authority semantics and role assignments.
  * Added Clock system variable requirement documentation for post-resolution timing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->