### PR TITLE
fix(stake): #161 fair recovery — realize forfeited junior loss at last-junior exit

### DIFF
--- a/kani-proofs/src/lib.rs
+++ b/kani-proofs/src/lib.rs
@@ -242,6 +242,35 @@ pub fn senior_balance(
     pv.checked_sub(effective_junior_balance(deposited, withdrawn, flushed, returned, junior_balance))
 }
 
+/// Mirror of StakePool::total_pool_value() AFTER the issue-#161 fix: the value a
+/// later insurance return can re-credit is reduced by `realized_junior_loss` —
+/// the loss the junior tranche permanently FORFEITED when its last LP exited
+/// during an outstanding loss. Those recovered tokens become dead (unclaimable)
+/// value so the refund cannot windfall to the protected senior tranche.
+pub fn total_pool_value_mode0_rl(
+    deposited: u32,
+    withdrawn: u32,
+    flushed: u32,
+    returned: u32,
+    realized_junior_loss: u32,
+) -> Option<u32> {
+    total_pool_value_mode0(deposited, withdrawn, flushed, returned)?
+        .checked_sub(realized_junior_loss)
+}
+
+/// Mirror of StakePool::senior_balance() after the #161 fix (RL-aware pool value).
+pub fn senior_balance_rl(
+    deposited: u32,
+    withdrawn: u32,
+    flushed: u32,
+    returned: u32,
+    junior_balance: u32,
+    realized_junior_loss: u32,
+) -> Option<u32> {
+    let pv = total_pool_value_mode0_rl(deposited, withdrawn, flushed, returned, realized_junior_loss)?;
+    pv.checked_sub(effective_junior_balance(deposited, withdrawn, flushed, returned, junior_balance))
+}
+
 // ═══════════════════════════════════════════════════════════════
 // KANI PROOFS — 54 harnesses (52 bounded + 2 INDUCTIVE §14)
 // PERC-783: kani::cover!() added to all symbolic proofs to guard
@@ -1627,5 +1656,67 @@ mod proofs {
         };
         kani::cover!(sb + ejb == pv, "COVER: tranche-decomposition path is reachable");
         assert!(sb as u64 + ejb as u64 == pv as u64, "senior + effective_junior == pool value");
+    }
+
+    /// ISSUE #161 — recovery never windfalls the protected senior tranche.
+    ///
+    /// Models the full lifecycle: senior `sp` + junior `jb0` deposit; an insurance
+    /// flush `nl` marks the junior down (junior-first); the LAST junior LP then
+    /// exits, which under the #161 fix REALIZES its absorbed loss `L`
+    /// (total_returned += L, realized_junior_loss += L); finally a permissionless
+    /// ReturnInsurance of `r` (bounded by the still-outstanding loss) lands.
+    ///
+    /// THEOREM: after all of that, senior_balance() ≤ its original principal `sp`.
+    /// The junior's forfeited loss is dead value — it can never be re-credited to
+    /// the senior tranche that was protected from it. (Pre-fix, the whole refund
+    /// windfalled to senior: senior_balance jumped to sp + L.)
+    #[kani::proof]
+    fn proof_161_recovery_never_windfalls_protected_senior() {
+        let sp: u32 = kani::any(); // senior principal
+        let jb0: u32 = kani::any(); // junior principal
+        let nl: u32 = kani::any(); // insurance flushed (== net_loss while returned==0)
+        kani::assume(sp <= 0xFFFF && jb0 <= 0xFFFF && nl <= 0xFFFF);
+
+        // Initial ledger: both tranches deposited, then `nl` flushed to the market.
+        let deposited = match sp.checked_add(jb0) {
+            Some(d) => d,
+            None => return,
+        };
+        kani::assume(nl <= deposited); // can't flush more principal than exists
+
+        // Junior-first loss split on the GROSS balances (what effective_junior_balance does).
+        let (junior_loss, _senior_loss) = distribute_loss(jb0, sp, nl);
+        let junior_payout = jb0.saturating_sub(junior_loss); // what the exiting junior withdraws
+
+        // --- #161 last-junior-exit booking ---
+        // forfeited L is the junior's absorbed loss, capped at the outstanding net_loss.
+        let l = junior_loss.min(nl);
+        let withdrawn = junior_payout; // junior fully exits
+        let returned_after_book = l; // total_returned += L
+        let rl = l; // realized_junior_loss += L
+        // After booking, junior_balance == 0.
+
+        // --- later permissionless ReturnInsurance of `r` ---
+        // bounded by the still-outstanding loss (flushed - returned_after_book).
+        let outstanding = nl.saturating_sub(returned_after_book);
+        let r: u32 = kani::any();
+        kani::assume(r <= outstanding);
+        let returned_final = match returned_after_book.checked_add(r) {
+            Some(v) => v,
+            None => return,
+        };
+
+        // Senior balance with junior gone (junior_balance == 0) and RL booked.
+        let senior = match senior_balance_rl(deposited, withdrawn, nl, returned_final, 0, rl) {
+            Some(v) => v,
+            None => return, // inconsistent accounting — not a reachable state
+        };
+
+        kani::cover!(senior == sp, "COVER: senior recovers exactly to principal (full senior-share return)");
+        kani::cover!(r > 0, "COVER: a non-trivial return is reachable");
+        assert!(
+            senior <= sp,
+            "#161: insurance recovery must never lift the protected senior above its principal"
+        );
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1031,6 +1031,41 @@ fn process_withdraw(
         pool.set_junior_total_lp(new_junior_lp);
 
         if new_junior_lp == 0 {
+            // #161 (fair-recovery): the LAST junior is exiting. Any insurance loss it
+            // absorbed (L = junior_balance − effective_junior_balance) is now FORFEITED —
+            // the junior took its marked-down payout and left, so a later ReturnInsurance
+            // of that portion must NOT windfall to senior (which was protected). REALIZE it:
+            // settle the junior portion (`total_returned += L`, capped at total_flushed so it
+            // can never exceed it) and record it in `realized_junior_loss` (which
+            // total_pool_value() subtracts). Net effect on total_pool_value() is zero at exit
+            // (the +L from total_returned cancels the −L from realized_junior_loss), so senior
+            // is unchanged here; but it caps any future return so the recovered tokens sit as
+            // DEAD value instead of inflating senior. Also lifts the deposit gate for the
+            // settled portion (net_loss drops). Must compute L BEFORE zeroing junior_balance.
+            let net_loss = pool.total_flushed.saturating_sub(pool.total_returned);
+            if net_loss > 0 {
+                let forfeited = pool
+                    .junior_balance()
+                    .saturating_sub(pool.effective_junior_balance());
+                // forfeited <= junior's share of net_loss <= net_loss, so total_returned + forfeited
+                // <= total_flushed (no over-settle); cap defensively all the same.
+                let forfeited = forfeited.min(net_loss);
+                if forfeited > 0 {
+                    pool.total_returned = pool
+                        .total_returned
+                        .checked_add(forfeited)
+                        .ok_or(StakeError::Overflow)?;
+                    pool.set_realized_junior_loss(
+                        pool.realized_junior_loss()
+                            .checked_add(forfeited)
+                            .ok_or(StakeError::Overflow)?,
+                    );
+                    msg!(
+                        "Last junior exit: realized (forfeited) junior loss {} (settled; not recoverable to senior)",
+                        forfeited
+                    );
+                }
+            }
             // All junior LP withdrawn — zero out the raw balance.
             // withdrawal_amount is derived from effective_junior_balance (loss-adjusted)
             // but junior_balance stores the raw (non-adjusted) value.  Subtracting

--- a/src/state.rs
+++ b/src/state.rs
@@ -284,6 +284,28 @@ impl StakePool {
         self.total_lp_supply.saturating_sub(self.junior_total_lp())
     }
 
+    /// Cumulative insurance loss that an exited junior tranche permanently REALIZED
+    /// (issue #161). Stored at `_reserved[51..59]` (LE u64).
+    ///
+    /// When the LAST junior LP exits while a loss is outstanding, the loss it absorbed
+    /// (`junior_balance − effective_junior_balance`) is forfeited: the junior took its
+    /// marked-down payout and walked away, so a later `ReturnInsurance` of that portion
+    /// must NOT flow to senior (which was protected). We settle that portion at exit
+    /// (`total_returned += L`) so it leaves the recoverable-loss ledger, and record it
+    /// here so `total_pool_value()` subtracts it — the recovered tokens then sit as DEAD
+    /// (unclaimable) value rather than windfalling senior. Conservation: vault tokens ==
+    /// junior_claims + senior_claims + realized_junior_loss(dead).
+    pub fn realized_junior_loss(&self) -> u64 {
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&self._reserved[51..59]);
+        u64::from_le_bytes(bytes)
+    }
+
+    /// Set the cumulative realized (forfeited) junior loss. See `realized_junior_loss`.
+    pub fn set_realized_junior_loss(&mut self, val: u64) {
+        self._reserved[51..59].copy_from_slice(&val.to_le_bytes());
+    }
+
     /// Loss-adjusted junior tranche balance.
     ///
     /// `junior_balance()` (stored) grows monotonically with deposits and withdrawals
@@ -457,11 +479,19 @@ impl StakePool {
             .checked_sub(self.total_flushed)?
             .checked_add(self.total_returned)?;
         // PERC-272: Include accrued trading fees for trading LP pools
-        if self.pool_mode == 1 {
-            base.checked_add(self.total_fees_earned)
+        let with_fees = if self.pool_mode == 1 {
+            base.checked_add(self.total_fees_earned)?
         } else {
-            Some(base)
-        }
+            base
+        };
+        // #161: subtract any realized (forfeited) junior loss. When the last junior exits
+        // during a loss, that portion is settled via `total_returned += L` (so it leaves
+        // the recoverable-loss ledger and lifts the deposit gate), and recorded in
+        // `realized_junior_loss`. The settle inflates the raw `+ total_returned` term by L
+        // without any tokens arriving, so we subtract it back here — the corresponding
+        // tokens (if ever physically returned) sit as DEAD value and are NOT claimable by
+        // senior, preventing the recovery-snipe windfall. Normally 0 (no-op).
+        with_fees.checked_sub(self.realized_junior_loss())
     }
 
     /// Principal-basis TVL: `deposited − withdrawn − flushed + returned`, WITHOUT
@@ -476,7 +506,10 @@ impl StakePool {
         self.total_deposited
             .checked_sub(self.total_withdrawn)?
             .checked_sub(self.total_flushed)?
-            .checked_add(self.total_returned)
+            .checked_add(self.total_returned)?
+            // #161: exclude realized (forfeited) junior loss — it is dead value, not live
+            // principal, so it must not count toward the deposit cap.
+            .checked_sub(self.realized_junior_loss())
     }
 
     /// Calculate LP tokens for a deposit amount.

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -968,3 +968,76 @@ fn test_154_deposit_cap_enforced_on_principal_not_fees() {
     m0.total_fees_earned = 99_999; // ignored for mode-0
     assert_eq!(m0.principal_tvl(), m0.total_pool_value(), "mode-0: principal_tvl == tpv");
 }
+
+#[test]
+fn test_161_last_junior_exit_does_not_windfall_recovery_to_senior() {
+    // Issue #161: junior 100k + senior 100k, flush 50k (junior-absorbed). The last junior
+    // exits at the marked-down price, then insurance is returned. Pre-fix the return windfalled
+    // entirely to senior (which was PROTECTED from the loss). The fix REALIZES the forfeited
+    // junior loss at exit (total_returned += L; realized_junior_loss += L), so total_pool_value()
+    // excludes it as dead value and senior stays at its principal.
+    let mut pool = new_pool();
+    pool.set_tranche_enabled(true);
+    pool.total_deposited = 200_000;
+    pool.total_lp_supply = 200_000;
+    pool.set_junior_balance(100_000);
+    pool.set_junior_total_lp(100_000);
+    assert_eq!(pool.senior_balance().unwrap(), 100_000, "senior 100k pre-loss");
+
+    // Flush 50k, junior-absorbed: senior protected, junior marked down to 50k.
+    pool.total_flushed = 50_000;
+    assert_eq!(pool.effective_junior_balance(), 50_000);
+    assert_eq!(pool.senior_balance().unwrap(), 100_000, "senior protected by junior first-loss");
+
+    // Last junior exits at eff_jb. Mirror process_withdraw's full-exit updates + the #161 booking.
+    let junior_payout = pool.effective_junior_balance(); // 50k
+    pool.total_withdrawn += junior_payout;
+    pool.total_lp_supply -= 100_000;
+    // ---- #161 booking (mirrors processor.rs last-junior-exit) ----
+    let net_loss = pool.total_flushed.saturating_sub(pool.total_returned);
+    let forfeited = pool
+        .junior_balance()
+        .saturating_sub(pool.effective_junior_balance())
+        .min(net_loss);
+    assert_eq!(forfeited, 50_000, "junior forfeits the 50k loss it absorbed");
+    pool.total_returned += forfeited;
+    pool.set_realized_junior_loss(pool.realized_junior_loss() + forfeited);
+    pool.set_junior_total_lp(0);
+    pool.set_junior_balance(0);
+    // --------------------------------------------------------------
+
+    // Senior is NOT windfalled — stays at its 100k principal.
+    assert_eq!(pool.effective_junior_balance(), 0);
+    assert_eq!(pool.total_pool_value().unwrap(), 100_000, "tpv excludes the dead forfeited loss");
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        100_000,
+        "#161: senior NOT windfalled by the junior-attributable recovery"
+    );
+    // Loss is settled — nothing left to return to inflate senior.
+    assert_eq!(
+        pool.total_flushed.saturating_sub(pool.total_returned),
+        0,
+        "junior loss realized/settled — no outstanding loss to return"
+    );
+    // Conservation: junior_got + senior_claim + realized_dead == deposited.
+    assert_eq!(
+        junior_payout + pool.senior_balance().unwrap() + pool.realized_junior_loss(),
+        200_000,
+        "conservation: junior payout + senior claim + dead(forfeited) == deposited"
+    );
+}
+
+#[test]
+fn test_161_no_loss_is_a_noop() {
+    // No loss → no forfeit → realized_junior_loss stays 0 → total_pool_value unchanged.
+    let mut pool = new_pool();
+    pool.set_tranche_enabled(true);
+    pool.total_deposited = 200_000;
+    pool.total_lp_supply = 200_000;
+    pool.set_junior_balance(100_000);
+    pool.set_junior_total_lp(100_000);
+    assert_eq!(pool.realized_junior_loss(), 0);
+    assert_eq!(pool.total_pool_value().unwrap(), 200_000);
+    assert_eq!(pool.senior_balance().unwrap(), 100_000);
+}


### PR DESCRIPTION
## Issue #161 — recovery-snipe windfall to the protected senior tranche

When the **last junior LP exits** while an insurance loss is still outstanding, the loss that junior absorbed (`junior_balance − effective_junior_balance`) used to stay in the recoverable-loss ledger. A later **permissionless `ReturnInsurance`** of that portion then flowed entirely to the **senior** tranche — which junior first-loss had *protected* from the loss. Senior could be lifted **above its principal** by a loss it never bore. That breaks conservation and is unfair (issue #161's worked example: junior 100k + senior 100k, flush 50k, last junior exits at 50k, return 50k → senior jumps to **150k**).

## Fix — realize the forfeited junior loss at exit (admin-free)

At the last-junior-exit branch in `process_withdraw`, settle the forfeited loss `L`:

- `total_returned += L`  (capped at `total_flushed`) — settles that portion so it leaves the outstanding-loss ledger (and lifts the deposit gate for it)
- `realized_junior_loss += L`  — new accessor at `StakePool._reserved[51..59]` (free bytes; **no size/version change**)

`total_pool_value()` and `principal_tvl()` now subtract `realized_junior_loss`. The `+L` from `total_returned` is exactly cancelled by the `−L` subtraction → **net-zero at exit (senior unchanged)**, and any future return is capped: the recovered tokens become **dead, unclaimable value** instead of windfalling senior.

**Conservation:** `vault_tokens == junior_claims + senior_claims + realized_junior_loss(dead)`.

This is pure exit-path bookkeeping — **no privileged instruction**, consistent with burned admin keys.

## Verification

- **Kani** `proof_161_recovery_never_windfalls_protected_senior` (in `kani-proofs/`, RL-aware mirrors): full lifecycle — flush → junior-first markdown → last-junior-exit realization → bounded `ReturnInsurance` — proves `senior_balance ≤ principal` for all symbolic states. `0 of 33` checks failed; **2/2 cover properties satisfied** (senior recovers *exactly* to principal on full senior-share return; non-trivial return reachable → non-vacuous).
- **Unit** `test_161_last_junior_exit_does_not_windfall_recovery_to_senior` (issue's exact 100k/100k/50k scenario → senior stays **100k**, conservation holds) + `test_161_no_loss_is_a_noop`. **62/62** unit tests pass.
- `cargo build-sbf --no-default-features` clean.

Closes #161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)