### PR TITLE
fix(stake): validate return insurance pool account data

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2506,6 +2506,7 @@ fn process_return_insurance(
     }
     verify_token_program(token_program)?;
     validate_account_owner(pool_pda, program_id)?;
+    validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
     let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2509,6 +2509,9 @@ fn process_return_insurance(
     validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
+    if pool_data.len() < STAKE_POOL_SIZE {
+        return Err(StakeError::InvalidAccount.into());
+    }
     let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
 
     if pool.is_initialized != 1 {


### PR DESCRIPTION
## Summary

- Adds the missing non-empty account validation in `process_return_insurance`
- Validates the pool PDA before borrowing mutable account data
- Aligns `process_return_insurance` with the validation pattern used by other stake pool write handlers

## How to test

- `cargo test return_insurance -- --nocapture`
- `cargo build-sbf`

## Checklist

- [x] Targeted return-insurance tests pass
- [x] SBF build passes
- [ ] Full `cargo test` suite

Full `cargo test` was not marked complete locally because unrelated `v17_stake_insurance_e2e` tests failed with `ProgramFailedToComplete`. The targeted return-insurance tests and SBF build passed.

## Related

Closes #158