### PR TITLE
refactor: name init trading pool account index

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -94,6 +94,10 @@ fn create_or_adopt_pda<'a>(
 /// withdrawals — `clock.slot` would never reach the saturating deadline (#121).
 const MAX_COOLDOWN_SLOTS: u64 = 78_840_000;
 
+/// Pool PDA account index in the InitPool-compatible account layout:
+/// admin=0, slab=1, pool_pda=2.
+const INIT_POOL_POOL_PDA_INDEX: usize = 2;
+
 /// Validate cooldown_slots parameter: must be > 0 to enforce cooldown, and bounded
 /// above so it cannot be used to permanently freeze withdrawals.
 fn validate_cooldown_slots(cooldown_slots: u64) -> ProgramResult {
@@ -2517,7 +2521,7 @@ fn process_init_trading_pool(
 
     // Now update pool_mode to 1 (trading LP)
     // AUDIT HIGH-4: Validate pool_pda ownership instead of trusting hardcoded index
-    let pool_ai = &accounts[2]; // Pool PDA is account [2] in InitPool (admin=0, slab=1, pool_pda=2)
+    let pool_ai = &accounts[INIT_POOL_POOL_PDA_INDEX];
     validate_account_owner(pool_ai, program_id)?;
     let mut pool_data = pool_ai.try_borrow_mut_data()?;
     let pool = bytemuck::try_from_bytes_mut::<state::StakePool>(&mut pool_data[..STAKE_POOL_SIZE])


### PR DESCRIPTION
## Summary

Fixes #186.
Addresses #190.

This PR replaces the hardcoded `accounts[2]` lookup in `process_init_trading_pool` with a named constant:

```rust
const INIT_POOL_POOL_PDA_INDEX: usize = 2;
```

`process_init_trading_pool` delegates to `process_init_pool(...)`, then reuses the InitPool-compatible account layout to fetch the pool PDA and set `pool_mode = 1`.

Previously, the code relied on a bare positional index:

```rust
let pool_ai = &accounts[2];
```

This PR makes that account-order dependency explicit by using:

```rust
let pool_ai = &accounts[INIT_POOL_POOL_PDA_INDEX];
```

## Why

The existing code is correct today, but the bare `accounts[2]` value creates fragile coupling between `process_init_trading_pool` and the account ordering expected by `process_init_pool`.

If the InitPool account layout is refactored later, the hardcoded index could become stale while still compiling. Naming the index makes the invariant explicit and easier to review.

## Changes

* Added `INIT_POOL_POOL_PDA_INDEX`.
* Documented the InitPool-compatible account layout:

  * `admin = 0`
  * `slab = 1`
  * `pool_pda = 2`
* Replaced the bare `accounts[2]` lookup in `process_init_trading_pool`.
* Kept the change limited to `src/processor.rs`.

## How to test

Run:

```bash
cargo test
```

## Checklist

* [x] Keeps logic unchanged
* [x] Removes the bare magic account index from `process_init_trading_pool`
* [x] Makes the InitPool account-order invariant explicit
* [x] Changes only `src/processor.rs`
* [x] No merge conflict with `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code quality in trading pool initialization through internal code structure enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->