### PR TITLE
fix: lock junior_fee_mult_bps once juniors are deposited

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1799,6 +1799,34 @@ fn process_admin_set_tranche_config(
         return Err(ProgramError::InvalidArgument);
     }
 
+    // GOVERNANCE: lock the multiplier once any junior LP exists.
+    //
+    // Junior depositors entered under the current junior_fee_mult_bps — it is
+    // the economic term they accepted for taking first-loss exposure.  Since
+    // process_accrue_fees reads the multiplier live (see distribute_fees call)
+    // with no per-epoch snapshot, a mid-life change would:
+    //   - allow admin to pump the multiplier right before AccrueFees to
+    //     extract outsized fees into an admin-controlled junior position, OR
+    //   - allow admin to depress the multiplier to silently reduce junior
+    //     yield below what depositors were promised.
+    //
+    // Allow idempotent re-writes (same value) so admin tooling can re-apply
+    // config without triggering the lock.  After all juniors withdraw
+    // (junior_total_lp == 0), the multiplier is freely configurable for the
+    // next cohort of depositors.
+    if pool.junior_total_lp() > 0
+        && pool.junior_fee_mult_bps() != junior_fee_mult_bps
+    {
+        msg!(
+            "AdminSetTrancheConfig: junior_fee_mult_bps is locked while juniors \
+             exist (current={}, requested={}, junior_total_lp={})",
+            pool.junior_fee_mult_bps(),
+            junior_fee_mult_bps,
+            pool.junior_total_lp()
+        );
+        return Err(StakeError::Unauthorized.into());
+    }
+
     pool.set_tranche_enabled(true);
     pool.set_junior_fee_mult_bps(junior_fee_mult_bps);
 


### PR DESCRIPTION
## Summary
`process_admin_set_tranche_config` allowed the admin to change `junior_fee_mult_bps` at any time, even while junior LPs were already deposited. Because `process_accrue_fees` reads the multiplier **live** (no per-epoch snapshot, see `distribute_fees` call at L1696), a mid-life change immediately rewrites the fee split for every junior LP.

## Attack
1. Juniors deposit at multiplier `M_1` (economic term they accepted)
2. Vault accumulates trading fees
3. Admin bumps multiplier to `M_2 > M_1`
4. Anyone calls `AccrueFees` — junior sub-pool captures outsized share
5. Admin (holding a junior position) withdraws at the inflated rate
6. Admin resets multiplier to `M_1` to cover tracks

**Inverse attack:** Admin depresses multiplier to silently reduce junior yield below what was promised at deposit time. Depositors have no recourse — they can't back out without losing cooldown/HWM protections.

## Severity
**MEDIUM** — governance/economic risk. Not immediate theft but a clear avenue for admin value extraction or unilateral repricing of outstanding obligations.

## Fix
Block any multiplier change when `junior_total_lp() > 0`. Idempotent re-writes (same value) still succeed so admin tooling can reapply config. Once all juniors withdraw (`junior_total_lp` back to 0), the multiplier is freely configurable for the next cohort.

```rust
if pool.junior_total_lp() > 0
    && pool.junior_fee_mult_bps() != junior_fee_mult_bps
{
    return Err(StakeError::Unauthorized.into());
}
```

## Design rationale
- **Locking post-deposit enforces the economic contract.** Junior LPs take first-loss exposure specifically because of the advertised multiplier. Mutating it is unilateral repricing.
- **Epoch lifecycle works naturally:** deposit window → fees accrue → market resolves → juniors exit → reconfigure → next cohort.
- **Idempotent no-op allowed** so admin tooling re-applying config doesn't trigger false positives.
- **The "no disable" design limitation** (`set_tranche_enabled(true)` hardcoded) is left as-is. Agents A/C raised a "disable mid-flight" attack vector, but because the current code literally cannot disable tranches, that attack surface doesn't exist in practice. A separate follow-up PR can add a proper `enabled: bool` parameter (wire-format change) if the product requires it.

## Verification
- [x] 3 independent agents confirmed the bug and traced the live-multiplier read path through AccrueFees
- [x] Chose Agent B's minimal approach over Agents A/C's full (wire-breaking) approach for consistency with #123/#124/#125/#126 pattern
- [x] `cargo check` via sbpf toolchain — compiles cleanly
- [x] 28 lines added, 0 removed — no ABI change

🤖 Generated with [Claude Code](https://claude.com/claude-code)