### PR TITLE
fix: allow fully wiped junior LP exits

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -952,12 +952,19 @@ fn process_withdraw(
         pool.calc_collateral_for_withdraw(lp_amount)
             .ok_or(StakeError::Overflow)?
     };
-    if withdrawal_amount == 0 {
+    let fully_wiped_junior_exit = pool.tranche_enabled()
+        && is_junior
+        && pool.effective_junior_balance() == 0
+        && withdrawal_amount == 0;
+
+    if withdrawal_amount == 0 && !fully_wiped_junior_exit {
         return Err(StakeError::ZeroAmount.into());
     }
 
-    // PERC-313: High-water mark floor enforcement
-    if pool.hwm_enabled() {
+    // PERC-313: High-water mark floor enforcement.
+    // A fully-wiped junior exit has zero collateral payout and cannot reduce TVL,
+    // so HWM should not block the LP burn/deposit cleanup path.
+    if pool.hwm_enabled() && !fully_wiped_junior_exit {
         let current_tvl = pool.total_pool_value().ok_or(StakeError::Overflow)?;
         let hwm = pool.refresh_hwm(clock.epoch, current_tvl);
         let post_tvl = current_tvl
@@ -1016,23 +1023,25 @@ fn process_withdraw(
     }
     let vault_auth_seeds: &[&[u8]] = &[b"vault_auth", pool_pda.key.as_ref(), &[vault_auth_bump]];
 
-    invoke_signed(
-        &crate::spl_token::transfer(
-            token_program.key,
-            vault.key,
-            user_ata.key,
-            vault_auth.key,
-            &[],
-            withdrawal_amount,
-        )?,
-        &[
-            vault.clone(),
-            user_ata.clone(),
-            vault_auth.clone(),
-            token_program.clone(),
-        ],
-        &[vault_auth_seeds],
-    )?;
+    if withdrawal_amount > 0 {
+        invoke_signed(
+            &crate::spl_token::transfer(
+                token_program.key,
+                vault.key,
+                user_ata.key,
+                vault_auth.key,
+                &[],
+                withdrawal_amount,
+            )?,
+            &[
+                vault.clone(),
+                user_ata.clone(),
+                vault_auth.clone(),
+                token_program.clone(),
+            ],
+            &[vault_auth_seeds],
+        )?;
+    }
 
     // Update pool totals
     pool.total_withdrawn = pool

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -882,3 +882,67 @@ fn test_large_amounts_no_overflow() {
     let lp = pool.calc_lp_for_deposit(u64::MAX / 4).unwrap();
     assert_eq!(lp, u64::MAX / 4, "Large LP calculation must use u128 intermediate");
 }
+
+/// Regression: fully-wiped junior LP should be able to burn worthless LP and exit.
+/// Zero-collateral payout is valid only in the fully-wiped junior terminal state.
+#[test]
+fn poc_fully_wiped_junior_lp_cannot_exit_due_zero_payout_guard() {
+    let mut pool = initialized_pool();
+    pool.set_tranche_enabled(true);
+    pool.set_junior_fee_mult_bps(20_000);
+
+    let senior_deposit = 10_000_000u64;
+    let junior_deposit = 5_000_000u64;
+
+    pool.total_deposited = senior_deposit + junior_deposit;
+    pool.total_lp_supply = senior_deposit + junior_deposit;
+    pool.set_junior_balance(junior_deposit);
+    pool.set_junior_total_lp(junior_deposit);
+
+    pool.total_flushed = junior_deposit;
+    pool.total_returned = 0;
+    pool.total_withdrawn = 0;
+
+    // Simulate an HWM floor that would block a normal withdrawal after the junior
+    // loss reduced current TVL below the same-epoch high-water mark. Since this
+    // fully-wiped junior exit has zero payout, it should still be allowed to
+    // reach the burn/cleanup path.
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(10_000);
+    pool.set_epoch_high_water_tvl(senior_deposit + junior_deposit);
+
+    let current_tvl = pool.total_pool_value().unwrap();
+    assert!(
+        !percolator_stake::math::hwm_withdrawal_allowed(
+            current_tvl,
+            pool.epoch_high_water_tvl(),
+            pool.hwm_floor_bps()
+        ),
+        "test setup should represent a state where HWM would block a normal withdrawal"
+    );
+
+    assert_eq!(pool.effective_junior_balance(), 0);
+
+    let lp_to_burn = junior_deposit;
+    let withdrawal_amount = percolator_stake::math::calc_junior_collateral_for_withdraw(
+        pool.junior_total_lp(),
+        pool.effective_junior_balance(),
+        lp_to_burn,
+    )
+    .unwrap();
+
+    assert_eq!(withdrawal_amount, 0);
+
+    let is_junior = true;
+    let fully_wiped_junior_exit = pool.tranche_enabled()
+        && is_junior
+        && pool.effective_junior_balance() == 0
+        && withdrawal_amount == 0;
+
+    let zero_amount_rejected = withdrawal_amount == 0 && !fully_wiped_junior_exit;
+
+    assert!(
+        !zero_amount_rejected,
+        "fully-wiped junior LP should be allowed to burn LP and cleanup state even with zero collateral payout"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #180.

This PR fixes the fully-wiped junior LP exit path where a junior LP position with zero remaining effective collateral could not be closed because the withdraw flow rejected `withdrawal_amount == 0` before LP burn and cleanup logic could run.

The withdraw path now only permits a zero-payout withdrawal when all of the following are true:

* tranches are enabled
* the position is junior
* `pool.effective_junior_balance() == 0`
* `withdrawal_amount == 0`

For that specific terminal state, the SPL token transfer is skipped, and HWM enforcement is bypassed because the zero-payout cleanup cannot reduce TVL. The LP burn and deposit/tranche cleanup path can still execute.

## Why

A fully-wiped junior LP can legitimately have no remaining collateral claim after absorbing losses.

Previously, the generic `ZeroAmount` guard rejected the withdrawal before the LP burn and cleanup path. After allowing the zero-payout path, HWM enforcement also needs to avoid blocking this specific cleanup scenario because no collateral leaves the pool.

This PR keeps zero-payout withdrawals rejected for normal/non-terminal cases, while allowing cleanup of a fully-wiped junior LP position.

## Changes

* Added a `fully_wiped_junior_exit` condition in `process_withdraw`.
* Kept `StakeError::ZeroAmount` for all zero-payout withdrawals except fully-wiped junior exits.
* Bypassed HWM enforcement only for fully-wiped junior zero-payout cleanup.
* Skipped the SPL token transfer when `withdrawal_amount == 0`.
* Preserved the existing burn/accounting cleanup path after the transfer section.
* Added a regression test for the fully-wiped junior LP zero-payout exit case, including HWM-blocked setup coverage.

## How to test

1. Build the SBF program:

```bash
cargo build-sbf
```

2. Run the targeted regression test:

```bash
cargo test poc_fully_wiped_junior_lp_cannot_exit_due_zero_payout_guard -- --nocapture
```

3. Run the v17 insurance E2E test:

```bash
cargo test --test v17_stake_insurance_e2e -- --nocapture
```

4. Run the full test suite:

```bash
cargo test
```

## Checklist

* [x] Linked issue included: Fixes #180
* [x] Regression test added
* [x] `cargo build-sbf` passes
* [x] Targeted regression test passes
* [x] `cargo test --test v17_stake_insurance_e2e -- --nocapture` passes
* [x] `cargo test` passes
* [x] No unrelated files changed
