### PR TITLE
fix(#159): gate senior deposits while an insurance loss has spilled past junior (complete #150 senior side)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -55,6 +55,11 @@ pub enum StakeError {
     /// Two-step admin rotation: no pending admin proposal exists (or it was
     /// cancelled), so AcceptAdmin has nothing to accept.
     NoPendingAdmin = 23,
+    /// Junior tranche deposits are paused while an insurance loss is outstanding
+    /// (total_flushed > total_returned). A junior depositing during an open claim
+    /// would inherit a pre-existing loss it was never exposed to (and the mirror
+    /// case could snipe the recovery). Deposits resume once insurance is returned.
+    InsuranceLossOutstanding = 24,
 }
 
 impl From<StakeError> for ProgramError {
@@ -91,6 +96,7 @@ pub fn error_hint(code: u32) -> &'static str {
         21 => "Wrong tranche — deposit already belongs to a different tranche",
         22 => "Zero shares minted — deposit amount too small to mint any LP at the current share price; increase the amount",
         23 => "No pending admin — there is no admin transfer to accept (propose one first, or it was cancelled)",
+        24 => "Insurance loss outstanding — junior tranche deposits are paused until the flushed insurance is returned (total_flushed > total_returned)",
         _ => "Unknown error — check the error code and pool state",
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -465,6 +465,36 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
         }
     }
 
+    // Insurance recovery-snipe gate (SENIOR path) — completes #150 for the senior tranche
+    // (see #159). When tranches are on and a flushed loss has spilled PAST junior into
+    // senior, the senior sub-pool is marked down (distribute_loss: senior_loss > 0 IFF
+    // net_loss > junior_balance), so senior_balance() is depressed. A late senior depositor
+    // could mint cheap LP here and redeem at the restored price after ReturnInsurance,
+    // stealing the recovery from the incumbent seniors who actually bore the loss. Pause
+    // exactly that window. The condition is PRECISE — not the junior gate's bare
+    // flushed > returned — because senior_balance() is a pure function of current state, so
+    // senior is depressed IFF net_loss > junior_balance(now). A junior-ABSORBED loss
+    // (net_loss <= junior_balance) leaves senior_balance() unchanged and offers nothing to
+    // snipe, so senior deposits stay open; gating it instead would DoS senior deposits for
+    // the entire (possibly never-returned) life of a loss junior fully covers. Self-lifts as
+    // ReturnInsurance raises total_returned. Tranche-only: the non-tranche/global path (#139)
+    // is untouched. The senior WITHDRAW path is intentionally not changed here (separate
+    // finding). junior_balance() is the raw stored balance — the same value distribute_loss
+    // measures absorption against.
+    if pool.tranche_enabled() {
+        let net_loss = pool.total_flushed.saturating_sub(pool.total_returned);
+        if net_loss > pool.junior_balance() {
+            msg!(
+                "DepositSenior paused: insurance loss spilled past junior (net_loss {} > junior_balance {}); flushed {} > returned {}",
+                net_loss,
+                pool.junior_balance(),
+                pool.total_flushed,
+                pool.total_returned
+            );
+            return Err(StakeError::InsuranceLossOutstanding.into());
+        }
+    }
+
     // #136: crystallize any pending trading-fee surplus into share price BEFORE pricing
     // this deposit, so LP cannot be minted at the stale pre-accrual price and capture
     // fees earned before the depositor joined. Mode-1 only; read the vault balance here

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2067,6 +2067,25 @@ fn process_deposit_junior(
         }
     }
 
+    // Pause junior deposits while an insurance loss is OUTSTANDING (flushed but not
+    // yet returned). effective_junior_balance() applies the pool's CURRENT net_loss
+    // to the junior tranche with no baseline for when the cohort began, so a junior
+    // depositing during an open claim would inherit a loss it was never exposed to
+    // (deterministic theft from the depositor; see the issue), and the mirror case
+    // would snipe the recovery. Both directions require a junior deposit while
+    // total_flushed > total_returned — so gate exactly that. total_flushed/returned
+    // move only via admin Flush/Return (mode-0), so deposits resume once insurance is
+    // returned. The SENIOR path is unaffected: a senior deposit prices against the
+    // current marked-down senior_balance and never perturbs effective_junior_balance.
+    if pool.total_flushed > pool.total_returned {
+        msg!(
+            "DepositJunior paused: insurance loss outstanding (flushed {} > returned {})",
+            pool.total_flushed,
+            pool.total_returned
+        );
+        return Err(StakeError::InsuranceLossOutstanding.into());
+    }
+
     // Use effective_junior_balance() so that LP pricing reflects any insurance
     // losses already absorbed by the junior tranche.  Pricing against the raw
     // junior_balance() (stale, pre-loss) would charge new depositors a higher

--- a/tests/poc_junior_preexisting_loss.rs
+++ b/tests/poc_junior_preexisting_loss.rs
@@ -1,0 +1,122 @@
+//! PoC / regression — the first junior depositor inherits a PRE-EXISTING insurance loss.
+//!
+//! ── The bug ──────────────────────────────────────────────────────────────────
+//! `effective_junior_balance()` applies the pool's CURRENT outstanding loss
+//! (`net_loss = total_flushed - total_returned`) to the junior tranche with NO
+//! baseline for when the junior cohort began. So if a pool takes an insurance loss
+//! while there is no junior (the loss is borne by the global/senior cohort), then a
+//! junior later deposits, the very next valuation re-assigns that ENTIRE pre-existing
+//! loss onto the new junior — making the incumbent (now senior) LPs whole at the new
+//! junior's expense. The junior was never present for the loss event.
+//!
+//! Reachable two ways: (a) a non-tranche pool takes a flush loss, the admin later
+//! enables tranches (no guard against an outstanding loss), then a junior deposits;
+//! (b) a tranche pool with an empty junior cohort takes a loss (borne by senior),
+//! then the first junior deposits.
+//!
+//! This test applies the EXACT functions the program uses on a real `StakePool`
+//! (`effective_junior_balance`, `senior_balance`, `calc_junior_lp_for_deposit`,
+//! `calc_junior_collateral_for_withdraw`, `calc_senior_collateral_for_withdraw`).
+//! Distinct from #145 (recovery-snipe / new-junior GAINS on recovery): here the new
+//! junior deterministically LOSES the pre-existing loss the instant they deposit.
+
+use bytemuck::Zeroable;
+use percolator_stake::math::{
+    calc_junior_collateral_for_withdraw, calc_junior_lp_for_deposit,
+    calc_senior_collateral_for_withdraw,
+};
+use percolator_stake::state::StakePool;
+
+fn pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.set_discriminator();
+    p // pool_mode 0 (insurance LP), tranches not yet enabled
+}
+
+#[test]
+fn first_junior_inherits_preexisting_loss() {
+    let mut pool = pool();
+
+    // Greg deposits 3,000,000 as a plain (non-tranche) LP.
+    pool.total_deposited = 3_000_000;
+    pool.total_lp_supply = 3_000_000;
+
+    // Admin flushes 600,000 to insurance (a real loss). Greg's stake is now worth
+    // total_pool_value() = 2,400,000 — Greg bears the loss, as he should.
+    pool.total_flushed = 600_000;
+    assert_eq!(pool.total_pool_value().unwrap(), 2_400_000);
+
+    // Admin enables tranches (there is NO guard against an outstanding loss).
+    pool.set_tranche_enabled(true);
+    pool.set_junior_fee_mult_bps(20_000);
+
+    // Jane deposits 1,000,000 as the FIRST junior. At deposit time junior_balance == 0,
+    // so effective_junior_balance() == 0 and she mints 1:1 — it looks like a fair entry.
+    let eff_at_deposit = pool.effective_junior_balance();
+    assert_eq!(eff_at_deposit, 0);
+    let jane_lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), eff_at_deposit, 1_000_000).unwrap();
+    assert_eq!(jane_lp, 1_000_000);
+    pool.set_junior_balance(1_000_000);
+    pool.set_junior_total_lp(jane_lp);
+    pool.total_deposited += 1_000_000;
+    pool.total_lp_supply += jane_lp;
+
+    // BUG: the instant Jane has a balance, the pre-existing 600,000 loss is reassigned
+    // to the junior tranche (junior-first), even though it predates her.
+    let eff_after = pool.effective_junior_balance();
+    assert_eq!(
+        eff_after, 400_000,
+        "first junior is marked down by a loss that predates her deposit"
+    );
+
+    // Jane withdraws her 1,000,000 LP and recovers only 400,000 — an instant 600,000 loss.
+    let jane_back = calc_junior_collateral_for_withdraw(pool.junior_total_lp(), eff_after, jane_lp).unwrap();
+    assert_eq!(jane_back, 400_000);
+    assert_eq!(1_000_000 - jane_back, 600_000, "Jane lost the full pre-existing loss");
+
+    // Greg (now senior) recovers his FULL 3,000,000 — his loss evaporated onto Jane.
+    let greg_back = calc_senior_collateral_for_withdraw(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        3_000_000,
+    )
+    .unwrap();
+    assert_eq!(greg_back, 3_000_000, "incumbent made whole at the new junior's expense");
+
+    // Conservation holds globally (3,000,000 + 400,000 == 3,400,000 == vault), which is
+    // exactly why no runtime check catches it — but 600,000 was transferred from the
+    // honest new junior to the incumbent.
+    //
+    // NOTE: this documents the MATH (effective_junior_balance reassigns the outstanding
+    // loss). The FIX is a handler-level gate: `process_deposit_junior` rejects with
+    // StakeError::InsuranceLossOutstanding while `total_flushed > total_returned`, so this
+    // buggy state is never reachable via a real junior deposit. The gate CONDITION is
+    // pinned below; the handler rejection itself is exercised by the v17 LiteSVM e2e suite.
+    assert_eq!(greg_back + jane_back, pool.total_pool_value().unwrap());
+}
+
+/// Pins the fix's gate condition: `process_deposit_junior` is paused exactly while an
+/// insurance loss is outstanding (`total_flushed > total_returned`) and resumes once the
+/// flushed insurance is fully returned. (The handler-level revert is covered by the v17
+/// LiteSVM e2e; this guards the condition so a future change to the predicate is flagged.)
+#[test]
+fn junior_deposit_gate_fires_while_loss_outstanding_and_lifts_on_return() {
+    let mut pool = pool();
+    pool.set_tranche_enabled(true);
+
+    // No loss yet → gate does not fire.
+    assert!(!(pool.total_flushed > pool.total_returned));
+
+    // Outstanding loss → gate fires (handler rejects DepositJunior).
+    pool.total_flushed = 600_000;
+    assert!(pool.total_flushed > pool.total_returned, "gate must fire while loss outstanding");
+
+    // Partial return → still outstanding → gate still fires.
+    pool.total_returned = 200_000;
+    assert!(pool.total_flushed > pool.total_returned, "gate must stay closed on partial return");
+
+    // Fully returned → gate lifts → junior deposits resume.
+    pool.total_returned = 600_000;
+    assert!(!(pool.total_flushed > pool.total_returned), "gate must lift once fully returned");
+}

--- a/tests/poc_senior_deposit_loss_snipe.rs
+++ b/tests/poc_senior_deposit_loss_snipe.rs
@@ -1,0 +1,156 @@
+//! PoC — Senior-deposit recovery-snipe (the senior half of #145, left open by #150).
+//!
+//! ── The bug ──────────────────────────────────────────────────────────────────
+//! #150 paused JUNIOR deposits while an insurance loss is outstanding
+//! (total_flushed > total_returned), closing the junior side of the recovery-snipe
+//! described in #145. But #145 explicitly noted "senior is the same once a loss
+//! spills past junior" — and the SENIOR deposit path (process_deposit, tranche
+//! branch) was never gated.
+//!
+//! When a flushed loss Φ EXCEEDS the junior balance J, junior is wiped and the
+//! senior sub-pool is marked down by Φ − J (distribute_loss: senior_loss > 0 iff
+//! net_loss > junior_balance). senior_balance() is depressed during the open-loss
+//! window. A late senior depositor mints cheap against the depressed senior_balance,
+//! then — once the admin returns the insurance — redeems at the restored price,
+//! capturing a pro-rata slice of the recovery from the incumbent seniors who
+//! actually bore the loss. Conservation-exact, unprivileged value transfer.
+//!
+//! Uses the real calc_senior_lp_for_deposit / calc_senior_collateral_for_withdraw
+//! + StakePool::senior_balance / effective_junior_balance / total_pool_value.
+
+use bytemuck::Zeroable;
+use percolator_stake::math::{
+    calc_junior_collateral_for_withdraw, calc_senior_collateral_for_withdraw,
+    calc_senior_lp_for_deposit,
+};
+use percolator_stake::state::StakePool;
+
+fn tranche_pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.set_discriminator();
+    p.set_tranche_enabled(true);
+    p
+}
+
+/// senior is marked down (the snipe is live) iff net_loss > junior_balance.
+fn senior_marked_down(p: &StakePool) -> bool {
+    p.total_flushed.saturating_sub(p.total_returned) > p.junior_balance()
+}
+
+#[test]
+fn senior_deposit_during_loss_snipes_recovery() {
+    let mut pool = tranche_pool();
+
+    // Incumbent senior Greg deposits 900k; junior Jane deposits 100k.
+    pool.total_deposited = 1_000_000;
+    pool.total_lp_supply = 1_000_000;
+    pool.set_junior_balance(100_000);
+    pool.set_junior_total_lp(100_000);
+    assert_eq!(pool.senior_total_lp(), 900_000);
+    assert_eq!(pool.senior_balance().unwrap(), 900_000);
+
+    // Admin flushes 600k (> junior 100k): junior wiped, senior marked down by 500k.
+    pool.total_flushed = 600_000;
+    assert_eq!(pool.effective_junior_balance(), 0);
+    assert_eq!(pool.total_pool_value().unwrap(), 400_000);
+    assert_eq!(pool.senior_balance().unwrap(), 400_000, "senior depressed during the loss");
+    assert!(senior_marked_down(&pool));
+
+    // Eve deposits 400k senior at the depressed price (UNGATED today).
+    let eve_lp =
+        calc_senior_lp_for_deposit(pool.senior_total_lp(), pool.senior_balance().unwrap(), 400_000)
+            .unwrap();
+    assert_eq!(eve_lp, 900_000, "400k * 900k / 400k");
+    pool.total_deposited += 400_000;
+    pool.total_lp_supply += eve_lp;
+    assert_eq!(pool.senior_total_lp(), 1_800_000);
+
+    // Admin returns 600k. net_loss -> 0; senior_balance restored over the inflated supply.
+    pool.total_returned = 600_000;
+    assert_eq!(pool.effective_junior_balance(), 100_000);
+    assert_eq!(pool.total_pool_value().unwrap(), 1_400_000);
+    assert_eq!(pool.senior_balance().unwrap(), 1_300_000);
+
+    // Eve withdraws her 900k senior LP.
+    let eve_out =
+        calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), eve_lp)
+            .unwrap();
+    assert_eq!(eve_out, 650_000, "900k * 1.3M / 1.8M");
+    assert_eq!(eve_out - 400_000, 250_000, "Eve nets +250k on a 400k deposit she never put at risk");
+    pool.total_withdrawn += eve_out;
+    pool.total_lp_supply -= eve_lp;
+
+    // Greg (incumbent senior) withdraws his 900k senior LP.
+    let greg_out =
+        calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), 900_000)
+            .unwrap();
+    assert_eq!(greg_out, 650_000, "deposited 900k, recovers only 650k");
+    assert_eq!(900_000 - greg_out, eve_out - 400_000, "Greg's -250k == Eve's +250k (clean transfer)");
+    // Without Eve, after the return senior_balance would be 900k over 900k LP -> Greg whole.
+}
+
+#[test]
+fn gate_blocks_snipe_only_while_senior_marked_down() {
+    // The fix gates senior deposits exactly when senior is marked down
+    // (net_loss > junior_balance) — and NOT when the loss is fully junior-absorbed.
+
+    // (a) Loss > junior: senior marked down -> gate fires, snipe deposit rejected.
+    let mut p = tranche_pool();
+    p.total_deposited = 1_000_000;
+    p.total_lp_supply = 1_000_000;
+    p.set_junior_balance(100_000);
+    p.set_junior_total_lp(100_000);
+    p.total_flushed = 600_000; // > junior 100k
+    assert!(senior_marked_down(&p), "loss spilled past junior -> senior deposits paused");
+
+    // (b) Loss <= junior: senior fully protected (unchanged) -> senior deposits stay OPEN.
+    let mut p2 = tranche_pool();
+    p2.total_deposited = 1_000_000;
+    p2.total_lp_supply = 1_000_000;
+    p2.set_junior_balance(100_000);
+    p2.set_junior_total_lp(100_000);
+    p2.total_flushed = 80_000; // < junior 100k: junior absorbs, senior NOT marked down
+    assert_eq!(p2.senior_balance().unwrap(), 900_000, "senior unchanged when loss <= junior");
+    assert!(!senior_marked_down(&p2), "no snipe possible -> senior deposits remain allowed");
+
+    // (c) After the insurance is returned, the gate lifts.
+    p.total_returned = 600_000;
+    assert!(!senior_marked_down(&p), "gate lifts once the loss is recovered");
+}
+
+/// The crux that picks the PRECISE gate over both the simple-symmetric gate and a
+/// "persisted accumulator": a junior PARTIAL exit during a junior-ABSORBED loss must NOT
+/// false-trigger the gate. The senior-balance markdown is a pure function of CURRENT state
+/// (senior_loss > 0 IFF net_loss > junior_balance(now)), and the junior-withdraw path
+/// decrements raw junior_balance by the loss-ADJUSTED withdrawal amount (not a proportional
+/// raw share), so junior_balance stays above net_loss and senior remains undepressed.
+#[test]
+fn precise_gate_no_false_fire_on_junior_partial_exit() {
+    let mut pool = tranche_pool();
+    // senior 900k, junior 400k.
+    pool.total_deposited = 1_300_000;
+    pool.total_lp_supply = 1_300_000;
+    pool.set_junior_balance(400_000);
+    pool.set_junior_total_lp(400_000);
+
+    // Flush 300k — junior-ABSORBED (300k <= 400k): senior NOT marked down.
+    pool.total_flushed = 300_000;
+    assert_eq!(pool.effective_junior_balance(), 100_000);
+    assert_eq!(pool.senior_balance().unwrap(), 900_000, "senior untouched by a junior-absorbed loss");
+    assert!(!senior_marked_down(&pool));
+
+    // A junior burns 390k of 400k LP. Valued against effective_junior (100k):
+    // withdrawal_amount = 390k * 100k / 400k = 97_500. Raw junior_balance drops by that.
+    let wd = calc_junior_collateral_for_withdraw(400_000, pool.effective_junior_balance(), 390_000).unwrap();
+    assert_eq!(wd, 97_500);
+    pool.total_withdrawn += wd;
+    pool.set_junior_balance(pool.junior_balance() - wd); // 400_000 - 97_500 = 302_500
+    pool.set_junior_total_lp(400_000 - 390_000); // 10_000
+    assert_eq!(pool.junior_balance(), 302_500);
+
+    // net_loss (300k) is still <= junior_balance (302_500): gate stays OPEN, and senior is
+    // STILL undepressed — so a senior deposit here is fair and must be allowed.
+    assert!(!senior_marked_down(&pool), "precise gate does NOT false-fire on junior partial exit");
+    assert_eq!(pool.senior_balance().unwrap(), 900_000, "senior still whole after junior's partial exit");
+}


### PR DESCRIPTION
## Summary

Fixes #159. Completes the senior side of the insurance recovery-snipe (#145). PR #150 paused **junior** deposits while a loss is outstanding, but #145 noted *"senior is the same once a loss spills past junior"* — and the **senior** deposit path was never gated.

When a flushed loss **Φ exceeds the junior balance J**, junior is wiped and the senior sub-pool is marked down by `Φ − J` (`distribute_loss`: `senior_loss > 0` iff `net_loss > junior_balance`). `senior_balance()` is depressed for the open-loss window, so a late senior depositor mints cheap LP and redeems at the restored price after `ReturnInsurance`, capturing a pro-rata slice of the recovery from the incumbent seniors who actually bore the loss — unprivileged, conservation-exact.

**Reproduced** (incumbent senior 900k + junior 100k, flush 600k): attacker deposits 400k senior → mints 900k LP; after a 600k return, withdraws **650k on a 400k deposit (+250k)** — exactly the incumbent senior's −250k.

## Fix

In `process_deposit`, before pricing, pause the senior (tranche) path while the loss has spilled past junior:

```rust
if pool.tranche_enabled() {
    let net_loss = pool.total_flushed.saturating_sub(pool.total_returned);
    if net_loss > pool.junior_balance() {
        return Err(StakeError::InsuranceLossOutstanding.into());
    }
}
```

### Design choices

- **Precise (`net_loss > junior_balance`), not the symmetric `flushed > returned`.** `senior_balance()` is a pure function of current state, so senior is depressed **iff** `net_loss > junior_balance(now)`. A junior-**absorbed** loss (`net_loss ≤ junior_balance`) leaves `senior_balance()` unchanged with nothing to snipe — so senior deposits stay open. The symmetric gate would DoS senior deposits for the entire (possibly **never-returned**) life of a loss junior fully covers, even though senior faces no snipe there.
- **Dynamic-junior safe.** Because the junior-withdraw path decrements raw `junior_balance` by the loss-**adjusted** withdrawal amount (not a proportional raw share), a junior partial exit during a junior-absorbed loss keeps `junior_balance ≥ net_loss`, so the precise gate does not false-trigger. (Verified — no persisted accumulator needed.)
- **Tranche-only.** Scoped to `tranche_enabled()`; the non-tranche/global path (#139) is untouched.
- **Withdraw path unchanged.** The senior/junior **withdraw** side (a junior fully exiting during a loss stranding recovery to senior) is a separate finding, not addressed here.
- **Self-lifting.** Reuses `StakeError::InsuranceLossOutstanding`; the gate clears automatically as `ReturnInsurance` raises `total_returned`.

## Tests

`tests/poc_senior_deposit_loss_snipe.rs`:
- `senior_deposit_during_loss_snipes_recovery` — reproduces the +250k / −250k transfer.
- `gate_blocks_snipe_only_while_senior_marked_down` — gate fires when `net_loss > junior`, stays open for a junior-absorbed loss, lifts after return.
- `precise_gate_no_false_fire_on_junior_partial_exit` — the dynamic-junior crux: a junior partial exit during a junior-absorbed loss does not false-trigger the gate; senior stays whole.

All verified against the real `calc_senior_lp_for_deposit` / `calc_senior_collateral_for_withdraw` + `StakePool::senior_balance` / `effective_junior_balance` / `total_pool_value`.

## Verification

- `cargo build --lib` ✔
- `cargo build-sbf` ✔ (on-chain target)
- PoC scenarios pass against the production v17 functions.

## Note

Builds on #150 — it reuses the `InsuranceLossOutstanding` gate that PR introduced, so this branch includes #150's commit. Merge after (or together with) #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Deposits are now paused when an insurance loss claim is outstanding, preventing unauthorized withdrawals during loss recovery.
  * Both senior and junior deposit flows now enforce insurance loss checks to protect against edge cases.

* **Tests**
  * Added regression tests for insurance loss scenarios and deposit gating behavior during claim processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->