### PR TITLE
fix: validate authority == vault_auth PDA in AdminSetInsurancePolicy (privilege escalation)

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1521,6 +1521,29 @@ fn process_admin_set_insurance_policy(
         return Err(ProgramError::InvalidArgument);
     }
 
+    // SECURITY: The wrapper's policy `authority` MUST be the vault_auth PDA.
+    // process_admin_withdraw_insurance (Tag 10) signs the matching
+    // WithdrawInsuranceLimited CPI with vault_auth_seeds — that is the ONLY
+    // signer the stake program can produce for this path.  If the admin sets
+    // any other authority here, they (or anyone with that key) can bypass the
+    // stake program entirely by calling the wrapper's WithdrawInsuranceLimited
+    // directly.  Funds extract to the attacker while pool.total_returned is
+    // never incremented, silently desyncing total_pool_value() from reality
+    // and corrupting LP redemption math.
+    //
+    // This mirrors the vault_auth derivation/check in
+    // process_admin_withdraw_insurance at lines 1418-1422.
+    let (expected_vault_auth, _) =
+        Pubkey::find_program_address(&[b"vault_auth", pool_pda.key.as_ref()], program_id);
+    if authority != &expected_vault_auth {
+        msg!(
+            "AdminSetInsurancePolicy: authority must equal vault_auth PDA (expected {}, got {})",
+            expected_vault_auth,
+            authority
+        );
+        return Err(StakeError::InvalidPda.into());
+    }
+
     let bump = validate_admin_cpi(program_id, pool_pda, admin, slab, percolator_program)?;
     let admin_seeds: &[&[u8]] = &[b"stake_pool", slab.key.as_ref(), &[bump]];
 


### PR DESCRIPTION
## Summary
`process_admin_set_insurance_policy` at [processor.rs:1498-1540](src/processor.rs#L1498-L1540) forwarded a caller-supplied `authority: Pubkey` to wrapper Tag 22 (`SetInsuranceWithdrawPolicy`) with zero validation — only `max_withdraw_bps` was range-checked.

## Attack

Post-resolution, an admin executes:

1. `AdminSetInsurancePolicy { authority: admin_wallet, max_withdraw_bps: 10000, cooldown_slots: 0, min_withdraw_base: 0 }`
   - Stake program signs the CPI using the legitimate `pool_pda` admin seeds → wrapper accepts and records `policy.authority = admin_wallet`
2. Admin calls the wrapper's `WithdrawInsuranceLimited` (Tag 23) **directly**, bypassing the stake program — signing as `admin_wallet` (the policy authority), with their own ATA as `authority_ata`
3. Wrapper transfers insurance tokens → admin's wallet

**Accounting impact:** `pool.total_returned` is **never** incremented (the only update is inside `process_admin_withdraw_insurance`, which is skipped). `total_pool_value()` continues reporting funds as "pending in insurance" while they are actually in the attacker's wallet. LP holders see no anomaly until they try to withdraw against a pool that doesn't hold the expected collateral.

## Severity
**HIGH** — genuine privilege escalation / post-resolution rug vector. The admin trust assumption for this program is "admin can trigger operations that route insurance into the pool vault for LP redemption." This flaw exceeds that trust: admin can redirect insurance to themselves and silently skip stake-program accounting.

## Fix
Derive the `vault_auth` PDA and require `authority == expected_vault_auth` before the CPI. Mirrors the exact check already present in `process_admin_withdraw_insurance` at lines 1418-1422.

```rust
let (expected_vault_auth, _) =
    Pubkey::find_program_address(&[b"vault_auth", pool_pda.key.as_ref()], program_id);
if authority != &expected_vault_auth {
    return Err(StakeError::InvalidPda.into());
}
```

## Design justification
The `vault_auth` PDA is the **only** signer the stake program can produce for `WithdrawInsuranceLimited`. Any other authority value either:
- Enables the bypass attack above, OR
- Permanently bricks legitimate withdrawals (wrong signer)

There is no legitimate alternate value. Considered but rejected Option B (remove the parameter entirely) because it's a breaking ABI change; runtime validation is the minimal safe fix for an active audit cycle.

## Test plan
- [x] `cargo check` via sbpf toolchain — compiles cleanly
- [x] 3 independent agents confirmed the bug with exact exploit trace
- [x] Fix mirrors the established pattern at `process_admin_withdraw_insurance:1418-1422`
- [x] 23 lines added, 0 removed — minimal surface change

## Followup
Consider adding an integration test that:
1. Calls `AdminSetInsurancePolicy` with a non-vault_auth authority
2. Asserts the tx fails with `StakeError::InvalidPda`

Current test suite (`tests/integration.rs` around lines 281-333) only validates CPI tag encoding, using `let authority = [0u8; 32]` — never asserts the constraint. This gap is why the bug reached audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)