### PR TITLE
fix(stake): #184 undersized-account guard in SetMarketResolved + #185 preserve HWM floor on disable

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2115,15 +2115,31 @@ fn process_admin_set_hwm_config(
         return Err(StakeError::Unauthorized.into());
     }
 
-    pool.set_hwm_enabled(enabled);
-    pool.set_hwm_floor_bps(hwm_floor_bps);
+    // #185: only write the floor when ENABLING. Disabling must preserve the
+    // previously stored floor — writing it unconditionally let a disable call
+    // (which carries hwm_floor_bps=0 and skips validate_hwm_floor_bps) clobber
+    // the stored floor, so re-enabling later silently lost the prior value.
+    apply_hwm_config(pool, enabled, hwm_floor_bps);
 
     msg!(
         "HWM config updated: enabled={}, floor_bps={}",
         enabled,
-        hwm_floor_bps
+        pool.hwm_floor_bps()
     );
     Ok(())
+}
+
+/// Apply a HWM config change to `pool`.
+///
+/// The enabled flag always tracks `enabled`. The floor is only written when
+/// enabling — disabling preserves whatever floor was previously stored so a
+/// subsequent re-enable does not silently reset it to the disable call's
+/// (validation-skipped) `hwm_floor_bps` argument (#185).
+fn apply_hwm_config(pool: &mut StakePool, enabled: bool, hwm_floor_bps: u16) {
+    pool.set_hwm_enabled(enabled);
+    if enabled {
+        pool.set_hwm_floor_bps(hwm_floor_bps);
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -2645,8 +2661,14 @@ fn process_set_market_resolved(program_id: &Pubkey, accounts: &[AccountInfo]) ->
         return Err(ProgramError::MissingRequiredSignature);
     }
     validate_account_owner(pool_pda, program_id)?;
+    // #184: mirror the #177/#183 fix — reject empty/undersized pool accounts
+    // before bytemuck reinterprets the data (a too-short slice would panic).
+    validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
+    if pool_data.len() < STAKE_POOL_SIZE {
+        return Err(StakeError::InvalidAccount.into());
+    }
     let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
 
     if pool.is_initialized != 1 {
@@ -2669,4 +2691,56 @@ fn process_set_market_resolved(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 
     msg!("SetMarketResolved: pool marked as resolved, deposits blocked");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytemuck::Zeroable;
+
+    // #185 regression: disabling HWM must NOT clobber the stored floor, so that
+    // a later re-enable preserves the operator's original floor. The disable
+    // path skips validate_hwm_floor_bps and typically carries hwm_floor_bps=0;
+    // before the fix that 0 overwrote the stored floor.
+    #[test]
+    fn test_apply_hwm_config_disable_preserves_floor() {
+        let mut pool = StakePool::zeroed();
+
+        // Enable with a real floor.
+        apply_hwm_config(&mut pool, true, 5000);
+        assert!(pool.hwm_enabled());
+        assert_eq!(pool.hwm_floor_bps(), 5000);
+
+        // Disable with the validation-skipped sentinel (0): floor must survive.
+        apply_hwm_config(&mut pool, false, 0);
+        assert!(!pool.hwm_enabled(), "disable must clear the enabled flag");
+        assert_eq!(
+            pool.hwm_floor_bps(),
+            5000,
+            "disabling HWM must preserve the previously stored floor"
+        );
+
+        // Re-enable without re-specifying the floor (0 again): the preserved
+        // floor remains in effect because disable never wiped it.
+        apply_hwm_config(&mut pool, true, 0);
+        assert!(pool.hwm_enabled());
+        // Re-enabling with an explicit 0 floor IS an intentional write (the
+        // enable path is validated upstream), so the floor now tracks the arg.
+        assert_eq!(pool.hwm_floor_bps(), 0);
+    }
+
+    // Enabling always writes the supplied (upstream-validated) floor.
+    #[test]
+    fn test_apply_hwm_config_enable_writes_floor() {
+        let mut pool = StakePool::zeroed();
+
+        apply_hwm_config(&mut pool, true, 7500);
+        assert!(pool.hwm_enabled());
+        assert_eq!(pool.hwm_floor_bps(), 7500);
+
+        // Re-enable with a different floor overwrites it.
+        apply_hwm_config(&mut pool, true, 9000);
+        assert!(pool.hwm_enabled());
+        assert_eq!(pool.hwm_floor_bps(), 9000);
+    }
 }

--- a/tests/regression_184_set_market_resolved_undersized.rs
+++ b/tests/regression_184_set_market_resolved_undersized.rs
@@ -1,0 +1,112 @@
+//! Regression for #184 — `process_set_market_resolved` must reject an
+//! owned-but-undersized pool account BEFORE `bytemuck::from_bytes_mut`
+//! reinterprets the data. Mirrors the merged #177/#183 fix in
+//! `process_return_insurance`.
+//!
+//! Before the fix the function validated owner only, then sliced
+//! `pool_data[..STAKE_POOL_SIZE]` — a data buffer shorter than
+//! `STAKE_POOL_SIZE` made that slice panic (program abort) instead of
+//! returning a clean `InvalidAccount` error.
+//!
+//! This loads ONLY the stake .so (no wrapper needed for tag 18) and sends a
+//! `SetMarketResolved` against a stake-program-owned account whose data is
+//! shorter than `STAKE_POOL_SIZE`, asserting the program returns
+//! `Custom(16)` (StakeError::InvalidAccount) rather than aborting.
+
+use litesvm::LiteSVM;
+use percolator_stake::state::STAKE_POOL_SIZE;
+use solana_sdk::{
+    account::Account,
+    instruction::{AccountMeta, Instruction, InstructionError},
+    pubkey::Pubkey,
+    signer::{keypair::Keypair, Signer},
+    transaction::{Transaction, TransactionError},
+};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+const STAKE_ID: &str = "9tbLt8fs1C7cJRXAyiGY7Ub88AT7MLWpxLqFNVCkqzA6";
+
+// StakeError::InvalidAccount = 16 (src/error.rs).
+const ERR_INVALID_ACCOUNT: u32 = 16;
+
+fn stake_so() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("target/deploy/percolator_stake.so");
+    p
+}
+
+#[test]
+fn set_market_resolved_rejects_undersized_pool_184() {
+    let so = stake_so();
+    if !so.exists() {
+        // Build artifact not present (e.g. cargo test without a prior
+        // build-sbf). Skip rather than fail — the unit/build-sbf gate covers
+        // the rest. Print so the skip is visible in CI logs.
+        eprintln!(
+            "SKIP set_market_resolved_rejects_undersized_pool_184: stake .so missing at {} \
+             — run `cargo build-sbf --no-default-features` first",
+            so.display()
+        );
+        return;
+    }
+
+    let mut svm = LiteSVM::new();
+    let stake_id = Pubkey::from_str(STAKE_ID).unwrap();
+    svm.add_program_from_file(stake_id, so).unwrap();
+
+    // Fund an admin/payer.
+    let admin = Keypair::new();
+    svm.airdrop(&admin.pubkey(), 1_000_000_000).unwrap();
+
+    // A stake-program-OWNED account whose data is shorter than the pool struct.
+    // Ownership passes validate_account_owner; non-emptiness passes
+    // validate_account_not_empty; the new length guard is what must catch it.
+    let pool_pda = Pubkey::new_unique();
+    let undersized = STAKE_POOL_SIZE / 2; // > 0 but < STAKE_POOL_SIZE
+    assert!(undersized > 0 && undersized < STAKE_POOL_SIZE);
+    svm.set_account(
+        pool_pda,
+        Account {
+            lamports: 1_000_000_000,
+            data: vec![0u8; undersized],
+            owner: stake_id,
+            executable: false,
+            rent_epoch: 0,
+        },
+    )
+    .unwrap();
+
+    // Tag 18: SetMarketResolved — accounts: [admin (signer), pool_pda].
+    let ix = Instruction {
+        program_id: stake_id,
+        accounts: vec![
+            AccountMeta::new(admin.pubkey(), true),
+            AccountMeta::new(pool_pda, false),
+        ],
+        data: vec![18u8],
+    };
+
+    let tx = Transaction::new(
+        &[&admin],
+        solana_sdk::message::Message::new(&[ix], Some(&admin.pubkey())),
+        svm.latest_blockhash(),
+    );
+
+    let err = svm
+        .send_transaction(tx)
+        .expect_err("undersized pool account must be rejected, not accepted");
+
+    match err.err {
+        TransactionError::InstructionError(0, InstructionError::Custom(code)) => {
+            assert_eq!(
+                code, ERR_INVALID_ACCOUNT,
+                "expected StakeError::InvalidAccount ({ERR_INVALID_ACCOUNT}), got Custom({code})"
+            );
+        }
+        other => panic!(
+            "expected clean Custom({ERR_INVALID_ACCOUNT}) InvalidAccount, got {other:?} \
+             (a ProgramFailedToComplete / abort would indicate the slice panic regressed)"
+        ),
+    }
+}


### PR DESCRIPTION
**#184** — `process_set_market_resolved` now rejects empty/undersized pool accounts (`validate_account_not_empty` + `len < STAKE_POOL_SIZE`) before the bytemuck reinterpret, mirroring the merged #177/#183 fix. **#185** — `apply_hwm_config` only writes the HWM floor when *enabling*, so a disable call (which carries `hwm_floor_bps=0` and skips validation) no longer clobbers the stored floor on re-enable.

Verified: `build-sbf` clean; full suite green incl. new `set_market_resolved_rejects_undersized_pool_184` + the #185 disable-preserves-floor unit test. Closes #184, #185.

⚠️ DRAFT — verified locally but NOT for merge until human-gated (fund-critical program / cutover). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HWM configuration to preserve previously stored floor values when disabling, preventing accidental overwrites.
  * Enhanced account validation in market resolution to prevent crashes with undersized or malformed data.

* **Tests**
  * Added comprehensive unit tests for HWM configuration behavior and regression test for account validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->