### PR TITLE
fix(stake): #169 — compute pool value in i128 to stop mode-1 fee-withdraw brick

### DIFF
--- a/kani-proofs/src/lib.rs
+++ b/kani-proofs/src/lib.rs
@@ -271,6 +271,29 @@ pub fn senior_balance_rl(
     pv.checked_sub(effective_junior_balance(deposited, withdrawn, flushed, returned, junior_balance))
 }
 
+/// Mirror of StakePool::total_pool_value() AFTER the issue-#169 i128 fix: the mode-1
+/// (fee-inclusive, RL-aware) value summed in a wide SIGNED intermediate. In mode 1 a
+/// withdrawer's payout includes their fee share, so `withdrawn` can exceed `deposited`;
+/// the pre-fix left-to-right `deposited.checked_sub(withdrawn)` underflowed to None and
+/// bricked the pool. Summing signed makes order irrelevant — we fail closed only when the
+/// FINAL value is genuinely out of range (negative = insolvent, or > u32::MAX here).
+pub fn total_pool_value_mode1_rl_i128(
+    deposited: u32,
+    withdrawn: u32,
+    flushed: u32,
+    returned: u32,
+    fees: u32,
+    realized_junior_loss: u32,
+) -> Option<u32> {
+    let v = deposited as i64 - withdrawn as i64 - flushed as i64 + returned as i64 + fees as i64
+        - realized_junior_loss as i64;
+    if v < 0 || v > u32::MAX as i64 {
+        None
+    } else {
+        Some(v as u32)
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════
 // KANI PROOFS — 54 harnesses (52 bounded + 2 INDUCTIVE §14)
 // PERC-783: kani::cover!() added to all symbolic proofs to guard
@@ -1656,6 +1679,40 @@ mod proofs {
         };
         kani::cover!(sb + ejb == pv, "COVER: tranche-decomposition path is reachable");
         assert!(sb as u64 + ejb as u64 == pv as u64, "senior + effective_junior == pool value");
+    }
+
+    /// ISSUE #169 — mode-1 pool value never falsely bricks; insolvency still fails closed.
+    ///
+    /// In a mode-1 trading pool a withdrawer's payout includes accrued fees, so
+    /// `total_withdrawn` can exceed `total_deposited`. The pre-fix left-to-right
+    /// `deposited.checked_sub(withdrawn)` underflowed to None and PERMANENTLY bricked the
+    /// pool (LP funds trapped) even when the true value was positive.
+    ///
+    /// THEOREM: for any ledger, the i128 value equals the true signed sum whenever that
+    /// sum is in range — INCLUDING when withdrawn > deposited (the case that bricked) —
+    /// and returns None exactly when the true value is negative (genuine insolvency).
+    #[kani::proof]
+    fn proof_169_mode1_no_false_underflow_brick() {
+        let dep: u32 = kani::any();
+        let wd: u32 = kani::any();
+        let flush: u32 = kani::any();
+        let ret: u32 = kani::any();
+        let fees: u32 = kani::any();
+        let rl: u32 = kani::any();
+        kani::assume(dep <= 0xFFFF && wd <= 0xFFFF && flush <= 0xFFFF && ret <= 0xFFFF && fees <= 0xFFFF && rl <= 0xFFFF);
+
+        let true_value = dep as i64 - wd as i64 - flush as i64 + ret as i64 + fees as i64 - rl as i64;
+        let got = total_pool_value_mode1_rl_i128(dep, wd, flush, ret, fees, rl);
+
+        if (0..=u32::MAX as i64).contains(&true_value) {
+            kani::cover!(wd > dep, "COVER: the fee-withdrawal (withdrawn>deposited) path is reachable");
+            assert!(
+                got == Some(true_value as u32),
+                "#169: returns the true value even when withdrawn>deposited — no false brick"
+            );
+        } else if true_value < 0 {
+            assert!(got.is_none(), "#169: genuine insolvency still fails closed (None)");
+        }
     }
 
     /// ISSUE #161 — recovery never windfalls the protected senior tranche.

--- a/src/state.rs
+++ b/src/state.rs
@@ -473,25 +473,34 @@ impl StakePool {
     /// includes the flushed amount. Missing `-flushed` causes phantom inflation
     /// that makes the pool insolvent after any flush+return cycle.
     pub fn total_pool_value(&self) -> Option<u64> {
-        let base = self
-            .total_deposited
-            .checked_sub(self.total_withdrawn)?
-            .checked_sub(self.total_flushed)?
-            .checked_add(self.total_returned)?;
-        // PERC-272: Include accrued trading fees for trading LP pools
-        let with_fees = if self.pool_mode == 1 {
-            base.checked_add(self.total_fees_earned)?
+        // #169: sum in a wide SIGNED intermediate. In mode 1 a withdrawer's payout
+        // includes their share of accrued fees, so `total_withdrawn` can legitimately
+        // exceed `total_deposited` once fees have been paid out. The old left-to-right
+        // `total_deposited.checked_sub(total_withdrawn)` then underflowed to None and
+        // PERMANENTLY BRICKED the pool (LP funds trapped) even though the true value was
+        // still positive. Computing in i128 makes evaluation order irrelevant; we only
+        // fail closed when the FINAL value is genuinely out of range — i.e. negative
+        // (insolvent: claims exceed assets) or impossibly large. This preserves the
+        // insolvency guard while eliminating the false-underflow brick.
+        //
+        // PERC-272: accrued trading fees count toward a mode-1 trading pool's value.
+        let fees = if self.pool_mode == 1 {
+            self.total_fees_earned as i128
         } else {
-            base
+            0
         };
-        // #161: subtract any realized (forfeited) junior loss. When the last junior exits
-        // during a loss, that portion is settled via `total_returned += L` (so it leaves
-        // the recoverable-loss ledger and lifts the deposit gate), and recorded in
-        // `realized_junior_loss`. The settle inflates the raw `+ total_returned` term by L
-        // without any tokens arriving, so we subtract it back here — the corresponding
-        // tokens (if ever physically returned) sit as DEAD value and are NOT claimable by
-        // senior, preventing the recovery-snipe windfall. Normally 0 (no-op).
-        with_fees.checked_sub(self.realized_junior_loss())
+        // #161: subtract realized (forfeited) junior loss — dead value the exit booking
+        // added to `total_returned` but that is NOT claimable by senior. Normally 0.
+        let value = self.total_deposited as i128 - self.total_withdrawn as i128
+            - self.total_flushed as i128
+            + self.total_returned as i128
+            + fees
+            - self.realized_junior_loss() as i128;
+        if value < 0 || value > u64::MAX as i128 {
+            None
+        } else {
+            Some(value as u64)
+        }
     }
 
     /// Principal-basis TVL: `deposited − withdrawn − flushed + returned`, WITHOUT
@@ -503,13 +512,17 @@ impl StakePool {
     /// `total_pool_value()` (fee-inclusive). For mode-0 pools this equals
     /// `total_pool_value()`.
     pub fn principal_tvl(&self) -> Option<u64> {
-        self.total_deposited
-            .checked_sub(self.total_withdrawn)?
-            .checked_sub(self.total_flushed)?
-            .checked_add(self.total_returned)?
-            // #161: exclude realized (forfeited) junior loss — it is dead value, not live
-            // principal, so it must not count toward the deposit cap.
-            .checked_sub(self.realized_junior_loss())
+        // #169: same i128 widening as total_pool_value(). In mode 1, fee-inclusive
+        // withdrawals can push total_withdrawn past total_deposited; the old checked_sub
+        // underflowed to None and bricked DEPOSITS (the cap check fails closed on None).
+        // A principal basis can't be negative, so clamp a net-negative result to 0 — no
+        // live principal means the cap simply admits new deposits, rather than bricking.
+        // #161: realized (forfeited) junior loss is dead value, excluded from the cap basis.
+        let value = self.total_deposited as i128 - self.total_withdrawn as i128
+            - self.total_flushed as i128
+            + self.total_returned as i128
+            - self.realized_junior_loss() as i128;
+        Some(value.clamp(0, u64::MAX as i128) as u64)
     }
 
     /// Calculate LP tokens for a deposit amount.

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1041,3 +1041,94 @@ fn test_161_no_loss_is_a_noop() {
     assert_eq!(pool.total_pool_value().unwrap(), 200_000);
     assert_eq!(pool.senior_balance().unwrap(), 100_000);
 }
+
+// ═══════════════════════════════════════════════════════════════
+// #169 — mode-1 total_pool_value() / principal_tvl() i128 underflow fix
+// ═══════════════════════════════════════════════════════════════
+
+#[test]
+fn test_169_mode1_fee_withdrawal_does_not_brick_total_pool_value() {
+    // Issue #169: in a mode-1 trading pool a withdrawer's payout includes their fee
+    // share, so total_withdrawn can exceed total_deposited. Pre-fix, the left-to-right
+    // checked_sub(total_deposited - total_withdrawn) underflowed to None and PERMANENTLY
+    // bricked the pool with LPs still in it. The i128 sum returns the true value.
+    // Scenario: deposit 1000, accrue 500 fees (pv 1500), an 80%-LP withdraw pays
+    // 800*1500/1000 = 1200 -> total_withdrawn 1200 > total_deposited 1000.
+    let mut pool = new_pool();
+    pool.pool_mode = 1;
+    pool.total_deposited = 1_000;
+    pool.total_fees_earned = 500;
+    pool.total_withdrawn = 1_200;
+    // true value = 1000 - 1200 - 0 + 0 + 500 - 0 = 300 (the 20% of LP still in the pool)
+    assert_eq!(
+        pool.total_pool_value(),
+        Some(300),
+        "#169: fee-withdrawal must not brick — value is 300, not None"
+    );
+}
+
+#[test]
+fn test_169_principal_tvl_clamps_instead_of_bricking_deposits() {
+    // Same mode-1 fee-withdrawal scenario: principal_tvl's deposited - withdrawn goes
+    // net-negative (-200), which previously bricked DEPOSITS (cap check fails on None).
+    // Now it clamps to 0 so the deposit cap admits new principal.
+    let mut pool = new_pool();
+    pool.pool_mode = 1;
+    pool.total_deposited = 1_000;
+    pool.total_fees_earned = 500;
+    pool.total_withdrawn = 1_200;
+    assert_eq!(
+        pool.principal_tvl(),
+        Some(0),
+        "#169: net-negative principal basis clamps to 0, not None"
+    );
+}
+
+#[test]
+fn test_169_insolvency_still_fails_closed() {
+    // The i128 fix must NOT mask genuine insolvency: when the FINAL value is negative
+    // (claims exceed assets), total_pool_value() still returns None (fail-closed).
+    let mut pool = new_pool();
+    pool.pool_mode = 0;
+    pool.total_deposited = 1_000;
+    pool.total_withdrawn = 1_000;
+    pool.total_flushed = 500; // flushed, never returned -> -500 net
+    assert_eq!(
+        pool.total_pool_value(),
+        None,
+        "#169: genuine insolvency must still fail closed"
+    );
+}
+
+#[test]
+fn test_169_mode0_unaffected_and_rl_still_subtracted() {
+    // mode-0 (no fees) value unchanged by the rewrite; #161 realized_junior_loss
+    // still subtracted by both total_pool_value() and principal_tvl().
+    let mut pool = new_pool();
+    pool.pool_mode = 0;
+    pool.total_deposited = 1_000;
+    pool.total_withdrawn = 200;
+    pool.total_flushed = 100;
+    pool.total_returned = 50;
+    assert_eq!(pool.total_pool_value(), Some(750)); // 1000 - 200 - 100 + 50
+    assert_eq!(pool.principal_tvl(), Some(750));
+    pool.set_realized_junior_loss(50);
+    assert_eq!(
+        pool.total_pool_value(),
+        Some(700),
+        "#161 RL still subtracted under the i128 rewrite"
+    );
+    assert_eq!(pool.principal_tvl(), Some(700), "principal_tvl also subtracts RL");
+}
+
+#[test]
+fn test_169_mode1_fees_included_in_value_but_not_principal() {
+    // Healthy mode-1 pool: fees count toward pool value (LP pricing) but NOT toward
+    // the principal cap basis. Verifies the mode split survives the rewrite.
+    let mut pool = new_pool();
+    pool.pool_mode = 1;
+    pool.total_deposited = 1_000;
+    pool.total_fees_earned = 250;
+    assert_eq!(pool.total_pool_value(), Some(1_250), "value includes fees in mode 1");
+    assert_eq!(pool.principal_tvl(), Some(1_000), "cap basis excludes fees");
+}


### PR DESCRIPTION
## Bug (#169)
In a mode-1 trading pool, a withdrawer's payout includes their share of accrued fees, so `total_withdrawn` legitimately exceeds `total_deposited` once fees are paid out. `total_pool_value()`'s left-to-right `total_deposited.checked_sub(total_withdrawn)` then underflowed to `None` and **permanently bricked the pool** — LP funds trapped. `principal_tvl()` had the same shape and bricked **deposits**.

## Fix
Sum both in a wide **signed i128** intermediate (order no longer matters):
- `total_pool_value()` → `None` only when the **final** value is out of range (negative = genuine insolvency, or > u64::MAX). False-underflow brick gone; insolvency guard preserved. Keeps the #161 `realized_junior_loss` term + PERC-272 mode-1 fee inclusion.
- `principal_tvl()` → clamp a net-negative basis to `0` (deposit cap admits new principal) instead of bricking. #161 RL still excluded.

This is the i128 idea from **#170 (@0x-SquidSol)**, reimplemented on current `main` so it **keeps the post-#161 `- realized_junior_loss()` term** (the PR's stale base dropped it, which would have reverted #161) and also fixes the twin `principal_tvl()`.

## Verified
- **Kani** `proof_169_mode1_no_false_underflow_brick`: i128 value == true signed sum when in range (incl. `withdrawn > deposited`, the bricking case) and `None` iff truly insolvent. `0/104` failed; cover satisfied (non-vacuous).
- **Unit**: 5 #169 regression tests; full suite green (46 + 67); `build-sbf` clean.

Closes #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issue `#169`: pool value calculations no longer fail when total withdrawals exceed total deposits.
  * Improved principal value calculation accuracy in edge-case scenarios.

* **Tests**
  * Added unit tests for pool value calculation edge cases and fee handling verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->