### PR TITLE
fix(stake): junior JIT fee-snipe (#146) + junior-mult lock & tranche Kani (#143)

### DIFF
--- a/kani-proofs/src/lib.rs
+++ b/kani-proofs/src/lib.rs
@@ -132,9 +132,123 @@ pub fn pool_inv(supply: u32, pv: u32) -> bool {
 }
 
 // ═══════════════════════════════════════════════════════════════
-// KANI PROOFS — 44 harnesses (42 bounded + 2 INDUCTIVE §14)
+// Tranche math (u32/u64 mirror of percolator-stake/src/math.rs tranche
+// helpers and StakePool::{total_pool_value, effective_junior_balance,
+// senior_balance}). Same arithmetic, narrower types for CBMC tractability.
+//
+// The senior/junior deposit + withdraw helpers delegate to the GLOBAL calc_*
+// over their own SUB-pool (supply, balance) — exactly as production does — so
+// they inherit the C9 orphaned-value guard. There is no separate "bootstrap"
+// branch: a true first sub-pool depositor has sub_balance == 0 (→ 1:1), while
+// orphaned sub-pool value (sub_lp == 0, sub_balance > 0) is rejected.
+// ═══════════════════════════════════════════════════════════════
+
+/// Mirror of calc_senior_lp_for_deposit / calc_junior_lp_for_deposit
+/// (both delegate to calc_lp_for_deposit over the sub-pool supply/balance).
+pub fn calc_subpool_lp_for_deposit(sub_lp: u32, sub_balance: u32, deposit: u32) -> Option<u32> {
+    calc_lp_for_deposit(sub_lp, sub_balance, deposit)
+}
+
+/// Mirror of calc_senior/junior_collateral_for_withdraw (delegate to global).
+pub fn calc_subpool_collateral_for_withdraw(sub_lp: u32, sub_balance: u32, lp: u32) -> Option<u32> {
+    calc_collateral_for_withdraw(sub_lp, sub_balance, lp)
+}
+
+/// Mirror of distribute_loss: the junior tranche absorbs loss first, capped at
+/// the combined balance. Returns (junior_loss, senior_loss).
+pub fn distribute_loss(junior_balance: u32, senior_balance: u32, loss: u32) -> (u32, u32) {
+    let total = (junior_balance as u64).saturating_add(senior_balance as u64);
+    let capped = (loss as u64).min(total);
+    if capped <= junior_balance as u64 {
+        (capped as u32, 0)
+    } else {
+        let senior_loss = capped - junior_balance as u64;
+        (junior_balance, senior_loss as u32)
+    }
+}
+
+/// Mirror of distribute_fees (SIMPLE path). Weighted split: junior weight =
+/// junior_balance * mult_bps, senior weight = senior_balance * 10_000; junior_fee
+/// = floor(total_fee * junior_weight / total_weight), senior_fee = remainder.
+///
+/// Production's u128 overflow fallback (when total_fee * junior_weight exceeds
+/// u128) is unreachable at this mirror's bounded scale, so it is not modelled —
+/// the conservation/bounds invariants proven here are the same ones that fallback
+/// must preserve. Returns (junior_fee, senior_fee), summing to <= total_fee.
+pub fn distribute_fees(
+    junior_balance: u32,
+    senior_balance: u32,
+    junior_fee_mult_bps: u32,
+    total_fee: u32,
+) -> (u32, u32) {
+    if total_fee == 0 {
+        return (0, 0);
+    }
+    let jb = junior_balance as u64;
+    let sb = senior_balance as u64;
+    if jb + sb == 0 {
+        return (0, 0);
+    }
+    let junior_weight = jb * junior_fee_mult_bps as u64;
+    let senior_weight = sb * 10_000;
+    let total_weight = junior_weight + senior_weight;
+    if total_weight == 0 {
+        return (0, 0);
+    }
+    let junior_fee = ((total_fee as u64) * junior_weight / total_weight).min(total_fee as u64);
+    let senior_fee = (total_fee as u64).saturating_sub(junior_fee);
+    (junior_fee as u32, senior_fee as u32)
+}
+
+/// Mirror of StakePool::total_pool_value() for pool_mode 0 (insurance LP):
+/// deposited - withdrawn - flushed + returned.
+pub fn total_pool_value_mode0(deposited: u32, withdrawn: u32, flushed: u32, returned: u32) -> Option<u32> {
+    deposited
+        .checked_sub(withdrawn)?
+        .checked_sub(flushed)?
+        .checked_add(returned)
+}
+
+/// Mirror of StakePool::effective_junior_balance(): junior tranche balance after
+/// absorbing outstanding insurance loss (net_loss = flushed - returned) against
+/// the GROSS (pre-loss) balances.
+pub fn effective_junior_balance(
+    deposited: u32,
+    withdrawn: u32,
+    flushed: u32,
+    returned: u32,
+    junior_balance: u32,
+) -> u32 {
+    let jb = junior_balance;
+    let net_loss = flushed.saturating_sub(returned);
+    if net_loss == 0 {
+        return jb;
+    }
+    let gross_pool = deposited.saturating_sub(withdrawn);
+    let gross_senior = gross_pool.saturating_sub(jb);
+    let (junior_loss, _) = distribute_loss(jb, gross_senior, net_loss);
+    jb.saturating_sub(junior_loss)
+}
+
+/// Mirror of StakePool::senior_balance(): total_pool_value - effective_junior_balance.
+pub fn senior_balance(
+    deposited: u32,
+    withdrawn: u32,
+    flushed: u32,
+    returned: u32,
+    junior_balance: u32,
+) -> Option<u32> {
+    let pv = total_pool_value_mode0(deposited, withdrawn, flushed, returned)?;
+    pv.checked_sub(effective_junior_balance(deposited, withdrawn, flushed, returned, junior_balance))
+}
+
+// ═══════════════════════════════════════════════════════════════
+// KANI PROOFS — 54 harnesses (52 bounded + 2 INDUCTIVE §14)
 // PERC-783: kani::cover!() added to all symbolic proofs to guard
 // against vacuous satisfaction of kani::assume constraints.
+// §15 (10 proofs) closes the tranche-math coverage gap — prior
+// sections cover only the GLOBAL (non-tranche) path. (Restored here:
+// these proofs were dropped in the v17 convergence.)
 // ═══════════════════════════════════════════════════════════════
 
 #[cfg(kani)]
@@ -1319,5 +1433,199 @@ mod proofs {
             total_out <= total_new_in_with_appr,
             "INDUCTIVE: total withdrawn by A+B ≤ total deposited by A+B + appreciation"
         );
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // SECTION 15: Tranche math (10 proofs) — senior/junior sub-pools,
+    // loss & fee distribution, and tranche valuation. Sections 1–14 cover
+    // only the GLOBAL (non-tranche) path; this section closes that gap.
+    //
+    // SAT budget: u16 range (≤ 0xFFFF). With supply,pv ≤ 0xFFFF the products in
+    // calc_*_for_deposit/withdraw stay < u32::MAX, so supply+lp and balance+dep
+    // never overflow (same width argument as §1's bounded proofs).
+    // ════════════════════════════════════════════════════════════
+
+    /// Loss distribution conserves value: junior_loss + senior_loss == the capped
+    /// loss, and neither tranche loses more than it holds.
+    #[kani::proof]
+    fn proof_distribute_loss_conservation() {
+        let jb: u32 = kani::any();
+        let sb: u32 = kani::any();
+        let loss: u32 = kani::any();
+        kani::assume(jb <= 0xFFFF && sb <= 0xFFFF && loss <= 0xFFFF);
+
+        let (jl, sl) = distribute_loss(jb, sb, loss);
+        let capped = (loss as u64).min(jb as u64 + sb as u64);
+        kani::cover!(sl > 0, "COVER: senior-absorbs-loss path is reachable");
+        assert!(jl as u64 + sl as u64 == capped, "loss conserved");
+        assert!(jl <= jb, "junior loss bounded by junior balance");
+        assert!(sl <= sb, "senior loss bounded by senior balance");
+    }
+
+    /// Junior-first: while the loss fits in the junior tranche, senior loses nothing.
+    #[kani::proof]
+    fn proof_distribute_loss_junior_first() {
+        let jb: u32 = kani::any();
+        let sb: u32 = kani::any();
+        let loss: u32 = kani::any();
+        kani::assume(jb <= 0xFFFF && sb <= 0xFFFF && loss <= 0xFFFF);
+        kani::assume(loss <= jb);
+
+        let (jl, sl) = distribute_loss(jb, sb, loss);
+        kani::cover!(sl == 0, "COVER: senior-protected path is reachable");
+        assert!(sl == 0, "senior protected while junior can absorb");
+        assert!(jl == loss, "junior absorbs the full loss");
+    }
+
+    /// Fee distribution conserves value: junior_fee + senior_fee <= total_fee
+    /// always, and == total_fee whenever there is fee and balance to distribute.
+    #[kani::proof]
+    fn proof_distribute_fees_conservation() {
+        let jb: u32 = kani::any();
+        let sb: u32 = kani::any();
+        let mult: u32 = kani::any();
+        let fee: u32 = kani::any();
+        kani::assume(jb <= 0xFFFF && sb <= 0xFFFF && fee <= 0xFFFF);
+        kani::assume(mult > 0 && mult <= 50_000); // production caps junior_fee_mult_bps
+
+        let (jf, sf) = distribute_fees(jb, sb, mult, fee);
+        assert!(jf <= fee, "junior fee bounded by total");
+        assert!(sf <= fee, "senior fee bounded by total");
+        assert!(jf as u64 + sf as u64 <= fee as u64, "fees never exceed total");
+        if fee > 0 && (jb > 0 || sb > 0) {
+            kani::cover!(jf + sf == fee, "COVER: fee-conservation path is reachable");
+            assert!(jf as u64 + sf as u64 == fee as u64, "fee fully conserved when distributable");
+        }
+    }
+
+    /// No fees strand to a phantom senior tranche: with zero senior balance and a
+    /// positive junior balance, the junior captures the entire fee. Underpins the
+    /// first-senior-deposit invariant — senior_balance stays 0 in a junior-only
+    /// pool, so a senior deposit there mints 1:1 (not against an orphan).
+    #[kani::proof]
+    fn proof_distribute_fees_no_senior_all_to_junior() {
+        let jb: u32 = kani::any();
+        let mult: u32 = kani::any();
+        let fee: u32 = kani::any();
+        kani::assume(jb > 0 && jb <= 0xFFFF);
+        kani::assume(fee > 0 && fee <= 0xFFFF);
+        kani::assume(mult > 0 && mult <= 50_000);
+
+        let (jf, sf) = distribute_fees(jb, 0, mult, fee);
+        kani::cover!(jf == fee, "COVER: all-fees-to-junior path is reachable");
+        assert!(jf == fee && sf == 0, "no senior => junior captures all fees");
+    }
+
+    /// C9 for a tranche sub-pool (the bootstrap-bypass fix): a deposit into a
+    /// sub-pool with NO LP but POSITIVE balance (orphaned value) is rejected,
+    /// never minted 1:1.
+    #[kani::proof]
+    fn proof_subpool_deposit_orphan_blocked() {
+        let bal: u32 = kani::any();
+        let dep: u32 = kani::any();
+        kani::assume(bal > 0 && bal <= 0xFFFF);
+        kani::assume(dep > 0 && dep <= 0xFFFF);
+
+        assert!(
+            calc_subpool_lp_for_deposit(0, bal, dep).is_none(),
+            "orphaned sub-pool value must block deposits (C9)"
+        );
+    }
+
+    /// A true first sub-pool depositor (empty sub-pool) mints exactly 1:1.
+    #[kani::proof]
+    fn proof_subpool_first_deposit_one_to_one() {
+        let dep: u32 = kani::any();
+        kani::assume(dep > 0 && dep <= 0xFFFF);
+        kani::cover!(
+            calc_subpool_lp_for_deposit(0, 0, dep) == Some(dep),
+            "COVER: first-subpool-depositor 1:1 path is reachable"
+        );
+        assert_eq!(calc_subpool_lp_for_deposit(0, 0, dep), Some(dep));
+    }
+
+    /// Sub-pool deposit→withdraw round-trip cannot profit (senior and junior both
+    /// price deposit AND withdrawal against the same sub-pool basis — the
+    /// invariant the senior-deposit mispricing fix restored).
+    #[kani::proof]
+    fn proof_subpool_deposit_withdraw_no_profit() {
+        let sub_lp: u32 = kani::any();
+        let sub_bal: u32 = kani::any();
+        let dep: u32 = kani::any();
+        kani::assume(sub_lp > 0 && sub_lp <= 0xFFFF);
+        kani::assume(sub_bal > 0 && sub_bal <= 0xFFFF);
+        kani::assume(dep > 0 && dep <= 0xFFFF);
+
+        let lp = match calc_subpool_lp_for_deposit(sub_lp, sub_bal, dep) {
+            Some(l) if l > 0 => l,
+            _ => return,
+        };
+        let back = match calc_subpool_collateral_for_withdraw(sub_lp + lp, sub_bal + dep, lp) {
+            Some(v) => v,
+            None => return,
+        };
+        kani::cover!(back <= dep, "COVER: subpool round-trip no-profit path is reachable");
+        assert!(back <= dep, "sub-pool deposit-then-withdraw cannot profit");
+    }
+
+    /// Tranche valuation never bricks senior withdrawals: under the pool
+    /// invariants (returns ≤ flushes; junior balance ≤ gross principal),
+    /// effective_junior_balance ≤ total_pool_value, so senior_balance() is always
+    /// Some (its checked_sub never underflows).
+    #[kani::proof]
+    fn proof_senior_balance_never_underflows() {
+        let dep: u32 = kani::any();
+        let wd: u32 = kani::any();
+        let flush: u32 = kani::any();
+        let ret: u32 = kani::any();
+        let jb: u32 = kani::any();
+        kani::assume(dep <= 0xFFFF && wd <= 0xFFFF && flush <= 0xFFFF && ret <= 0xFFFF && jb <= 0xFFFF);
+
+        let pv = match total_pool_value_mode0(dep, wd, flush, ret) {
+            Some(v) => v,
+            None => return, // inconsistent accounting — not a reachable pool state
+        };
+        let gross_pool = match dep.checked_sub(wd) {
+            Some(g) => g,
+            None => return,
+        };
+        // Pool invariants: insurance returns never exceed flushes; junior tranche
+        // balance never exceeds the net principal.
+        kani::assume(ret <= flush);
+        kani::assume(jb <= gross_pool);
+
+        let ejb = effective_junior_balance(dep, wd, flush, ret, jb);
+        kani::cover!(ejb <= pv, "COVER: effective_junior <= pool_value path is reachable");
+        assert!(ejb <= pv, "effective junior balance never exceeds pool value");
+        assert!(
+            senior_balance(dep, wd, flush, ret, jb).is_some(),
+            "senior_balance never underflows under the pool invariants"
+        );
+    }
+
+    /// The two tranches partition the pool exactly:
+    /// senior_balance + effective_junior_balance == total_pool_value.
+    #[kani::proof]
+    fn proof_tranche_decomposition() {
+        let dep: u32 = kani::any();
+        let wd: u32 = kani::any();
+        let flush: u32 = kani::any();
+        let ret: u32 = kani::any();
+        let jb: u32 = kani::any();
+        kani::assume(dep <= 0xFFFF && wd <= 0xFFFF && flush <= 0xFFFF && ret <= 0xFFFF && jb <= 0xFFFF);
+        kani::assume(ret <= flush);
+        kani::assume(jb <= dep.saturating_sub(wd));
+
+        let pv = match total_pool_value_mode0(dep, wd, flush, ret) {
+            Some(v) => v,
+            None => return,
+        };
+        let ejb = effective_junior_balance(dep, wd, flush, ret, jb);
+        let sb = match senior_balance(dep, wd, flush, ret, jb) {
+            Some(v) => v,
+            None => return,
+        };
+        kani::cover!(sb + ejb == pv, "COVER: tranche-decomposition path is reachable");
+        assert!(sb as u64 + ejb as u64 == pv as u64, "senior + effective_junior == pool value");
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1963,6 +1963,34 @@ fn process_admin_set_tranche_config(
         return Err(ProgramError::InvalidArgument);
     }
 
+    // GOVERNANCE (#127): lock the multiplier once any junior LP exists.
+    //
+    // Junior depositors entered under the current junior_fee_mult_bps — it is the
+    // economic term they accepted for taking first-loss exposure. Since
+    // process_accrue_fees reads the multiplier live (see the distribute_fees call)
+    // with no per-epoch snapshot, a mid-life change would either:
+    //   - let the admin pump the multiplier right before AccrueFees to extract an
+    //     outsized fee share into an admin-controlled junior position, or
+    //   - let the admin depress the multiplier to silently cut junior yield below
+    //     what depositors were promised at deposit time.
+    //
+    // Idempotent re-writes (same value) still succeed so admin tooling can re-apply
+    // config. Once all juniors withdraw (junior_total_lp == 0), the multiplier is
+    // freely configurable for the next cohort.
+    //
+    // NOTE: this guard was dropped in the v17 convergence (it post-dated the branch
+    // point); restored here to match the audited pre-v17 behavior.
+    if pool.junior_total_lp() > 0 && pool.junior_fee_mult_bps() != junior_fee_mult_bps {
+        msg!(
+            "AdminSetTrancheConfig: junior_fee_mult_bps is locked while juniors \
+             exist (current={}, requested={}, junior_total_lp={})",
+            pool.junior_fee_mult_bps(),
+            junior_fee_mult_bps,
+            pool.junior_total_lp()
+        );
+        return Err(StakeError::Unauthorized.into());
+    }
+
     pool.set_tranche_enabled(true);
     pool.set_junior_fee_mult_bps(junior_fee_mult_bps);
 

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -465,21 +465,11 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
         }
     }
 
-    // #136: crystallize any pending trading-fee surplus into share price BEFORE pricing
-    // this deposit, so LP cannot be minted at the stale pre-accrual price and capture
-    // fees earned before the depositor joined. Mode-1 only; read the vault balance here
-    // (before the user->vault transfer below) so only the fee surplus — not this deposit's
-    // own collateral — is folded. pool.vault == vault.key was verified above.
-    if pool.pool_mode == 1 {
-        if *vault.owner != crate::spl_token::id() {
-            return Err(ProgramError::IllegalOwner);
-        }
-        let current_balance = {
-            let vault_data = vault.try_borrow_data()?;
-            crate::spl_token::state::Account::unpack(&vault_data)?.amount
-        };
-        accrue_fees_inner(pool, current_balance)?;
-    }
+    // #136: crystallize pending trading-fee surplus into share price BEFORE pricing this
+    // deposit (mode-1), so LP cannot be minted at the stale pre-accrual price and capture
+    // fees earned before the depositor joined. Reads the vault balance before the
+    // user->vault transfer below; pool.vault == vault.key was verified above.
+    pre_accrue_mode1(pool, vault)?;
 
     // Calculate LP tokens to mint.
     //
@@ -809,21 +799,11 @@ fn process_withdraw(
         is_junior = deposit._reserved[8] == 1;
     }
 
-    // #136: crystallize any pending trading-fee surplus into share price BEFORE pricing
-    // this withdrawal, so the withdrawer realizes their fair share of earned fees (and the
-    // HWM floor sees true TVL) rather than redeeming at the stale pre-accrual price.
-    // Mode-1 only; pool.vault == vault.key was verified above; read the balance before the
-    // vault->user transfer below.
-    if pool.pool_mode == 1 {
-        if *vault.owner != crate::spl_token::id() {
-            return Err(ProgramError::IllegalOwner);
-        }
-        let current_balance = {
-            let vault_data = vault.try_borrow_data()?;
-            crate::spl_token::state::Account::unpack(&vault_data)?.amount
-        };
-        accrue_fees_inner(pool, current_balance)?;
-    }
+    // #136: crystallize pending trading-fee surplus into share price BEFORE pricing this
+    // withdrawal (mode-1), so the withdrawer realizes their fair share of earned fees (and
+    // the HWM floor sees true TVL) rather than redeeming at the stale pre-accrual price.
+    // Reads the vault balance before the vault->user transfer below; pool.vault verified above.
+    pre_accrue_mode1(pool, vault)?;
 
     // PERC-303: Determine withdrawal amount based on tranche
     let withdrawal_amount = if pool.tranche_enabled() && is_junior {
@@ -1693,6 +1673,30 @@ fn process_rotate_insurance_authority(
 // PERC-272: LP Vault — Fee Accrual & Trading Pool Init
 // ============================================================================
 
+/// #136 pre-accrue guard — shared by EVERY path that prices against pool balances
+/// (`process_deposit`, `process_withdraw`, `process_deposit_junior`). Crystallizes any
+/// pending mode-1 trading-fee surplus into share price BEFORE pricing, so LP cannot be
+/// minted/redeemed at the stale pre-accrual price and capture fees earned before joining.
+///
+/// MUST be called AFTER the caller has verified `pool.vault == vault.key` and BEFORE the
+/// caller's user<->vault transfer, so the balance read reflects only the fee surplus and
+/// NOT the operation's own collateral. Mode-0 is a no-op; idempotent (a second call folds
+/// zero surplus). Centralized so the pricing paths cannot drift — this guard was previously
+/// inline-duplicated and the junior path was the one that was missed (see #146).
+fn pre_accrue_mode1(pool: &mut state::StakePool, vault: &AccountInfo) -> ProgramResult {
+    if pool.pool_mode == 1 {
+        if *vault.owner != crate::spl_token::id() {
+            return Err(ProgramError::IllegalOwner);
+        }
+        let current_balance = {
+            let vault_data = vault.try_borrow_data()?;
+            crate::spl_token::state::Account::unpack(&vault_data)?.amount
+        };
+        accrue_fees_inner(pool, current_balance)?;
+    }
+    Ok(())
+}
+
 /// Crystallize any un-accrued vault surplus into pool share price. Shared by the
 /// permissionless `AccrueFees` instruction AND the deposit/withdraw pre-accrue guard
 /// (#136) so every pricing path applies byte-identical accounting.
@@ -2066,6 +2070,15 @@ fn process_deposit_junior(
             return Err(StakeError::Unauthorized.into());
         }
     }
+
+    // #136 (junior): crystallize pending trading-fee surplus into share price BEFORE pricing
+    // this junior deposit (mode-1). process_deposit (senior/global) and process_withdraw
+    // already do this; the junior path was the one that was missed — without it a junior
+    // depositor mints at the stale pre-fee price and a later permissionless AccrueFees hands
+    // them a (multiplier-weighted) share of fees earned before they joined (see #146). Reads
+    // the vault balance before the user->vault transfer below; pool.vault + token program
+    // were verified above.
+    pre_accrue_mode1(pool, vault)?;
 
     // Use effective_junior_balance() so that LP pricing reflects any insurance
     // losses already absorbed by the junior tranche.  Pricing against the raw

--- a/tests/poc_junior_jit_fee_snipe.rs
+++ b/tests/poc_junior_jit_fee_snipe.rs
@@ -1,0 +1,151 @@
+//! PoC / regression — JIT trading-fee snipe on the JUNIOR tranche (mode-1 pools).
+//!
+//! ── The bug ──────────────────────────────────────────────────────────────────
+//! In a trading-LP pool (`pool_mode == 1`) with tranches enabled, trading fees land
+//! in the vault as an UN-ACCRUED surplus (`current_balance > total_pool_value()`)
+//! until the permissionless `AccrueFees` folds them into `total_fees_earned` and
+//! credits the junior tranche's (multiplier-weighted) share into `junior_balance`
+//! via `distribute_fees`.
+//!
+//! `process_deposit` (senior/global path) and `process_withdraw` CRYSTALLIZE that
+//! surplus (`accrue_fees_inner`) BEFORE pricing — the #136 fix. `process_deposit_junior`
+//! does NOT: it prices the junior deposit directly against `effective_junior_balance()`,
+//! which excludes the pending surplus. So a junior depositor mints LP at the stale
+//! pre-fee price and, after `AccrueFees`, captures a share of fees earned BEFORE they
+//! joined — diluting the existing junior LPs. The junior fee multiplier (up to 5x)
+//! makes the captured share strictly larger than the senior-path snipe #136 fixed.
+//!
+//! These tests apply the EXACT functions the program uses
+//! (`calc_junior_lp_for_deposit`, `distribute_fees`, `calc_junior_collateral_for_withdraw`)
+//! and model `accrue_fees_inner` / `total_pool_value()` on a real `StakePool`,
+//! mirroring `tests/poc_jit_fee_snipe.rs`. `junior_jit_fee_snipe_is_profitable_*`
+//! documents the bug; `pre_accrue_before_junior_pricing_prevents_snipe` is the fix guard.
+
+use bytemuck::Zeroable;
+use percolator_stake::math::{
+    calc_junior_collateral_for_withdraw, calc_junior_lp_for_deposit, distribute_fees,
+};
+use percolator_stake::state::StakePool;
+
+const MULT: u16 = 20_000; // junior_fee_mult_bps = 2x
+
+fn mode1_tranche_pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.pool_mode = 1; // trading LP
+    p.set_discriminator();
+    p.set_tranche_enabled(true);
+    p.set_junior_fee_mult_bps(MULT);
+    p
+}
+
+/// First senior deposit (1:1): only touches the global counters; senior_total_lp
+/// and senior_balance are derived (total_lp_supply − junior_total_lp / total_pool_value
+/// − effective_junior_balance).
+fn add_senior(pool: &mut StakePool, vault: &mut u64, amount: u64) {
+    pool.total_deposited += amount;
+    pool.total_lp_supply += amount;
+    *vault += amount;
+}
+
+/// Models `accrue_fees_inner` (mode-1 tranche): fold the vault surplus into
+/// `total_fees_earned` and credit the junior share, snapshotting balances BEFORE the add.
+fn accrue(pool: &mut StakePool, vault: u64) {
+    let pv = pool.total_pool_value().unwrap();
+    if vault > pv && pool.total_lp_supply > 0 {
+        let fee_delta = vault - pv;
+        let snap_j = pool.effective_junior_balance(); // == junior_balance in mode-1 (net_loss=0)
+        let snap_s = pool.senior_balance().unwrap();
+        let (junior_fee, _senior_fee) =
+            distribute_fees(snap_j, snap_s, pool.junior_fee_mult_bps(), fee_delta);
+        pool.total_fees_earned += fee_delta;
+        pool.set_junior_balance(pool.junior_balance() + junior_fee);
+    }
+}
+
+/// CURRENT `process_deposit_junior`: price against `effective_junior_balance()` with NO pre-accrue.
+fn deposit_junior_current(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
+    let lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), pool.effective_junior_balance(), amount)
+        .expect("calc_junior_lp_for_deposit");
+    pool.total_deposited += amount;
+    pool.total_lp_supply += lp;
+    pool.set_junior_total_lp(pool.junior_total_lp() + lp);
+    pool.set_junior_balance(pool.junior_balance() + amount);
+    *vault += amount;
+    lp
+}
+
+/// FIXED `process_deposit_junior`: crystallize pending fees (pre-accrue) BEFORE pricing.
+fn deposit_junior_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
+    accrue(pool, *vault); // <-- the fix: mirror the #136 pre-accrue from process_deposit
+    let lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), pool.effective_junior_balance(), amount)
+        .expect("calc_junior_lp_for_deposit");
+    pool.total_deposited += amount;
+    pool.total_lp_supply += lp;
+    pool.set_junior_total_lp(pool.junior_total_lp() + lp);
+    pool.set_junior_balance(pool.junior_balance() + amount);
+    *vault += amount;
+    lp
+}
+
+fn withdraw_junior(pool: &mut StakePool, vault: &mut u64, lp: u64) -> u64 {
+    let coll =
+        calc_junior_collateral_for_withdraw(pool.junior_total_lp(), pool.effective_junior_balance(), lp)
+            .expect("calc_junior_collateral_for_withdraw");
+    pool.total_withdrawn += coll;
+    pool.total_lp_supply -= lp;
+    pool.set_junior_total_lp(pool.junior_total_lp() - lp);
+    pool.set_junior_balance(pool.junior_balance() - coll);
+    *vault -= coll;
+    coll
+}
+
+#[test]
+fn junior_jit_fee_snipe_is_profitable_with_current_pricing() {
+    let mut pool = mode1_tranche_pool();
+    let mut vault = 0u64;
+
+    // Senior Alice 1M + honest junior Jane 1M.
+    add_senior(&mut pool, &mut vault, 1_000_000);
+    let _jane_lp = deposit_junior_current(&mut pool, &mut vault, 1_000_000);
+
+    // Engine pays 1,000,000 trading fees into the vault — un-accrued surplus.
+    vault += 1_000_000;
+
+    // Eve front-runs the accrual: DepositJunior at the STALE pre-fee price (current code).
+    let eve_dep = 1_000_000u64;
+    let eve_lp = deposit_junior_current(&mut pool, &mut vault, eve_dep);
+
+    // Anyone calls AccrueFees (Eve can bundle it in the same tx).
+    accrue(&mut pool, vault);
+
+    let eve_back = withdraw_junior(&mut pool, &mut vault, eve_lp);
+    assert!(
+        eve_back > eve_dep,
+        "junior JIT snipe must profit (got {eve_back} for {eve_dep})"
+    );
+    assert_eq!(eve_back, 1_400_000, "Eve captures +400,000 of fees she did not earn");
+}
+
+#[test]
+fn pre_accrue_before_junior_pricing_prevents_snipe() {
+    // Regression guard for the fix: crystallize pending fees BEFORE pricing a junior
+    // deposit (mirroring process_deposit / process_withdraw). The JIT depositor then
+    // buys at the post-fee price and gains nothing.
+    let mut pool = mode1_tranche_pool();
+    let mut vault = 0u64;
+
+    add_senior(&mut pool, &mut vault, 1_000_000);
+    let _jane_lp = deposit_junior_fixed(&mut pool, &mut vault, 1_000_000);
+
+    vault += 1_000_000; // fees earned while Jane is the sole junior
+
+    let eve_dep = 1_000_000u64;
+    let eve_lp = deposit_junior_fixed(&mut pool, &mut vault, eve_dep); // pre-accrues -> fair price
+    accrue(&mut pool, vault);
+    let eve_back = withdraw_junior(&mut pool, &mut vault, eve_lp);
+    assert!(
+        eve_back <= eve_dep,
+        "FIX: pre-accrued junior deposit must not profit (got {eve_back} for {eve_dep})"
+    );
+}


### PR DESCRIPTION
Integrates two verified stake fixes (cherry-picked with attribution; build-sbf clean + 327 tests pass):
- **#146/#147**: `process_deposit_junior` omitted the mode-1 fee pre-accrue (junior twin of the senior #136 fix) → permissionless JIT fee-snipe on the junior tranche. Centralizes the guard into `pre_accrue_mode1(pool, vault)` used by senior deposit, withdraw, AND junior deposit.
- **#143/#144**: restores the `junior_fee_mult_bps` lock (block value-change in AdminSetTrancheConfig while junior_total_lp>0; idempotent same-value allowed; unlocks when juniors exit) + tranche-math Kani proofs. (Low/hardening — verified it does NOT break the existing admin-set-tranche tests.)

Closes #146, #143. Supersedes #147, #144.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance lock for tranche configuration to prevent changes when junior LPs are active.

* **Bug Fixes**
  * Fixed fee crystallization in junior deposit pricing to prevent LP price manipulation.

* **Tests**
  * Expanded formal verification from 44 to 54 harnesses.
  * Added regression test for junior tranche fee exploit scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->