### PR TITLE
ci: add BPF tree-shake verification for dev-only CVE ignores

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,86 @@
+name: Audit
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.cargo/audit.toml'
+      - '.github/workflows/audit.yml'
+  schedule:
+    # Weekly Monday 06:00 UTC — catches dep tree regressions in untouched branches.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Enforces the "dev-only, not in BPF binary" rationale in .cargo/audit.toml
+  # by mechanically asserting that ed25519-dalek 1.x and curve25519-dalek 3.x
+  # (the crates with ignored RustSec advisories RUSTSEC-2022-0093 and
+  # RUSTSEC-2024-0344) do not appear in the on-chain dependency tree.
+  #
+  # `cargo audit` itself is tracked separately — upstream cargo-audit 0.21.x
+  # cannot parse CVSS 4.0 advisories present in the current RustSec DB.
+  # See tracking issue for when to add the audit step back.
+  bpf-tree-shake:
+    name: Verify ignored advisories stay dev-only
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
+        with:
+          toolchain: stable
+      - name: Resolve on-chain (non-dev) dependency tree
+        # -e normal excludes dev-dependencies and build-dependencies.
+        # --prefix none strips tree-drawing characters so crate names start at column 0.
+        # This is the set of crates that end up in the BPF .so.
+        run: |
+          cargo tree -e normal --no-default-features --prefix none > on-chain-tree.txt
+          echo "=== On-chain dependency tree ==="
+          cat on-chain-tree.txt
+      - name: Assert ignored-CVE crates are absent from on-chain tree
+        # .cargo/audit.toml ignores RUSTSEC-2022-0093 (ed25519-dalek <2.0) and
+        # RUSTSEC-2024-0344 (curve25519-dalek timing) with the rationale that
+        # these crates are reachable only via [dev-dependencies] (solana-sdk etc.)
+        # and never link into the on-chain BPF binary.  If a future dep change
+        # pulled either crate into the normal tree, the ignores would become
+        # unsafe — fail CI so the regression is caught before mainnet.
+        #
+        # Grep patterns are version-specific: curve25519-dalek v4.x is
+        # legitimately present in the normal tree via solana-program — only
+        # v3.x has the ignored CVE, so no false positive.
+        run: |
+          set -euo pipefail
+          fail=0
+          if grep -E '^ed25519-dalek v1\.' on-chain-tree.txt; then
+            echo "::error::ed25519-dalek 1.x found in on-chain dependency tree."
+            echo "::error::This invalidates the .cargo/audit.toml ignore for RUSTSEC-2022-0093."
+            echo "::error::Either remove the dependency or remove the audit.toml ignore."
+            fail=1
+          fi
+          if grep -E '^curve25519-dalek v3\.' on-chain-tree.txt; then
+            echo "::error::curve25519-dalek 3.x found in on-chain dependency tree."
+            echo "::error::This invalidates the .cargo/audit.toml ignore for RUSTSEC-2024-0344."
+            echo "::error::Either remove the dependency or remove the audit.toml ignore."
+            fail=1
+          fi
+          if [ "$fail" = "0" ]; then
+            echo "OK: ignored-CVE crates absent from on-chain dependency tree."
+          fi
+          exit $fail
+      - name: Upload dependency tree artifact
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        with:
+          name: on-chain-tree
+          path: on-chain-tree.txt


### PR DESCRIPTION
## Summary
[`.cargo/audit.toml`](/.cargo/audit.toml) ignores **RUSTSEC-2022-0093** (ed25519-dalek 1.x) and **RUSTSEC-2024-0344** (curve25519-dalek 3.x) with the rationale that these crates are reachable only through `[dev-dependencies]` (`solana-sdk → ed25519-dalek-bip32 → dalek 1.x`) and never link into the on-chain BPF binary.

**But no CI check mechanically verifies the "dev-only" claim.** If a future dep change pulled either crate into the normal tree, the BPF binary would ship with known-vulnerable code and CI would say nothing — the ignore rules would silently become unsafe.

## Fix
Added [`.github/workflows/audit.yml`](.github/workflows/audit.yml) with a `bpf-tree-shake` job that:

1. Runs `cargo tree -e normal --no-default-features` — excludes `[dev-dependencies]` and `[build-dependencies]`, matching the on-chain build's actual dep surface
2. Greps the result for `ed25519-dalek v1.x` and `curve25519-dalek v3.x` specifically
3. Fails if either appears, with a clear error message pointing to the offending `audit.toml` ignore

Runs on PR, master push, and weekly schedule.

## Local verification

```
$ cargo tree -e normal --no-default-features --prefix none | grep -E '^(ed25519|curve25519)-dalek'
curve25519-dalek v4.1.3        # ← v4.x, not affected by ignored CVE
curve25519-dalek-derive v0.1.1 # ← proc-macro
```

Grep patterns are **version-specific**: `curve25519-dalek v4.1.3` is legitimately present via `solana-program`, but only `v3.x` has the ignored CVE — no false positives.

## Related: companion cargo-audit step blocked upstream

The original audit proposal also included a `cargo audit --deny warnings` step. Local testing revealed `cargo-audit 0.21.2` cannot parse CVSS 4.0 format advisories now present in the RustSec DB:

```
error: error loading advisory database: unsupported CVSS version: 4.0
  RUSTSEC-2026-0066.md | cvss = "CVSS:4.0/AV:N/AC:H/..."
```

CVSS 4.0 support is [merged upstream](https://github.com/rustsec/rustsec/pull/1285) but not yet released to crates.io. Tracking as issue #128 for when upstream ships a fix.

This PR ships the half that **works today and is more important** — the BPF tree-shake mechanically enforces the audit.toml "dev-only" claim against dep-tree regressions.

## Verification
- [x] 3 independent agents confirmed the bug and agreed on workflow structure
- [x] Local run of `cargo tree -e normal --no-default-features --prefix none` verified both grep patterns
- [x] Grep patterns version-specific, confirmed no false positives on legitimate v4.x crates
- [x] Action SHAs pinned to match existing `ci.yml` style
- [x] Companion cargo-audit step tracked separately (issue #128) due to upstream blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)