### PR TITLE
fix(stake): deposit-cap principal basis (#154) + clear deposit record on full withdraw (#155)

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -493,7 +493,9 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
     // the pool once lifetime deposits hit the cap, even if 99% was withdrawn.
     // (H6 fix)
     if pool.deposit_cap > 0 {
-        let current_value = pool.total_pool_value().ok_or(StakeError::Overflow)?;
+        // #154: enforce the cap on PRINCIPAL TVL (no accrued fees), not total_pool_value();
+        // otherwise fee appreciation on a mode-1 trading pool silently locks out new deposits.
+        let current_value = pool.principal_tvl().ok_or(StakeError::Overflow)?;
         let new_value = current_value
             .checked_add(amount)
             .ok_or(StakeError::Overflow)?;
@@ -1069,6 +1071,19 @@ fn process_withdraw(
         .lp_amount
         .checked_sub(lp_amount)
         .ok_or(StakeError::InsufficientLpTokens)?;
+
+    // #155: once the position is fully withdrawn, reset the record's init + tranche
+    // flag so the (pool,user) PDA can be reused for EITHER tranche on the next deposit.
+    // Without this, _reserved[8] (the junior flag) and is_initialized persist, so PERC-303's
+    // anti-mixing guard permanently blocks the wallet from depositing into the OTHER tranche
+    // (and a junior who fully exits can never go senior, or vice-versa). Safe vs PERC-303:
+    // mixing requires a RESIDUAL liened position; with lp_amount == 0 there is nothing to mix.
+    // Metadata-only — touches no token/LP/accounting field. The deposit re-init path
+    // (process_deposit / process_deposit_junior) correctly re-initializes a zeroed record.
+    if deposit_mut.lp_amount == 0 {
+        deposit_mut.is_initialized = 0;
+        deposit_mut._reserved[8] = 0;
+    }
 
     if pool.tranche_enabled() && is_junior {
         msg!(
@@ -2183,7 +2198,9 @@ fn process_deposit_junior(
     }
 
     if pool.deposit_cap > 0 {
-        let current_value = pool.total_pool_value().ok_or(StakeError::Overflow)?;
+        // #154: enforce the cap on PRINCIPAL TVL (no accrued fees), not total_pool_value();
+        // otherwise fee appreciation on a mode-1 trading pool silently locks out new deposits.
+        let current_value = pool.principal_tvl().ok_or(StakeError::Overflow)?;
         let new_value = current_value
             .checked_add(amount)
             .ok_or(StakeError::Overflow)?;

--- a/src/state.rs
+++ b/src/state.rs
@@ -464,6 +464,21 @@ impl StakePool {
         }
     }
 
+    /// Principal-basis TVL: `deposited − withdrawn − flushed + returned`, WITHOUT
+    /// accrued trading fees. This is the basis the deposit cap is enforced against
+    /// (issue #154): the cap limits contributed principal/exposure, not fee
+    /// appreciation. Using `total_pool_value()` (fee-inclusive) for the cap meant a
+    /// mode-1 trading pool that earned fees would silently lock out new deposits even
+    /// though contributed principal was below the cap. LP pricing still uses
+    /// `total_pool_value()` (fee-inclusive). For mode-0 pools this equals
+    /// `total_pool_value()`.
+    pub fn principal_tvl(&self) -> Option<u64> {
+        self.total_deposited
+            .checked_sub(self.total_withdrawn)?
+            .checked_sub(self.total_flushed)?
+            .checked_add(self.total_returned)
+    }
+
     /// Calculate LP tokens for a deposit amount.
     /// Delegates to pure math module (Kani-verified).
     /// Returns None if pool accounting is broken (total_pool_value() underflows).

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -937,3 +937,34 @@ fn test_pool_stores_percolator_program() {
         "zeroed pool should have zero percolator_program"
     );
 }
+
+#[test]
+fn test_154_deposit_cap_enforced_on_principal_not_fees() {
+    // #154: a mode-1 trading pool that has earned fees. total_pool_value() is fee-inclusive,
+    // principal_tvl() is not. The deposit cap must be enforced on principal_tvl(), or fee
+    // appreciation silently locks out deposits whose contributed principal is under the cap.
+    let mut pool = new_pool();
+    pool.pool_mode = 1;
+    pool.deposit_cap = 1_000_000;
+    pool.total_deposited = 800_000;
+    pool.total_lp_supply = 800_000;
+    pool.total_fees_earned = 300_000; // tpv = 1_100_000 (> cap); principal = 800_000 (< cap)
+
+    assert_eq!(pool.principal_tvl(), Some(800_000), "principal excludes accrued fees");
+    assert_eq!(pool.total_pool_value(), Some(1_100_000), "tpv includes accrued fees");
+
+    // A 150K deposit keeps principal at 950K (<= 1M cap) → admitted under the fixed (principal) basis.
+    let deposit = 150_000u64;
+    let principal_after = pool.principal_tvl().unwrap() + deposit;
+    assert!(principal_after <= pool.deposit_cap, "#154: principal-basis cap admits the deposit");
+    // The old tpv-basis would have (wrongly) rejected it: 1.1M + 150K = 1.25M > cap.
+    let tpv_after = pool.total_pool_value().unwrap() + deposit;
+    assert!(tpv_after > pool.deposit_cap, "old fee-inclusive basis would have rejected it");
+
+    // mode-0: principal_tvl == total_pool_value (no fee term).
+    let mut m0 = new_pool();
+    m0.pool_mode = 0;
+    m0.total_deposited = 500_000;
+    m0.total_fees_earned = 99_999; // ignored for mode-0
+    assert_eq!(m0.principal_tvl(), m0.total_pool_value(), "mode-0: principal_tvl == tpv");
+}


### PR DESCRIPTION
Fixes **#154** (deposit cap counted accrued fees → spurious lockout) and **#155** (deposit-PDA tranche flag persisted after full withdrawal → wallet permanently blocked from the other tranche). See commit for the mechanism + safety analysis. **#157 deliberately NOT fixed** — on my own analysis it is *not a reachable bug* (a fee-enriched junior always covers any loss ≤ deposited, so the gross_senior saturation never affects the result); I reverted the speculative change and will note it on #157. Build-sbf clean; suite green except the 4 pre-existing `v17_stake_insurance_e2e` LiteSVM failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed deposit cap enforcement in mode-1 trading pools to exclude accrued fees, preventing legitimate deposits from being incorrectly rejected.
  * Deposit records can now be reused for either tranche on subsequent deposits.

* **Tests**
  * Added regression test to validate deposit cap enforcement behavior with accrued fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->