### PR TITLE
fix(config): bound cooldown_slots above to prevent permanent withdrawal lock (closes #121)

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -22,10 +22,21 @@ fn verify_token_program(token_program: &AccountInfo) -> ProgramResult {
     Ok(())
 }
 
-/// Validate cooldown_slots parameter: must be > 0 to enforce cooldown.
+/// Upper bound on cooldown_slots (~1 year at ~2.5 slots/sec ≈ 78.84M slots). Long
+/// enough for any realistic withdrawal cooldown, but finite so an admin cannot set
+/// cooldown_slots = u64::MAX (via InitPool/UpdateConfig) and permanently lock
+/// withdrawals — `clock.slot` would never reach the saturating deadline (#121).
+const MAX_COOLDOWN_SLOTS: u64 = 78_840_000;
+
+/// Validate cooldown_slots parameter: must be > 0 to enforce cooldown, and bounded
+/// above so it cannot be used to permanently freeze withdrawals.
 fn validate_cooldown_slots(cooldown_slots: u64) -> ProgramResult {
     if cooldown_slots == 0 {
         msg!("Invalid cooldown_slots: cannot be 0 (would disable cooldown protection)");
+        return Err(ProgramError::InvalidArgument);
+    }
+    if cooldown_slots > MAX_COOLDOWN_SLOTS {
+        msg!("Invalid cooldown_slots: exceeds maximum (~1 year of slots); would permanently lock withdrawals");
         return Err(ProgramError::InvalidArgument);
     }
     Ok(())


### PR DESCRIPTION
Closes #121.

`validate_cooldown_slots` (`src/processor.rs`) only rejected `cooldown_slots == 0`. An admin could set `cooldown_slots = u64::MAX` via `InitPool` or `UpdateConfig`; in `process_withdraw`, `deposit.last_deposit_slot.saturating_add(pool.cooldown_slots)` then yields `u64::MAX`, a deadline `clock.slot` can never reach — permanently freezing **all** withdrawals.

This adds an upper bound `MAX_COOLDOWN_SLOTS = 78_840_000` (~1 year at ~2.5 slots/sec) — long enough for any realistic withdrawal cooldown, but finite so a permanent lock is impossible. It's enforced on both paths that set the value (`process_init_pool` and `process_update_config` both call `validate_cooldown_slots`).

`cargo check` passes. (The exact cap is easy to adjust if you prefer a different ceiling.)
