### PR TITLE
fix(#169): compute total_pool_value() in i128 — stop mode-1 fee-withdraw underflow that permanently bricks trading pools

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -451,16 +451,36 @@ impl StakePool {
     /// includes the flushed amount. Missing `-flushed` causes phantom inflation
     /// that makes the pool insolvent after any flush+return cycle.
     pub fn total_pool_value(&self) -> Option<u64> {
-        let base = self
-            .total_deposited
-            .checked_sub(self.total_withdrawn)?
-            .checked_sub(self.total_flushed)?
-            .checked_add(self.total_returned)?;
-        // PERC-272: Include accrued trading fees for trading LP pools
-        if self.pool_mode == 1 {
-            base.checked_add(self.total_fees_earned)
+        // Sum every term in a wide signed intermediate (i128) before range-checking, so no
+        // transient intermediate can spuriously underflow OR overflow. In a mode-1 (trading-LP)
+        // pool, withdrawals are fee-INCLUSIVE, so `total_withdrawn` can exceed `total_deposited`
+        // even while the pool is solvent (the surplus is accounted for by `total_fees_earned`).
+        // The previous `total_deposited.checked_sub(total_withdrawn)` underflowed to None in that
+        // case and PERMANENTLY BRICKED the pool — every caller does `.ok_or(Overflow)?` (see #169).
+        // i128 holds the sum/difference of five u64 counters with ~60 bits to spare
+        // (|value| < 5 * 2^64 < 2^67 ≪ 2^127), so the only way to reach None is the explicit
+        // final range check: net < 0 (genuine insolvency / over-flush, e.g. the over-withdraw
+        // guard callers rely on) or net > u64::MAX (genuinely unrepresentable). mode-0 stays
+        // byte-identical to `deposited - withdrawn - flushed + returned`.
+        //
+        // IMPORTANT: the `-flushed` term is essential. Do NOT simplify to
+        // `deposited - withdrawn + returned`: that double-counts, because returned tokens are
+        // already back in the vault while deposited conceptually still includes the flushed
+        // amount — omitting `-flushed` phantom-inflates value after any flush+return cycle.
+        //
+        // PERC-272: accrued trading fees count toward value only in mode 1.
+        let fees = if self.pool_mode == 1 {
+            self.total_fees_earned as i128
         } else {
-            Some(base)
+            0
+        };
+        let value = self.total_deposited as i128 + self.total_returned as i128 + fees
+            - self.total_withdrawn as i128
+            - self.total_flushed as i128;
+        if (0..=u64::MAX as i128).contains(&value) {
+            Some(value as u64)
+        } else {
+            None
         }
     }
 

--- a/tests/poc_mode1_fee_withdraw_underflow.rs
+++ b/tests/poc_mode1_fee_withdraw_underflow.rs
@@ -1,0 +1,84 @@
+//! PoC / regression — mode-1 (trading-LP) `total_pool_value()` underflow brick.
+//!
+//! `total_pool_value()` computes `total_deposited.checked_sub(total_withdrawn)` FIRST and
+//! adds `total_fees_earned` LAST (mode 1). But in a trading pool the withdrawal amount is
+//! fee-INCLUSIVE (priced against the fee-inclusive TPV), so `total_withdrawn` accumulates
+//! payouts that include fees while `total_deposited` tracks principal only. Once cumulative
+//! payouts exceed cumulative principal, `total_deposited.checked_sub(total_withdrawn)`
+//! underflows → None → every subsequent `total_pool_value()` returns None and the pool
+//! permanently bricks (deposits/withdrawals/accruals all revert via `.ok_or(Overflow)`),
+//! trapping remaining LPs' funds. Reachable in normal operation of any profitable trading
+//! pool — no attacker.
+//!
+//! These tests assert the CORRECT (post-fix) solvent values: they FAIL against the pre-fix
+//! code (None) and PASS once the arithmetic nets all credits before subtracting debits.
+
+use bytemuck::Zeroable;
+use percolator_stake::state::StakePool;
+
+fn trading_pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.set_discriminator();
+    p.pool_mode = 1; // trading LP
+    p
+}
+
+#[test]
+fn mode1_fee_inclusive_withdraw_does_not_brick_pool() {
+    let mut pool = trading_pool();
+    // Two LPs deposit 100 each (principal only).
+    pool.total_deposited = 200;
+    pool.total_lp_supply = 200;
+    // Engine trading fees of 300 crystallized via AccrueFees.
+    pool.total_fees_earned = 300;
+    assert_eq!(pool.total_pool_value(), Some(500), "200 - 0 - 0 + 0 + 300");
+
+    // LP A withdraws 100 of 200 LP at the fee-inclusive price: 100 * 500 / 200 = 250.
+    pool.total_withdrawn = 250; // fee-inclusive payout — exceeds total_deposited (200)
+    pool.total_lp_supply = 100; // LP B still holds 100 LP
+
+    // Real remaining value = 200 + 300 − 250 = 250. Pre-fix this underflows to None.
+    assert_eq!(
+        pool.total_pool_value(),
+        Some(250),
+        "must not underflow when fee-inclusive total_withdrawn (250) > total_deposited (200)"
+    );
+}
+
+#[test]
+fn mode1_tpv_reads_zero_not_none_when_emptied_via_fees() {
+    // Single LP deposits 100, earns 100 fees, withdraws everything (200 out).
+    let mut pool = trading_pool();
+    pool.total_deposited = 100;
+    pool.total_lp_supply = 100;
+    pool.total_fees_earned = 100;
+    assert_eq!(pool.total_pool_value(), Some(200));
+
+    pool.total_withdrawn = 200; // total_withdrawn (200) > total_deposited (100)
+    pool.total_lp_supply = 0;
+
+    // Empty, solvent pool must read 0 — not a None brick that blocks future re-use.
+    assert_eq!(pool.total_pool_value(), Some(0), "emptied pool reads 0, not None");
+}
+
+#[test]
+fn mode0_total_pool_value_unchanged_and_insolvency_still_none() {
+    // mode-0 (insurance) must be byte-identical: deposited − withdrawn − flushed + returned.
+    let mut pool = StakePool::zeroed();
+    pool.is_initialized = 1;
+    pool.set_discriminator();
+    pool.pool_mode = 0;
+    pool.total_deposited = 1_000;
+    pool.total_withdrawn = 200;
+    pool.total_flushed = 300;
+    pool.total_returned = 100;
+    assert_eq!(pool.total_pool_value(), Some(600), "1000 - 200 - 300 + 100");
+
+    pool.total_flushed = 900; // 1000 - 200 - 900 + 100 = 0
+    assert_eq!(pool.total_pool_value(), Some(0));
+
+    // A genuine over-flush (true insolvency / over-withdraw) must STILL return None.
+    pool.total_flushed = 1_100; // net negative
+    assert_eq!(pool.total_pool_value(), None, "genuine insolvency still surfaces as None");
+}


### PR DESCRIPTION
## Summary

Fixes #169. In a **mode-1 (trading-LP)** pool, `total_pool_value()` underflowed to `None` once cumulative withdrawals exceeded cumulative deposits, permanently **bricking the pool** — every caller does `.ok_or(StakeError::Overflow)?`, so deposits, withdrawals, and `AccrueFees` all revert and remaining LPs' funds are trapped. This is reachable in normal operation of any profitable trading pool (no attacker), because withdrawal payouts are fee-inclusive while `total_deposited` tracks principal only.

## Root cause

`total_pool_value()` subtracted `total_withdrawn` from `total_deposited` **first** and added `total_fees_earned` **last**:

```rust
let base = total_deposited.checked_sub(total_withdrawn)?  // underflows when withdrawn > deposited
    .checked_sub(total_flushed)?.checked_add(total_returned)?;
if pool_mode == 1 { base.checked_add(total_fees_earned) } else { Some(base) }
```

A withdrawal is priced against the fee-inclusive TPV, so `total_withdrawn += withdrawal_amount` accumulates principal **plus** fees, while `total_deposited` is principal only. Once payouts exceed principal, the intermediate `checked_sub` underflows → `None`, even though the *final* value (after adding fees) is non-negative and correct.

## Fix

Accumulate credits − debits in a wide signed intermediate (`i128`), then range-check the final net to `u64`:

```rust
let fees = if self.pool_mode == 1 { self.total_fees_earned as i128 } else { 0 };
let value = self.total_deposited as i128 + self.total_returned as i128 + fees
    - self.total_withdrawn as i128
    - self.total_flushed as i128;
if (0..=u64::MAX as i128).contains(&value) { Some(value as u64) } else { None }
```

`i128` holds the sum/difference of five `u64` counters with ~60 bits to spare (`|value| < 5·2^64 < 2^67 ≪ 2^127`), so no intermediate can spuriously under- or over-flow. The only path to `None` is now the explicit final check: `net < 0` (genuine insolvency / over-flush — the over-withdraw guard callers rely on) or `net > u64::MAX`.

### Why i128 over a u64 "credits-first" reorder

All three solution agents independently reached the same conclusion: a `checked_add`-credits-then-`checked_sub`-debits reorder fixes the reported underflow but introduces a **residual spurious-`None`** — on a long-lived pool the credit sum (`deposited + returned + fees`, all lifetime-cumulative) can overflow `u64` even when the net value is small, relocating the brick rather than eliminating it. The i128 form removes the entire spurious-`None` class.

## Behavior preserved

- **mode-0** byte-identical to `deposited − withdrawn − flushed + returned` (fees ignored unless `pool_mode == 1`).
- **Genuine insolvency / over-flush** still returns `None` (the only behavioral change is converting the *spurious* mode-1 `None` into the correct `Some`).
- `Some(0)` at exact zero; the `u64::MAX` boundary is inclusive.

## Tests

`tests/poc_mode1_fee_withdraw_underflow.rs`:
- `mode1_fee_inclusive_withdraw_does_not_brick_pool` — the fee-inclusive withdraw yields `Some(250)`, not the pre-fix `None`.
- `mode1_tpv_reads_zero_not_none_when_emptied_via_fees` — an emptied-via-fees pool reads `Some(0)`.
- `mode0_total_pool_value_unchanged_and_insolvency_still_none` — mode-0 unchanged, and a genuine over-flush still returns `None`.

## Verification

- `cargo build --lib` ✔
- `cargo build-sbf` ✔ (on-chain target)
- Scratch runner confirms `total_pool_value()` returns `Some(250)` (was `None`) after the fee-inclusive withdrawal, and **every other tranche/HWM/pricing scenario — all of which route through `total_pool_value()` — still passes**, confirming no regression.

## Note on scope

This is the **mode-1 (trading-LP)** path. The fix is correct and harmless regardless, but the real-world severity is CRITICAL if trading pools are deployed and merely latent if only mode-0 (insurance) pools are live — worth confirming on your side which modes are in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stake pool value calculation that caused trading mode pools to become permanently unresponsive when fee-inclusive withdrawals exceeded principal deposits, while maintaining standard mode behavior.

* **Tests**
  * Added test suite validating correct pool value calculations across trading and standard modes, including edge cases with fees, full pool depletion, and insolvency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->