### PR TITLE
fix(stake): bound hwm_floor_bps below 100% so the HWM floor can't freeze withdrawals

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -94,6 +94,19 @@ fn create_or_adopt_pda<'a>(
 /// withdrawals — `clock.slot` would never reach the saturating deadline (#121).
 const MAX_COOLDOWN_SLOTS: u64 = 78_840_000;
 
+/// Upper bound on `hwm_floor_bps` (90%). The high-water-mark floor is a per-epoch
+/// drain RATE LIMITER, not a withdrawal kill switch. At 10_000 (100%) the floor
+/// equals the full water mark, and because `refresh_hwm` keeps the mark at or above
+/// current TVL (and re-anchors it to current TVL on every new epoch), ANY positive
+/// withdrawal lands below the floor — a permanent, pool-wide withdrawal freeze that
+/// even survives epoch rollover. Capping strictly below 100% guarantees the floor is
+/// always below the mark; 90% in particular keeps at least 10% of peak TVL
+/// withdrawable per epoch, so the feature stays a rate limiter while still allowing a
+/// very aggressive anti-drain posture. This mirrors `MAX_COOLDOWN_SLOTS` (#121),
+/// which finitely bounds the cooldown for the same "an admin must never be able to
+/// permanently lock withdrawals" reason.
+const MAX_HWM_FLOOR_BPS: u16 = 9_000;
+
 /// Pool PDA account index in the InitPool-compatible account layout:
 /// admin=0, slab=1, pool_pda=2.
 const INIT_POOL_POOL_PDA_INDEX: usize = 2;
@@ -112,11 +125,17 @@ fn validate_cooldown_slots(cooldown_slots: u64) -> ProgramResult {
     Ok(())
 }
 
-/// Validate HWM floor basis points: must be in range [1, 10000].
+/// Validate HWM floor basis points: must be in range [1, MAX_HWM_FLOOR_BPS].
+///
+/// The upper bound is strictly below 100% (10_000): a 100% floor would equal the
+/// high-water mark and, because `refresh_hwm` keeps the mark at or above current TVL
+/// each epoch, would permanently freeze every withdrawal. Bounding it below 100%
+/// keeps the floor a per-epoch drain rate limiter that always leaves exit headroom.
 fn validate_hwm_floor_bps(hwm_floor_bps: u16) -> ProgramResult {
-    if hwm_floor_bps == 0 || hwm_floor_bps > 10_000 {
+    if hwm_floor_bps == 0 || hwm_floor_bps > MAX_HWM_FLOOR_BPS {
         msg!(
-            "Invalid hwm_floor_bps: must be 1-10000, got {}",
+            "Invalid hwm_floor_bps: must be 1-{}, got {}",
+            MAX_HWM_FLOOR_BPS,
             hwm_floor_bps
         );
         return Err(ProgramError::InvalidArgument);
@@ -2746,5 +2765,73 @@ mod tests {
         apply_hwm_config(&mut pool, true, 9000);
         assert!(pool.hwm_enabled());
         assert_eq!(pool.hwm_floor_bps(), 9000);
+    }
+
+    // ── #196: hwm_floor_bps must be bounded strictly below 100% ──
+    //
+    // The HWM floor is a per-epoch drain rate limiter, not a kill switch. At exactly
+    // 10_000 (100%) the floor equals the high-water mark and — because refresh_hwm
+    // keeps the mark >= current TVL and re-anchors it every new epoch — EVERY positive
+    // withdrawal is permanently blocked (a pool-wide freeze that survives epoch
+    // rollover). validate_hwm_floor_bps must therefore reject 100% (and anything above
+    // the cap) while still accepting the full legitimate rate-limiter range.
+
+    #[test]
+    fn test_validate_hwm_floor_bps_rejects_100_percent_and_above_cap() {
+        // The exact freeze value from #196.
+        assert!(
+            validate_hwm_floor_bps(10_000).is_err(),
+            "100% floor must be rejected: it permanently freezes all withdrawals (#196)"
+        );
+        // One basis point past the cap, and the u16 extreme, must also be rejected.
+        assert!(validate_hwm_floor_bps(MAX_HWM_FLOOR_BPS + 1).is_err());
+        assert!(validate_hwm_floor_bps(u16::MAX).is_err());
+    }
+
+    #[test]
+    fn test_validate_hwm_floor_bps_rejects_zero() {
+        // Unchanged: a 0 floor offers no anti-drain protection and is rejected on the
+        // (validated) enable path.
+        assert!(validate_hwm_floor_bps(0).is_err());
+    }
+
+    #[test]
+    fn test_validate_hwm_floor_bps_accepts_legitimate_range_up_to_cap() {
+        // Every legitimate rate-limiter floor, including the new maximum, is accepted.
+        for bps in [1u16, 5_000, 7_500, MAX_HWM_FLOOR_BPS] {
+            assert!(
+                validate_hwm_floor_bps(bps).is_ok(),
+                "{bps} bps is a valid non-freezing floor and must be accepted"
+            );
+        }
+        // The cap is strictly below 100%, so a withdrawal margin always exists.
+        assert!(MAX_HWM_FLOOR_BPS < 10_000);
+    }
+
+    // Behavioral proof through the same math the withdraw gate calls
+    // (processor.rs withdraw path -> math::hwm_floor / hwm_withdrawal_allowed): at the
+    // capped maximum a healthy pool still permits a positive withdrawal (the feature
+    // stays a limiter), whereas the now-rejected 100% value blocked even a 1-unit exit.
+    #[test]
+    fn test_capped_floor_preserves_a_withdrawal_margin() {
+        use crate::math::{hwm_floor, hwm_withdrawal_allowed};
+
+        let tvl: u64 = 1_000_000;
+        let hwm = tvl; // refresh_hwm invariant: hwm >= current_tvl
+
+        let floor = hwm_floor(hwm, MAX_HWM_FLOOR_BPS).expect("floor computes");
+        assert!(floor < tvl, "capped floor must leave a withdrawable margin");
+        let margin = tvl - floor; // 100_000 at 9_000 bps (10% of peak)
+        assert!(margin > 0);
+        assert!(
+            hwm_withdrawal_allowed(tvl - margin, hwm, MAX_HWM_FLOOR_BPS),
+            "a withdrawal down to the floor must be allowed at the cap"
+        );
+
+        // Contrast: the rejected 100% value blocks even a single unit.
+        assert!(
+            !hwm_withdrawal_allowed(tvl - 1, hwm, 10_000),
+            "100% floor (now rejected by the setter) would block every withdrawal"
+        );
     }
 }

--- a/tests/poc_hwm_floor_100pct_freeze.rs
+++ b/tests/poc_hwm_floor_100pct_freeze.rs
@@ -1,0 +1,104 @@
+//! PoC — `hwm_floor_bps == 10_000` (100%) turns the HWM drain-limiter into a permanent
+//! withdrawal kill-switch (issue #196).
+//!
+//! ── Mechanism ────────────────────────────────────────────────────────────────
+//! `validate_hwm_floor_bps` accepts any value in `[1, 10_000]` (processor.rs:117 —
+//! the guard is `bps == 0 || bps > 10_000`, so 10_000 passes). The withdraw path
+//! (processor.rs:982-996) enforces, for an enabled pool:
+//!
+//!     current_tvl = pool.total_pool_value()
+//!     hwm         = pool.refresh_hwm(epoch, current_tvl)   // only RAISES within an epoch;
+//!                                                          // RE-ANCHORS to current_tvl on a new epoch
+//!     post_tvl    = current_tvl - withdrawal_amount
+//!     require  hwm_withdrawal_allowed(post_tvl, hwm, floor_bps)  // == post_tvl >= hwm*bps/10000
+//!
+//! At `bps == 10_000` the floor equals the full mark. Because `refresh_hwm` guarantees
+//! `hwm >= current_tvl`, we have `floor == hwm >= current_tvl`, so ANY positive
+//! withdrawal makes `post_tvl < floor` → rejected with `WithdrawalBelowHwmFloor`.
+//!
+//! Crucially this is NOT escaped by waiting for the next epoch: on a new epoch
+//! `refresh_hwm` re-anchors the mark to the (still full) current TVL, so the floor
+//! re-pegs to 100% of current TVL and the next withdrawal is blocked again. The only
+//! escape is the admin lowering the floor / disabling HWM. The freeze is permanent
+//! and pool-wide.
+//!
+//! Uses the real `StakePool::refresh_hwm` + `math::hwm_withdrawal_allowed` — the exact
+//! functions the withdraw instruction calls.
+
+use bytemuck::Zeroable;
+use percolator_stake::math::{hwm_floor, hwm_withdrawal_allowed};
+use percolator_stake::state::StakePool;
+
+/// A healthy, fully-backed pool (no loss) with HWM enabled at a 100% floor.
+fn pool_with_floor(bps: u16) -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.set_discriminator();
+    p.set_hwm_enabled(true);
+    p.set_hwm_floor_bps(bps);
+    p.total_deposited = 1_000_000; // total_pool_value() == 1_000_000 (no flush, no fees)
+    p
+}
+
+/// Replicates the withdraw-path HWM gate (processor.rs:982-996) for a given epoch &
+/// withdrawal amount. Returns `true` if the withdrawal would be ALLOWED.
+fn withdrawal_allowed(pool: &mut StakePool, epoch: u64, amount: u64) -> bool {
+    let current_tvl = pool.total_pool_value().unwrap();
+    let hwm = pool.refresh_hwm(epoch, current_tvl);
+    let post_tvl = current_tvl - amount;
+    hwm_withdrawal_allowed(post_tvl, hwm, pool.hwm_floor_bps())
+}
+
+#[test]
+fn floor_100pct_blocks_every_positive_withdrawal_on_a_healthy_pool() {
+    let mut pool = pool_with_floor(10_000); // 100%
+
+    // Sanity: at 100% the floor equals the full mark.
+    let hwm = pool.refresh_hwm(5, 1_000_000);
+    assert_eq!(hwm, 1_000_000);
+    assert_eq!(hwm_floor(hwm, 10_000), Some(1_000_000), "floor == 100% of the mark");
+
+    // No loss has occurred — the pool is fully solvent (TVL == 1,000,000) — yet EVERY
+    // positive withdrawal is rejected, from a dust 1-unit exit up to a full redemption.
+    for amount in [1u64, 1_000, 250_000, 999_999, 1_000_000] {
+        assert!(
+            !withdrawal_allowed(&mut pool, 5, amount),
+            "withdraw of {amount} must be blocked at a 100% HWM floor (post_tvl < floor)"
+        );
+    }
+}
+
+#[test]
+fn epoch_rollover_does_not_lift_the_freeze() {
+    // The issue posits the freeze lasts only "for the remainder of that epoch" and that the
+    // next epoch unfreezes it. That is FALSE at exactly 100%: refresh_hwm re-anchors the mark
+    // to the (still full) current TVL on the new epoch, so the floor re-pegs to 100% of TVL.
+    let mut pool = pool_with_floor(10_000);
+
+    // Epoch 5: frozen.
+    assert!(!withdrawal_allowed(&mut pool, 5, 1), "frozen in the peak epoch");
+
+    // Epoch 6 (rollover): refresh_hwm re-anchors mark to current TVL = 1,000,000.
+    let hwm_new_epoch = pool.refresh_hwm(6, 1_000_000);
+    assert_eq!(hwm_new_epoch, 1_000_000, "mark re-anchors to current TVL on a new epoch");
+    assert!(
+        !withdrawal_allowed(&mut pool, 6, 1),
+        "STILL frozen one epoch later — the freeze is permanent until the admin lowers the floor"
+    );
+
+    // And many epochs later — same result.
+    assert!(!withdrawal_allowed(&mut pool, 9_999, 1), "still frozen thousands of epochs later");
+}
+
+#[test]
+fn boundary_9999_allows_a_sliver_so_10000_is_the_discontinuity() {
+    // At 9999 bps the floor is 999,900, so a withdrawal of up to 100 units is allowed —
+    // the feature still functions as a *rate limiter*. Bumping the cap by a single bp to
+    // 10000 removes the last unit of headroom and converts it into a *kill switch*.
+    let mut pool99 = pool_with_floor(9_999);
+    assert!(withdrawal_allowed(&mut pool99, 5, 100), "9999 bps allows a 100-unit withdrawal");
+    assert!(!withdrawal_allowed(&mut pool99, 5, 101), "9999 bps blocks beyond the 0.01% headroom");
+
+    let mut pool100 = pool_with_floor(10_000);
+    assert!(!withdrawal_allowed(&mut pool100, 5, 1), "10000 bps blocks even a single unit");
+}


### PR DESCRIPTION
## Summary

Bounds `hwm_floor_bps` strictly below 100% so the high-water-mark floor can never freeze withdrawals. Fixes #196.

The HWM floor is intended as a per-epoch drain **rate limiter**, but `validate_hwm_floor_bps` accepted the full `[1, 10_000]` range. At `10_000` (100%) the withdraw-path gate computes `floor == epoch_high_water_tvl`, and because `refresh_hwm` keeps the mark at or above current TVL — and re-anchors it to the (still full) current TVL on every new epoch — **any positive withdrawal lands below the floor**. The result is a permanent, pool-wide withdrawal freeze that is *not* lifted by epoch rollover; only the admin lowering the floor or disabling HWM can clear it.

Because pool creation is permissionless, this is reachable by an untrusted pool admin. It also contradicts the invariant already enforced elsewhere in the program that an admin must never be able to permanently lock withdrawals — see the `MAX_COOLDOWN_SLOTS` cap and the deliberate `freeze_authority = None` on the LP mint.

## Fix

- Add `const MAX_HWM_FLOOR_BPS: u16 = 9_000;` (90%) and reject anything above it in `validate_hwm_floor_bps`, mirroring the existing `MAX_COOLDOWN_SLOTS` / `validate_cooldown_slots` idiom.
- 90% keeps **≥10% of peak TVL withdrawable per epoch**, so the floor stays a genuine rate limiter (full exit possible within ~10 epochs) while still allowing a very aggressive anti-drain posture. The default floor is 50%, so this restricts only the degenerate 90–100% band, which has no legitimate rate-limiting use.

## Why the validator is the only change point

- `validate_hwm_floor_bps` is invoked on the **only** validated write path to the floor: `AdminSetHwmConfig` → `apply_hwm_config`, and only when `enabled == true`.
- `process_init_pool` never writes the floor (a fresh pool is zeroed: HWM disabled, floor 0).
- The disable path carries `bps = 0`, skips validation, and `apply_hwm_config` does not write the floor when disabling, so it can never install 100%.
- This is a fresh-start deployment (no v1 pools exist), so no pool can already hold a stored 100% floor; no migration or read-side clamp is required. The withdraw hot path is unchanged (no added CU).

## Tests

- New same-file unit tests in `src/processor.rs` for the validator bound: rejects `10_000` (the freeze value), rejects `MAX_HWM_FLOOR_BPS + 1` and `u16::MAX`, rejects `0`, accepts `[1, 5_000, 7_500, 9_000]`, and a behavioral check (via the real `math::hwm_floor` / `hwm_withdrawal_allowed`) that the capped floor still permits a positive withdrawal whereas 100% blocks even a single unit.
- New standalone PoC `tests/poc_hwm_floor_100pct_freeze.rs` demonstrating the 100% discontinuity through the real `refresh_hwm` / `hwm_withdrawal_allowed` / `hwm_floor` functions, including that epoch rollover does not lift the freeze.

```
$ cargo test --lib   # processor::tests + state/math, all green
test result: ok. 126 passed; 0 failed

processor::tests::test_validate_hwm_floor_bps_rejects_100_percent_and_above_cap ... ok
processor::tests::test_validate_hwm_floor_bps_rejects_zero ... ok
processor::tests::test_validate_hwm_floor_bps_accepts_legitimate_range_up_to_cap ... ok
processor::tests::test_capped_floor_preserves_a_withdrawal_margin ... ok
```

## Severity

Low (privileged-role-gated, denial-of-service only, reversible by the admin — no loss of funds). Tracked as hardening; see #196 for the full analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the maximum high-water mark (HWM) floor configuration to 90%, preventing a setting that could permanently freeze withdrawals on otherwise healthy pools.

* **Tests**
  * Added comprehensive tests validating HWM floor behavior across various percentage thresholds and confirming withdrawal mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->