### PR TITLE
fix(stake,v17): pre-accrue mode-1 fees on the junior deposit path (closes #146)

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -465,21 +465,11 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
         }
     }
 
-    // #136: crystallize any pending trading-fee surplus into share price BEFORE pricing
-    // this deposit, so LP cannot be minted at the stale pre-accrual price and capture
-    // fees earned before the depositor joined. Mode-1 only; read the vault balance here
-    // (before the user->vault transfer below) so only the fee surplus — not this deposit's
-    // own collateral — is folded. pool.vault == vault.key was verified above.
-    if pool.pool_mode == 1 {
-        if *vault.owner != crate::spl_token::id() {
-            return Err(ProgramError::IllegalOwner);
-        }
-        let current_balance = {
-            let vault_data = vault.try_borrow_data()?;
-            crate::spl_token::state::Account::unpack(&vault_data)?.amount
-        };
-        accrue_fees_inner(pool, current_balance)?;
-    }
+    // #136: crystallize pending trading-fee surplus into share price BEFORE pricing this
+    // deposit (mode-1), so LP cannot be minted at the stale pre-accrual price and capture
+    // fees earned before the depositor joined. Reads the vault balance before the
+    // user->vault transfer below; pool.vault == vault.key was verified above.
+    pre_accrue_mode1(pool, vault)?;
 
     // Calculate LP tokens to mint.
     //
@@ -809,21 +799,11 @@ fn process_withdraw(
         is_junior = deposit._reserved[8] == 1;
     }
 
-    // #136: crystallize any pending trading-fee surplus into share price BEFORE pricing
-    // this withdrawal, so the withdrawer realizes their fair share of earned fees (and the
-    // HWM floor sees true TVL) rather than redeeming at the stale pre-accrual price.
-    // Mode-1 only; pool.vault == vault.key was verified above; read the balance before the
-    // vault->user transfer below.
-    if pool.pool_mode == 1 {
-        if *vault.owner != crate::spl_token::id() {
-            return Err(ProgramError::IllegalOwner);
-        }
-        let current_balance = {
-            let vault_data = vault.try_borrow_data()?;
-            crate::spl_token::state::Account::unpack(&vault_data)?.amount
-        };
-        accrue_fees_inner(pool, current_balance)?;
-    }
+    // #136: crystallize pending trading-fee surplus into share price BEFORE pricing this
+    // withdrawal (mode-1), so the withdrawer realizes their fair share of earned fees (and
+    // the HWM floor sees true TVL) rather than redeeming at the stale pre-accrual price.
+    // Reads the vault balance before the vault->user transfer below; pool.vault verified above.
+    pre_accrue_mode1(pool, vault)?;
 
     // PERC-303: Determine withdrawal amount based on tranche
     let withdrawal_amount = if pool.tranche_enabled() && is_junior {
@@ -1693,6 +1673,30 @@ fn process_rotate_insurance_authority(
 // PERC-272: LP Vault — Fee Accrual & Trading Pool Init
 // ============================================================================
 
+/// #136 pre-accrue guard — shared by EVERY path that prices against pool balances
+/// (`process_deposit`, `process_withdraw`, `process_deposit_junior`). Crystallizes any
+/// pending mode-1 trading-fee surplus into share price BEFORE pricing, so LP cannot be
+/// minted/redeemed at the stale pre-accrual price and capture fees earned before joining.
+///
+/// MUST be called AFTER the caller has verified `pool.vault == vault.key` and BEFORE the
+/// caller's user<->vault transfer, so the balance read reflects only the fee surplus and
+/// NOT the operation's own collateral. Mode-0 is a no-op; idempotent (a second call folds
+/// zero surplus). Centralized so the pricing paths cannot drift — this guard was previously
+/// inline-duplicated and the junior path was the one that was missed (see #146).
+fn pre_accrue_mode1(pool: &mut state::StakePool, vault: &AccountInfo) -> ProgramResult {
+    if pool.pool_mode == 1 {
+        if *vault.owner != crate::spl_token::id() {
+            return Err(ProgramError::IllegalOwner);
+        }
+        let current_balance = {
+            let vault_data = vault.try_borrow_data()?;
+            crate::spl_token::state::Account::unpack(&vault_data)?.amount
+        };
+        accrue_fees_inner(pool, current_balance)?;
+    }
+    Ok(())
+}
+
 /// Crystallize any un-accrued vault surplus into pool share price. Shared by the
 /// permissionless `AccrueFees` instruction AND the deposit/withdraw pre-accrue guard
 /// (#136) so every pricing path applies byte-identical accounting.
@@ -2066,6 +2070,15 @@ fn process_deposit_junior(
             return Err(StakeError::Unauthorized.into());
         }
     }
+
+    // #136 (junior): crystallize pending trading-fee surplus into share price BEFORE pricing
+    // this junior deposit (mode-1). process_deposit (senior/global) and process_withdraw
+    // already do this; the junior path was the one that was missed — without it a junior
+    // depositor mints at the stale pre-fee price and a later permissionless AccrueFees hands
+    // them a (multiplier-weighted) share of fees earned before they joined (see #146). Reads
+    // the vault balance before the user->vault transfer below; pool.vault + token program
+    // were verified above.
+    pre_accrue_mode1(pool, vault)?;
 
     // Use effective_junior_balance() so that LP pricing reflects any insurance
     // losses already absorbed by the junior tranche.  Pricing against the raw

--- a/tests/poc_junior_jit_fee_snipe.rs
+++ b/tests/poc_junior_jit_fee_snipe.rs
@@ -1,0 +1,151 @@
+//! PoC / regression — JIT trading-fee snipe on the JUNIOR tranche (mode-1 pools).
+//!
+//! ── The bug ──────────────────────────────────────────────────────────────────
+//! In a trading-LP pool (`pool_mode == 1`) with tranches enabled, trading fees land
+//! in the vault as an UN-ACCRUED surplus (`current_balance > total_pool_value()`)
+//! until the permissionless `AccrueFees` folds them into `total_fees_earned` and
+//! credits the junior tranche's (multiplier-weighted) share into `junior_balance`
+//! via `distribute_fees`.
+//!
+//! `process_deposit` (senior/global path) and `process_withdraw` CRYSTALLIZE that
+//! surplus (`accrue_fees_inner`) BEFORE pricing — the #136 fix. `process_deposit_junior`
+//! does NOT: it prices the junior deposit directly against `effective_junior_balance()`,
+//! which excludes the pending surplus. So a junior depositor mints LP at the stale
+//! pre-fee price and, after `AccrueFees`, captures a share of fees earned BEFORE they
+//! joined — diluting the existing junior LPs. The junior fee multiplier (up to 5x)
+//! makes the captured share strictly larger than the senior-path snipe #136 fixed.
+//!
+//! These tests apply the EXACT functions the program uses
+//! (`calc_junior_lp_for_deposit`, `distribute_fees`, `calc_junior_collateral_for_withdraw`)
+//! and model `accrue_fees_inner` / `total_pool_value()` on a real `StakePool`,
+//! mirroring `tests/poc_jit_fee_snipe.rs`. `junior_jit_fee_snipe_is_profitable_*`
+//! documents the bug; `pre_accrue_before_junior_pricing_prevents_snipe` is the fix guard.
+
+use bytemuck::Zeroable;
+use percolator_stake::math::{
+    calc_junior_collateral_for_withdraw, calc_junior_lp_for_deposit, distribute_fees,
+};
+use percolator_stake::state::StakePool;
+
+const MULT: u16 = 20_000; // junior_fee_mult_bps = 2x
+
+fn mode1_tranche_pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.pool_mode = 1; // trading LP
+    p.set_discriminator();
+    p.set_tranche_enabled(true);
+    p.set_junior_fee_mult_bps(MULT);
+    p
+}
+
+/// First senior deposit (1:1): only touches the global counters; senior_total_lp
+/// and senior_balance are derived (total_lp_supply − junior_total_lp / total_pool_value
+/// − effective_junior_balance).
+fn add_senior(pool: &mut StakePool, vault: &mut u64, amount: u64) {
+    pool.total_deposited += amount;
+    pool.total_lp_supply += amount;
+    *vault += amount;
+}
+
+/// Models `accrue_fees_inner` (mode-1 tranche): fold the vault surplus into
+/// `total_fees_earned` and credit the junior share, snapshotting balances BEFORE the add.
+fn accrue(pool: &mut StakePool, vault: u64) {
+    let pv = pool.total_pool_value().unwrap();
+    if vault > pv && pool.total_lp_supply > 0 {
+        let fee_delta = vault - pv;
+        let snap_j = pool.effective_junior_balance(); // == junior_balance in mode-1 (net_loss=0)
+        let snap_s = pool.senior_balance().unwrap();
+        let (junior_fee, _senior_fee) =
+            distribute_fees(snap_j, snap_s, pool.junior_fee_mult_bps(), fee_delta);
+        pool.total_fees_earned += fee_delta;
+        pool.set_junior_balance(pool.junior_balance() + junior_fee);
+    }
+}
+
+/// CURRENT `process_deposit_junior`: price against `effective_junior_balance()` with NO pre-accrue.
+fn deposit_junior_current(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
+    let lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), pool.effective_junior_balance(), amount)
+        .expect("calc_junior_lp_for_deposit");
+    pool.total_deposited += amount;
+    pool.total_lp_supply += lp;
+    pool.set_junior_total_lp(pool.junior_total_lp() + lp);
+    pool.set_junior_balance(pool.junior_balance() + amount);
+    *vault += amount;
+    lp
+}
+
+/// FIXED `process_deposit_junior`: crystallize pending fees (pre-accrue) BEFORE pricing.
+fn deposit_junior_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
+    accrue(pool, *vault); // <-- the fix: mirror the #136 pre-accrue from process_deposit
+    let lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), pool.effective_junior_balance(), amount)
+        .expect("calc_junior_lp_for_deposit");
+    pool.total_deposited += amount;
+    pool.total_lp_supply += lp;
+    pool.set_junior_total_lp(pool.junior_total_lp() + lp);
+    pool.set_junior_balance(pool.junior_balance() + amount);
+    *vault += amount;
+    lp
+}
+
+fn withdraw_junior(pool: &mut StakePool, vault: &mut u64, lp: u64) -> u64 {
+    let coll =
+        calc_junior_collateral_for_withdraw(pool.junior_total_lp(), pool.effective_junior_balance(), lp)
+            .expect("calc_junior_collateral_for_withdraw");
+    pool.total_withdrawn += coll;
+    pool.total_lp_supply -= lp;
+    pool.set_junior_total_lp(pool.junior_total_lp() - lp);
+    pool.set_junior_balance(pool.junior_balance() - coll);
+    *vault -= coll;
+    coll
+}
+
+#[test]
+fn junior_jit_fee_snipe_is_profitable_with_current_pricing() {
+    let mut pool = mode1_tranche_pool();
+    let mut vault = 0u64;
+
+    // Senior Alice 1M + honest junior Jane 1M.
+    add_senior(&mut pool, &mut vault, 1_000_000);
+    let _jane_lp = deposit_junior_current(&mut pool, &mut vault, 1_000_000);
+
+    // Engine pays 1,000,000 trading fees into the vault — un-accrued surplus.
+    vault += 1_000_000;
+
+    // Eve front-runs the accrual: DepositJunior at the STALE pre-fee price (current code).
+    let eve_dep = 1_000_000u64;
+    let eve_lp = deposit_junior_current(&mut pool, &mut vault, eve_dep);
+
+    // Anyone calls AccrueFees (Eve can bundle it in the same tx).
+    accrue(&mut pool, vault);
+
+    let eve_back = withdraw_junior(&mut pool, &mut vault, eve_lp);
+    assert!(
+        eve_back > eve_dep,
+        "junior JIT snipe must profit (got {eve_back} for {eve_dep})"
+    );
+    assert_eq!(eve_back, 1_400_000, "Eve captures +400,000 of fees she did not earn");
+}
+
+#[test]
+fn pre_accrue_before_junior_pricing_prevents_snipe() {
+    // Regression guard for the fix: crystallize pending fees BEFORE pricing a junior
+    // deposit (mirroring process_deposit / process_withdraw). The JIT depositor then
+    // buys at the post-fee price and gains nothing.
+    let mut pool = mode1_tranche_pool();
+    let mut vault = 0u64;
+
+    add_senior(&mut pool, &mut vault, 1_000_000);
+    let _jane_lp = deposit_junior_fixed(&mut pool, &mut vault, 1_000_000);
+
+    vault += 1_000_000; // fees earned while Jane is the sole junior
+
+    let eve_dep = 1_000_000u64;
+    let eve_lp = deposit_junior_fixed(&mut pool, &mut vault, eve_dep); // pre-accrues -> fair price
+    accrue(&mut pool, vault);
+    let eve_back = withdraw_junior(&mut pool, &mut vault, eve_lp);
+    assert!(
+        eve_back <= eve_dep,
+        "FIX: pre-accrued junior deposit must not profit (got {eve_back} for {eve_dep})"
+    );
+}


### PR DESCRIPTION
Closes #146.

## What

`process_deposit_junior` was the one pricing path that did **not** crystallize pending mode-1 trading fees before pricing — `process_deposit` (senior/global) and `process_withdraw` already did (the #136 fix). So a junior depositor could mint LP at the stale pre-fee price and, after a permissionless `AccrueFees`, capture a multiplier-weighted (up to 5×) share of fees earned **before they joined** — a permissionless JIT fee-snipe against the existing junior LPs.

PoC (2× junior multiplier): deposit 1,000,000 → withdraw **1,400,000 (+400,000)**; with the fix → 999,999 (no profit).

This is a v17-convergence regression: the original #136 fix covered all three pricing paths; v17 kept it on deposit/withdraw and dropped it on the junior path.

## Fix

The #136 pre-accrue block was **inline-duplicated** across the paths — which is exactly how the junior copy went missing. I extracted it into a single shared helper `pre_accrue_mode1(pool, vault)` and routed all three sites through it, so a future pricing path cannot silently drift again.

- The `process_deposit` / `process_withdraw` change is a **behavior-preserving extraction** (the helper body is byte-identical to the removed inline blocks).
- `process_deposit_junior` gets the call placed **before pricing** — after the existing cap / token-program / user-ATA checks and before the user→vault transfer, matching `process_deposit`'s ordering. So it folds only the fee surplus (vault balance read pre-transfer, never the deposit's own collateral) and prices against the **post-accrual** junior balance.

The `vault.owner == spl_token::id()` check is retained in the helper (it validates the vault account is SPL-owned — distinct from `verify_token_program`, which validates the token program). Mode-0 is a no-op; the helper is idempotent.

## Verification

- `cargo build --lib` and `cargo build-sbf`: clean.
- New regression test `tests/poc_junior_jit_fee_snipe.rs` (repo convention, mirrors `tests/poc_jit_fee_snipe.rs`): `junior_jit_fee_snipe_is_profitable_with_current_pricing` documents the +400,000; `pre_accrue_before_junior_pricing_prevents_snipe` guards the fix. Both verified out-of-band against the v17 production functions (current → 1,400,000; fixed → 999,999).
- Reviewed line-by-line; three independent solution proposals converged on this fix, and the helper extraction was chosen specifically to eliminate the duplication that caused the regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced junior liquidity provider pricing to apply fee accrual consistently before computing deposit shares, preventing unintended profit extraction.

* **Tests**
  * Added regression test confirming junior liquidity provider pricing integrity under fee-accrual scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->