### PR TITLE
test: add Kani proofs for effective_junior_balance wrapper composition

### DIFF
--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -518,6 +518,197 @@ mod kani_proofs {
     }
 
     // ═══════════════════════════════════════════════════════════
+    // effective_junior_balance Wrapper Composition
+    // ═══════════════════════════════════════════════════════════
+    //
+    // effective_junior_balance is consumed by every junior deposit
+    // (process_deposit_junior) for LP pricing and every junior
+    // withdrawal (process_withdraw) for collateral valuation.  It
+    // composes distribute_loss (already Kani-proven in the proofs
+    // above) with a derivation of gross_senior from raw accounting
+    // fields.  distribute_loss is proven in isolation; these proofs
+    // verify the wrapper composition, including the net_loss == 0
+    // short-circuit, the gross_senior derivation, and the final
+    // saturating_sub — the region involved in the prior BUG-6 fix
+    // where losses were previously double-applied on the junior side.
+
+    /// Panic-freedom for effective_junior_balance across arbitrary
+    /// accounting states (including pathological ones like
+    /// withdrawn > deposited).  All internal arithmetic uses
+    /// saturating_sub or the already-proven distribute_loss.
+    #[kani::proof]
+    fn proof_effective_junior_balance_no_panic() {
+        use bytemuck::Zeroable;
+        use percolator_stake::state::StakePool;
+
+        let junior_balance: u64 = kani::any();
+        let total_deposited: u64 = kani::any();
+        let total_withdrawn: u64 = kani::any();
+        let total_flushed: u64 = kani::any();
+        let total_returned: u64 = kani::any();
+
+        kani::assume(junior_balance <= 1_000_000_000);
+        kani::assume(total_deposited <= 1_000_000_000);
+        kani::assume(total_withdrawn <= 1_000_000_000);
+        kani::assume(total_flushed <= 1_000_000_000);
+        kani::assume(total_returned <= 1_000_000_000);
+
+        let mut pool = StakePool::zeroed();
+        pool.set_discriminator();
+        pool.set_tranche_enabled(true);
+        pool.set_junior_balance(junior_balance);
+        pool.total_deposited = total_deposited;
+        pool.total_withdrawn = total_withdrawn;
+        pool.total_flushed = total_flushed;
+        pool.total_returned = total_returned;
+
+        // If we reach here without panicking, the proof passes.
+        let _ = pool.effective_junior_balance();
+    }
+
+    /// effective_junior_balance() <= junior_balance() for ALL inputs.
+    /// Loss adjustment can only DECREASE the junior side, never inflate.
+    /// This is the load-bearing invariant LP-pricing call sites depend on.
+    #[kani::proof]
+    fn proof_effective_junior_balance_bounded_by_raw() {
+        use bytemuck::Zeroable;
+        use percolator_stake::state::StakePool;
+
+        let junior_balance: u64 = kani::any();
+        let total_deposited: u64 = kani::any();
+        let total_withdrawn: u64 = kani::any();
+        let total_flushed: u64 = kani::any();
+        let total_returned: u64 = kani::any();
+
+        kani::assume(junior_balance <= 1_000_000_000);
+        kani::assume(total_deposited <= 1_000_000_000);
+        kani::assume(total_withdrawn <= 1_000_000_000);
+        kani::assume(total_flushed <= 1_000_000_000);
+        kani::assume(total_returned <= 1_000_000_000);
+
+        let mut pool = StakePool::zeroed();
+        pool.set_discriminator();
+        pool.set_tranche_enabled(true);
+        pool.set_junior_balance(junior_balance);
+        pool.total_deposited = total_deposited;
+        pool.total_withdrawn = total_withdrawn;
+        pool.total_flushed = total_flushed;
+        pool.total_returned = total_returned;
+
+        let eff = pool.effective_junior_balance();
+
+        // Non-vacuity: the loss-application branch is reachable beyond
+        // the trivial net_loss == 0 short-circuit.
+        kani::cover!(
+            eff < junior_balance,
+            "loss-application branch is reachable"
+        );
+
+        assert!(
+            eff <= junior_balance,
+            "effective_junior_balance must never exceed stored junior_balance"
+        );
+    }
+
+    /// When total_flushed == total_returned (no outstanding insurance
+    /// loss), effective_junior_balance() == junior_balance() exactly.
+    /// Pins the net_loss == 0 early-return: a regression that mis-derives
+    /// gross_senior could silently apply a non-zero junior_loss even on
+    /// lossless pools, causing depositors to over-pay for junior LP.
+    #[kani::proof]
+    fn proof_effective_junior_balance_no_loss_identity() {
+        use bytemuck::Zeroable;
+        use percolator_stake::state::StakePool;
+
+        let junior_balance: u64 = kani::any();
+        let total_deposited: u64 = kani::any();
+        let total_withdrawn: u64 = kani::any();
+        let flushed_eq_returned: u64 = kani::any();
+
+        kani::assume(junior_balance <= 1_000_000_000);
+        kani::assume(total_deposited <= 1_000_000_000);
+        kani::assume(total_withdrawn <= 1_000_000_000);
+        kani::assume(flushed_eq_returned <= 1_000_000_000);
+
+        let mut pool = StakePool::zeroed();
+        pool.set_discriminator();
+        pool.set_tranche_enabled(true);
+        pool.set_junior_balance(junior_balance);
+        pool.total_deposited = total_deposited;
+        pool.total_withdrawn = total_withdrawn;
+        // Key precondition: no outstanding insurance loss.
+        pool.total_flushed = flushed_eq_returned;
+        pool.total_returned = flushed_eq_returned;
+
+        kani::cover!(
+            junior_balance > 0,
+            "identity holds for non-trivial junior_balance"
+        );
+
+        assert_eq!(
+            pool.effective_junior_balance(),
+            junior_balance,
+            "no-loss pool must not adjust junior balance"
+        );
+    }
+
+    /// Tranche conservation: effective_junior + senior == total_pool_value
+    /// when both are well-defined.  senior_balance() is derived as
+    /// total_pool_value() - effective_junior_balance(), so this proves
+    /// the two derived getters are mutually consistent — no value is
+    /// created or destroyed by the tranche split.  Pins the implicit
+    /// precondition senior_balance's checked_sub relies on.
+    #[kani::proof]
+    fn proof_effective_junior_tranche_conservation() {
+        use bytemuck::Zeroable;
+        use percolator_stake::state::StakePool;
+
+        let junior_balance: u64 = kani::any();
+        let total_deposited: u64 = kani::any();
+        let total_withdrawn: u64 = kani::any();
+        let total_flushed: u64 = kani::any();
+        let total_returned: u64 = kani::any();
+
+        kani::assume(junior_balance <= 1_000_000_000);
+        kani::assume(total_deposited <= 1_000_000_000);
+        kani::assume(total_withdrawn <= 1_000_000_000);
+        kani::assume(total_flushed <= 1_000_000_000);
+        kani::assume(total_returned <= 1_000_000_000);
+
+        let mut pool = StakePool::zeroed();
+        pool.set_discriminator();
+        pool.set_tranche_enabled(true);
+        pool.set_junior_balance(junior_balance);
+        pool.total_deposited = total_deposited;
+        pool.total_withdrawn = total_withdrawn;
+        pool.total_flushed = total_flushed;
+        pool.total_returned = total_returned;
+
+        // Only meaningful when the pool accounting is consistent enough
+        // for total_pool_value() and senior_balance() to be well-defined.
+        let tpv = match pool.total_pool_value() {
+            Some(v) => v,
+            None => return,
+        };
+        let senior = match pool.senior_balance() {
+            Some(v) => v,
+            None => return,
+        };
+        let junior = pool.effective_junior_balance();
+
+        kani::cover!(
+            junior > 0 && senior > 0,
+            "both tranches non-empty"
+        );
+
+        assert_eq!(
+            junior + senior,
+            tpv,
+            "tranche conservation violated: junior + senior != total_pool_value"
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════
     // PERC-313: High-Water Mark Floor
     // ═══════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
`StakePool::effective_junior_balance()` ([state.rs:277-304](src/state.rs#L277-L304)) is used in every junior deposit (LP pricing) and every junior withdrawal (collateral valuation). It composes the already-Kani-proven `distribute_loss` with a derivation of `gross_senior` from raw accounting fields.

The wrapper composition itself — the `net_loss == 0` short-circuit, the `gross_senior` derivation, and the final `saturating_sub` — had **no formal verification**. This is the region that was involved in the prior BUG-6 fix where losses were previously double-applied on the junior side. A regression here would silently mis-price junior tranche operations.

## Added Proofs

All 4 proofs added to [tests/kani.rs](tests/kani.rs) inside the existing `#[cfg(kani)] mod kani_proofs` block, between the fee distribution proofs and the HWM section.

### 1. `proof_effective_junior_balance_no_panic`
Panic-freedom across arbitrary accounting states, including pathological cases (`withdrawn > deposited`, `flushed > returned`). All internal arithmetic uses `saturating_sub` or calls the already-proven `distribute_loss`.

### 2. `proof_effective_junior_balance_bounded_by_raw`
`effective_junior_balance() <= junior_balance()` for ALL inputs. Loss adjustment can only decrease, never inflate — the load-bearing invariant LP-pricing call sites depend on. Includes `kani::cover!` guard proving the loss-application branch is reachable beyond the trivial `net_loss == 0` short-circuit.

### 3. `proof_effective_junior_balance_no_loss_identity`
When `total_flushed == total_returned` (no outstanding insurance loss), `effective == junior_balance` exactly. Pins the `net_loss == 0` early-return: a regression that mis-derives `gross_senior` could silently apply a non-zero `junior_loss` even on lossless pools, causing depositors to over-pay for junior LP.

### 4. `proof_effective_junior_tranche_conservation`
`effective_junior + senior_balance == total_pool_value` when both are well-defined. `senior_balance()` is defined as the `total_pool_value()` residual, so this is definitional today — but serves as a regression guard if the senior_balance derivation is ever refactored. Also pins the implicit precondition that `senior_balance()`'s `checked_sub` relies on (`effective_junior <= total_pool_value`).

## Design Choices
- **Bounds:** `<= 1_000_000_000` per symbolic field, matching the established convention for the surrounding `distribute_loss` / `distribute_fees` proofs (CBMC tractability). The underlying arithmetic is scale-invariant — the BUG-6 property is structural, not magnitude-dependent.
- **Location:** Added to `tests/kani.rs` (which already imports `StakePool` directly) rather than `kani-proofs/src/lib.rs` (which uses u32 mirror types and intentionally avoids `StakePool` layout dependencies).
- **Non-breaking:** All proofs behind `#[cfg(kani)]` — no impact on normal builds, `cargo check`, or CI tests.

## Severity
**MEDIUM** — closing a formal verification gap in a safety-critical function. Prevents a class of regression (BUG-6-style double-application, silent `gross_senior` mis-derivation) that unit tests can miss.

## Verification
- [x] 3 agents confirmed the gap and agreed on Kani proofs as the right tool
- [x] 3 agents verified the implementation (API calls, cover guards, vacuity checks) and agreed to ship as-is
- [x] `cargo check` passes (library compiles; proofs gated by `#[cfg(kani)]`)
- [x] All API calls verified against `src/state.rs`: `StakePool::zeroed()`, `set_discriminator()`, `set_tranche_enabled()`, `set_junior_balance()`, public fields (`total_deposited`, `total_withdrawn`, `total_flushed`, `total_returned`), `effective_junior_balance()`, `total_pool_value()`, `senior_balance()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)