### PR TITLE
fix(#151): re-baseline HWM on FlushToInsurance so an insurance loss doesn't freeze all withdrawals

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1155,6 +1155,24 @@ fn process_flush_to_insurance(
         .checked_add(amount)
         .ok_or(StakeError::Overflow)?;
 
+    // PERC-313 HWM: a flush is a realized insurance LOSS — pool TVL drops by `amount`.
+    // The high-water-mark withdrawal floor must track that loss, or LPs get frozen out
+    // of a pool that just lost money. `refresh_hwm` only RAISES the mark within an epoch
+    // and is never called here, so the mark must be lowered explicitly. Lower it by
+    // exactly the flushed amount (the realized loss) so the floor recomputes against the
+    // loss-adjusted peak (peak − Σ losses). This preserves anti-drain protection:
+    // WITHDRAWALS never lower the mark (only refresh_hwm's raise and this flush do), so a
+    // withdrawal-driven drain is still floored; only a real loss lowers the floor, and only
+    // by the loss amount — no free withdrawal headroom is created (TVL dropped by the same
+    // `amount`). saturating_sub is panic-free; if a stale/zero mark is below `amount` it
+    // floors at 0 (floor 0 = no restriction), and the next withdraw's refresh_hwm re-bases
+    // the mark to live TVL. Left ungated on hwm_enabled(): the mark is only ever READ in the
+    // hwm_enabled branch, and a lowered mark is strictly more permissive, so tracking the
+    // loss unconditionally keeps "mark = peak − losses" true and avoids a stale-high mark
+    // re-freezing if HWM is toggled on mid-epoch after a flush. ReturnInsurance is left
+    // untouched: recovery rides the existing same-epoch refresh_hwm raise (clamped to TVL).
+    pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(amount));
+
     msg!(
         "Flushed {} collateral to percolator insurance via CPI",
         amount

--- a/tests/poc_hwm_flush_freeze.rs
+++ b/tests/poc_hwm_flush_freeze.rs
@@ -1,0 +1,133 @@
+//! PoC / regression — HWM floor + an insurance loss freezes ALL withdrawals until epoch.
+//!
+//! ── The bug ──────────────────────────────────────────────────────────────────
+//! The high-water-mark (HWM) withdrawal floor blocks withdrawals that would drop TVL
+//! below `epoch_high_water_tvl * hwm_floor_bps / 10000` (anti-drain protection).
+//! `refresh_hwm` is called on deposit/withdraw/deposit_junior and, within an epoch,
+//! ONLY RAISES the mark (never lowers it). `process_flush_to_insurance` — which
+//! LOWERS TVL (an insurance loss) — does NOT call `refresh_hwm` at all.
+//!
+//! So after a flush loss, `epoch_high_water_tvl` stays pegged at the pre-loss peak
+//! while actual TVL has dropped. If the loss pushes TVL below the floor, the next
+//! withdrawal check blocks EVERY withdrawal (even a 1-token / zero-size one), because
+//! current TVL is already under the stale floor. LPs are frozen out of a pool that
+//! just LOST money, until the Solana epoch rolls over (refresh_hwm resets the mark to
+//! current TVL on a new epoch) or the admin disables HWM / returns the insurance.
+//!
+//! Uses the real `StakePool::refresh_hwm` + `math::hwm_withdrawal_allowed`.
+
+use bytemuck::Zeroable;
+use percolator_stake::math::hwm_withdrawal_allowed;
+use percolator_stake::state::StakePool;
+
+fn hwm_pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.set_discriminator();
+    p.set_hwm_enabled(true);
+    p.set_hwm_floor_bps(5000); // 50% floor
+    p
+}
+
+#[test]
+fn hwm_freeze_after_loss_blocks_all_withdrawals() {
+    let mut pool = hwm_pool();
+
+    // Peak TVL 1,000,000 in epoch 5 → mark ratchets to 1,000,000.
+    pool.total_deposited = 1_000_000;
+    pool.refresh_hwm(5, 1_000_000);
+    assert_eq!(pool.epoch_high_water_tvl(), 1_000_000);
+
+    // Admin flushes 600,000 to insurance (a real loss). TVL drops to 400,000.
+    // FlushToInsurance does NOT call refresh_hwm, so the mark is untouched.
+    pool.total_flushed = 600_000;
+    assert_eq!(pool.total_pool_value().unwrap(), 400_000);
+
+    // A withdraw calls refresh_hwm(5, 400_000): same epoch, 400k < mark, so the mark is
+    // NOT lowered (it only raises). Floor stays 50% of the stale 1,000,000 peak = 500,000.
+    let mark = pool.refresh_hwm(5, 400_000);
+    assert_eq!(mark, 1_000_000, "mark stays pegged to the pre-loss peak (the bug)");
+
+    // Current TVL (400,000) is already below the 500,000 floor, so EVERY withdrawal —
+    // even a zero-size one (post_tvl == current TVL) — is blocked.
+    assert!(
+        !hwm_withdrawal_allowed(400_000, mark, 5000),
+        "ALL withdrawals frozen after the loss, until the epoch rolls over"
+    );
+}
+
+#[test]
+fn rebaselining_hwm_on_flush_unfreezes_withdrawals() {
+    // Fix direction: a flush (a legitimate loss, not a drain) lowers the high-water mark
+    // alongside TVL, so the floor tracks the loss rather than freezing exits. The
+    // anti-drain protection (floor vs. the loss-adjusted mark) stays intact.
+    let mut pool = hwm_pool();
+    pool.total_deposited = 1_000_000;
+    pool.refresh_hwm(5, 1_000_000);
+
+    // Flush 600,000 AND lower the mark by the flushed amount (the fix).
+    pool.total_flushed = 600_000;
+    pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(600_000)); // -> 400,000
+
+    let mark = pool.refresh_hwm(5, 400_000);
+    assert_eq!(mark, 400_000, "mark tracks the legitimate loss");
+
+    // Floor = 50% of 400,000 = 200,000. Withdrawals down to the loss-adjusted floor resume.
+    assert!(hwm_withdrawal_allowed(400_000, mark, 5000), "withdrawals resume after re-baseline");
+    assert!(hwm_withdrawal_allowed(200_000, mark, 5000), "allowed down to the loss-adjusted floor");
+    assert!(!hwm_withdrawal_allowed(199_999, mark, 5000), "floor still enforced — anti-drain intact");
+}
+
+/// The crux that picks "lower the mark by the flushed amount" over "reset the mark to
+/// post-flush TVL": a flush must reduce the protected peak by the LOSS only, never forgive
+/// prior intra-epoch withdrawal drain. Peak 1,000,000; withdraw down to 800,000 (mark stays
+/// 1,000,000 — withdrawals never lower it); then flush 600,000 → TVL 200,000.
+///   lower-by-amount: mark 1,000,000 − 600,000 = 400,000, floor 200,000 → TVL already at
+///   floor, no further withdrawal headroom (the prior 200,000 drain is "remembered").
+///   reset-to-TVL (rejected): mark 200,000, floor 100,000 → re-opens 100,000 of post-loss
+///   drain — exactly the bank-run the HWM exists to prevent.
+#[test]
+fn lower_by_amount_does_not_forgive_prior_drain() {
+    let mut pool = hwm_pool();
+    pool.total_deposited = 1_000_000;
+    pool.refresh_hwm(5, 1_000_000); // mark 1,000,000
+
+    // Withdrawals bring TVL to 800,000; the mark does NOT move (refresh only raises).
+    pool.total_withdrawn = 200_000;
+    let mark_after_withdraw = pool.refresh_hwm(5, 800_000);
+    assert_eq!(mark_after_withdraw, 1_000_000, "withdrawals never lower the mark");
+
+    // Flush 600,000 → TVL 200,000. The handler lowers the mark by the flushed amount.
+    pool.total_flushed = 600_000;
+    assert_eq!(pool.total_pool_value().unwrap(), 200_000);
+    pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(600_000)); // -> 400,000
+    let mark = pool.refresh_hwm(5, 200_000);
+    assert_eq!(mark, 400_000, "lower by the LOSS only — not down to post-flush TVL");
+
+    // Floor = 200,000. Post-flush TVL is already at the floor → no further drain allowed.
+    assert!(hwm_withdrawal_allowed(200_000, mark, 5000), "exactly at the loss-adjusted floor");
+    assert!(!hwm_withdrawal_allowed(199_999, mark, 5000), "prior drain remembered — no new headroom");
+    // reset-to-TVL would have set mark=200,000, floor=100,000, wrongly allowing TVL→100,000.
+    assert!(!hwm_withdrawal_allowed(100_000, mark, 5000), "reset-to-TVL would have allowed this — rejected");
+}
+
+/// Multiple flushes in an epoch compose: mark = peak − Σ flushed (saturating).
+#[test]
+fn multiple_flushes_compose() {
+    let mut pool = hwm_pool();
+    pool.total_deposited = 1_000_000;
+    pool.refresh_hwm(5, 1_000_000);
+    pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(300_000));
+    pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(300_000));
+    assert_eq!(pool.epoch_high_water_tvl(), 400_000, "two 300k flushes == one 600k flush");
+}
+
+/// A flush whose amount exceeds the (stale/zero) mark saturates to 0 — floor 0, no freeze.
+#[test]
+fn flush_exceeding_mark_saturates_to_zero() {
+    let mut pool = hwm_pool();
+    pool.set_epoch_high_water_tvl(100_000);
+    pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(200_000));
+    assert_eq!(pool.epoch_high_water_tvl(), 0, "saturates, no underflow/panic");
+    assert!(hwm_withdrawal_allowed(0, 0, 5000), "floor 0 → no restriction");
+}


### PR DESCRIPTION
## Summary

Fixes #151. With HWM withdrawal protection enabled, an insurance loss (`FlushToInsurance`) froze **all** withdrawals until the Solana epoch rolled over. `refresh_hwm` only *raises* the high-water mark within an epoch and is never called by `process_flush_to_insurance`, so after a flush lowered TVL the withdrawal floor stayed pegged to the pre-loss peak. If the loss dropped TVL below `peak * hwm_floor_bps / 10000`, every withdrawal — even a zero-size one — reverted with `WithdrawalBelowHwmFloor`, locking LPs out of a pool that had just lost money.

## Mechanism (50% floor)

1. Peak TVL 1,000,000 in epoch 5 → mark ratchets to 1,000,000 (floor 500,000).
2. Admin flushes 600,000 (insurance loss). TVL → 400,000. `FlushToInsurance` did not touch the mark.
3. Withdraw calls `refresh_hwm(5, 400_000)`: same epoch, `400,000 < 1,000,000` → mark **not** lowered (it only raises). Floor stays 500,000.
4. TVL (400,000) is already below the 500,000 floor → every withdrawal reverts until the epoch rolls over.

## Fix

In `process_flush_to_insurance`, after booking `total_flushed += amount`, lower the mark by exactly the flushed amount:

```rust
pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(amount));
```

so the floor recomputes against the loss-adjusted peak (`peak − Σ losses`).

**Anti-drain protection preserved.** Withdrawals never lower the mark (only `refresh_hwm`'s raise and this flush do), so a withdrawal-driven drain is still floored. Only a *real loss* lowers the floor, and only by the loss amount — TVL dropped by the same `amount`, so no free withdrawal headroom is created.

### Design choices

- **Lower-by-amount, not reset-to-current-TVL.** Resetting the mark to post-flush TVL would forgive prior intra-epoch withdrawal drain. Example: peak 1,000,000 → withdraw to 800,000 (mark stays 1,000,000) → flush 600,000 (TVL 200,000). Lower-by-amount → mark 400,000, floor 200,000, TVL already at floor (prior 200,000 drain remembered). Reset-to-TVL → mark 200,000, floor 100,000, re-opening 100,000 of post-loss drain — exactly the bank-run the HWM exists to prevent.
- **Ungated on `hwm_enabled()`.** The mark is only ever *read* in the `hwm_enabled` branch, and a lowered mark is strictly more permissive, so tracking the loss unconditionally keeps `mark = peak − losses` true and avoids a stale-high mark re-freezing if HWM is toggled on mid-epoch after a flush.
- **`ReturnInsurance` unchanged.** Recovery rides the existing same-epoch `refresh_hwm` raise, which clamps the mark to current TVL — so a return can't push the floor above achievable TVL and re-freeze.
- **`saturating_sub`** is panic-free; a stale/zero mark below `amount` floors at 0 (no restriction), and the next withdraw's `refresh_hwm` re-bases the mark to live TVL.

## Tests

`tests/poc_hwm_flush_freeze.rs`:
- `hwm_freeze_after_loss_blocks_all_withdrawals` — reproduces the freeze (stale mark 1,000,000 → all withdrawals blocked at 400k < 500k floor).
- `rebaselining_hwm_on_flush_unfreezes_withdrawals` — the fix: mark 400,000, floor 200,000, withdrawals resume down to the loss-adjusted floor; the anti-drain floor still binds (199,999 rejected).
- `lower_by_amount_does_not_forgive_prior_drain` — the crux: prior intra-epoch drain is not forgiven (a reset-to-TVL would wrongly allow it).
- `multiple_flushes_compose` + `flush_exceeding_mark_saturates_to_zero` — multi-flush composition and saturation.

All scenarios verified against the real `StakePool::refresh_hwm` + `math::hwm_withdrawal_allowed`.

## Verification

- `cargo build --lib` ✔
- `cargo build-sbf` ✔ (on-chain target)
- PoC scenarios pass against the production v17 functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Insurance fund claims from pools now immediately recalculate withdrawal restrictions, ensuring the withdrawal floor accurately reflects legitimate losses without waiting for the next epoch refresh.

* **Tests**
  * Added comprehensive test suite validating withdrawal eligibility behavior and protections during insurance fund claims and multiple sequential claim scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->