### PR TITLE
fix(pool-init): read decimals from collateral_mint and use for LP mint

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -362,6 +362,17 @@ fn process_init_pool(
     // anti-freeze guarantee and is NOT an endorsement of transferring. Clients must
     // treat the LP as a soulbound receipt. (Enforced non-transferability via a
     // transfer hook is the future hardening; tracked in #167.)
+    // Read collateral mint decimals before creating the LP mint.
+    // The collateral_mint account is already in scope and its key is
+    // verified above (circular-mint guard + stored in pool state).
+    let collateral_decimals = {
+        let mint_data = collateral_mint.try_borrow_data()?;
+        if mint_data.len() < crate::spl_token::state::Mint::LEN {
+            return Err(StakeError::InvalidAccount.into());
+        }
+        crate::spl_token::state::Mint::unpack(&mint_data)?.decimals
+    };
+
     let vault_auth_seeds: &[&[u8]] = &[b"vault_auth", pool_pda.key.as_ref(), &[vault_auth_bump]];
     invoke_signed(
         &crate::spl_token::initialize_mint(
@@ -369,7 +380,7 @@ fn process_init_pool(
             lp_mint.key,
             vault_auth.key,
             None, // freeze_authority: None — LP tokens must not be freezable
-            6,
+            collateral_decimals,
         )?,
         &[lp_mint.clone(), rent_sysvar.clone()],
         &[vault_auth_seeds],

--- a/src/spl_token.rs
+++ b/src/spl_token.rs
@@ -199,4 +199,29 @@ pub mod state {
             Ok(Self { amount, state })
         }
     }
+
+    /// spl_token::state::Mint::LEN = 82
+    pub const MINT_LEN: usize = 82;
+
+    pub struct Mint {
+        pub decimals: u8,
+        pub is_initialized: bool,
+    }
+
+    impl Mint {
+        pub const LEN: usize = MINT_LEN;
+
+        /// Equivalent to `spl_token::state::Mint::unpack`.
+        pub fn unpack(data: &[u8]) -> Result<Self, ProgramError> {
+            if data.len() < Self::LEN {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            let decimals = data[44];
+            let is_initialized = data[45] != 0;
+            Ok(Self {
+                decimals,
+                is_initialized,
+            })
+        }
+    }
 }


### PR DESCRIPTION
## Issue Reference
Fixes #168 — **LP Mint Decimal Mismatch on Pool Initialization**

## Description
This PR replaces the hardcoded `6` decimals used during the initialization of the pool's LP mint with the actual decimals of the pool's `collateral_mint`.

### Context & Impact
Previously, initializing a pool with a non-6-decimal collateral (e.g., wrapped SOL at 9 decimals, or WBTC at 8 decimals) resulted in an LP mint permanently locked to 6 decimals. This decimal mismatch caused:
- **UI/Wallet Misrepresentation:** Balances rendered incorrectly (e.g., 1000× off for wSOL).
- **Mismatched Off-Chain Arithmetic:** Frontends and clients dividing mismatched units when calculating share price.
- **Deposit/Withdraw Amount Errors:** Off-by-delta scaling bugs when converting human-readable inputs to raw units.

### Proposed Changes
1. **Added `Mint` Unpacking State Helper (`src/spl_token.rs`)**:
   Introduced a minimal `Mint` struct and `unpack()` helper under the `state` module to read the SPL Mint's `decimals` (offset 44) and `is_initialized` (offset 45) fields byte-by-byte.
2. **Dynamic Decimals Fetch (`src/processor.rs`)**:
   Updated `process_init_pool` to read the decimals from `collateral_mint` using the new helper, and passed `collateral_decimals` into the `initialize_mint` CPI instead of the hardcoded `6` literal.

### Safety & Trust Assumptions
- The `collateral_mint` is already trusted and stored in the pool state. Unpacking it to read the `decimals` field introduces no new trust assumptions.
- The `unpack()` helper returns an error if the account data size is less than 82 bytes, adding a free account validity check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* LP tokens now dynamically inherit the collateral mint's decimal configuration instead of using a fixed value, ensuring LP token precision is consistent with the underlying collateral asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->