### PR TITLE
fix: seal secure-bind rotate-back after asset-admin burn

### DIFF
--- a/src/cpi.rs
+++ b/src/cpi.rs
@@ -11,9 +11,11 @@
 //!   * UpdateAssetAuthority (tag 65)      — burn `asset_admin` (kind=0,
 //!     new_pubkey=[0;32]) so the admin cannot rotate any authority back.
 //!
-//! The last three CPIs are issued atomically in BindInsuranceAuthority (tag 19)
-//! to guarantee the STRONG no-admin-drain property: after bind, no admin key
-//! can drain insurance via WithdrawInsuranceAsset (tag 57).
+//! The authority and operator CPIs are issued together in BindInsuranceAuthority
+//! (tag 19); the asset_admin burn is a separate finalization step
+//! (BurnAssetAdmin, tag 21). Together they guarantee the STRONG no-admin-drain
+//! property: after bind + burn, no admin key can drain insurance via
+//! WithdrawInsuranceAsset (tag 57), and stake will not rotate the PDA roles back.
 //!
 //! V17 WIRE CHANGE (collision row 43): the v16 wire used tag 32 `UpdateAuthority`
 //! with kind byte = 2 (AUTHORITY_INSURANCE) and a 34-byte payload. The v17 auth

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -99,8 +99,8 @@ pub enum StakeInstruction {
     /// otherwise-permanent bind: without it, a stake redeploy to a new program id
     /// would orphan insurance_authority on the dead program and brick the flush.
     /// Migration: rotate to the admin wallet from the OLD program before
-    /// decommissioning it, then re-bind from the NEW program. Only works while the
-    /// PDA is the current authority (i.e. after a bind).
+    /// decommissioning it, then re-bind from the NEW program before BurnAssetAdmin.
+    /// Only works while the PDA is the current authority and before the final burn.
     ///
     /// Accounts:
     ///   0. `[signer]` Admin (must equal pool.admin — the stake-side gate)
@@ -114,15 +114,15 @@ pub enum StakeInstruction {
     /// 21: BurnAssetAdmin — irrevocably remove the admin's rotate-back capability.
     /// Calls UpdateAssetAuthority(kind=0, new_pubkey=[0;32]) to burn asset_admin to
     /// zero. After this, no key can rotate any per-asset authority (insurance,
-    /// operator, backing, oracle) back to an admin-controlled key. Only the current
-    /// holder of each authority can self-rotate it.
+    /// operator, backing, oracle) back to an admin-controlled key through stake.
+    /// Stake also records the burn and disables its PDA-signed rotate escapes.
     ///
     /// IRREVERSIBLE. Only call this after BindInsuranceAuthority has completed.
     /// Must NOT be called again if asset_admin is already zero (causes Unauthorized).
     ///
     /// Accounts:
     ///   0. `[signer]` Admin (current asset_admin == pool.admin)
-    ///   1. `[]` Pool PDA
+    ///   1. `[writable]` Pool PDA
     ///   2. `[]` Vault authority PDA (placeholder new_authority slot — not checked for burn)
     ///   3. `[writable]` Slab / market account (wrapper-owned)
     ///   4. `[]` Percolator program
@@ -133,11 +133,11 @@ pub enum StakeInstruction {
     /// kind=2 (ASSET_AUTH_INSURANCE_OPERATOR). The vault_auth PDA signs as the
     /// CURRENT operator (invoke_signed); new_target co-signs the outer tx.
     ///
-    /// Part of the full no-lockout migration sequence:
+    /// Part of the full no-lockout migration sequence, before final burn:
     ///   1. RotateInsuranceAuthority (tag 20): authority PDA → admin wallet
     ///   2. RotateInsuranceOperator  (tag 22): operator  PDA → admin wallet
     ///   3. Re-bind from NEW program (BindInsuranceAuthority, tag 19)
-    ///   4. BurnAssetAdmin (tag 21) — only if not already burned
+    ///   4. BurnAssetAdmin (tag 21) when the new bind is final
     ///
     /// Accounts:
     ///   0. `[signer]` Admin (must equal pool.admin — the stake-side gate)

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1531,11 +1531,9 @@ fn process_accept_admin(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
 /// BindInsuranceAuthority + BurnAssetAdmin form the COMPLETE secure-bind sequence.
 ///
 /// NOTE: the two CPIs are split from the admin-burn because BurnAssetAdmin is
-/// irreversible and only needed once per market. On a re-bind after a redeploy
-/// (RotateInsuranceAuthority + RotateInsuranceOperator back to admin, then re-bind
-/// from the new program), the admin burn is already done — calling BurnAssetAdmin
-/// again would fail (asset_admin already zero). Two separate instructions avoids
-/// that footgun while preserving atomicity of the authority moves.
+/// irreversible and only needed once per market. On a redeploy, rotate authority
+/// and operator back to admin first, bind from the new program, and only then call
+/// BurnAssetAdmin when the new bind is final.
 fn process_bind_insurance_authority(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -1632,13 +1630,14 @@ fn process_bind_insurance_authority(
 ///
 /// This is the FINAL HARDENING step of the secure-bind sequence:
 ///   1. BindInsuranceAuthority — moves authority + operator to PDA
-///   2. BurnAssetAdmin         — burns the admin's rotate-back escape hatch
+///   2. BurnAssetAdmin         — burns the admin's rotate-back escape hatch and
+///      records the finality in stake state
 ///
 /// After BurnAssetAdmin:
 ///   - asset_admin == [0;32] (no key can rotate per-asset authorities for this asset)
 ///   - Only the current holder of each authority can self-rotate it
-///   - The PDA (vault_auth) is permanently the insurance_authority and insurance_operator
-///     until a RotateInsuranceAuthority / RotateInsuranceOperator escape is exercised
+///   - The PDA (vault_auth) stays the insurance_authority and insurance_operator
+///     unless rotation happened before the burn
 ///
 /// IRREVERSIBILITY: asset_admin [0;32] can never be restored. This is intentional.
 /// Once burned, the secure state is locked. Only call this when committed.
@@ -1649,7 +1648,7 @@ fn process_bind_insurance_authority(
 ///
 /// Accounts:
 ///   0. `[signer, writable]` Admin (current asset_admin == pool.admin)
-///   1. `[]` Pool PDA (read, validates admin)
+///   1. `[writable]` Pool PDA (records that asset_admin has been burned)
 ///   2. `[]` Vault authority PDA (placeholder new_authority slot — not checked for burn)
 ///   3. `[writable]` Slab / market account (wrapper-owned)
 ///   4. `[]` Percolator program
@@ -1668,6 +1667,7 @@ fn process_burn_asset_admin(
         return Err(ProgramError::MissingRequiredSignature);
     }
 
+    validate_account_writable(pool_pda)?;
     validate_account_owner(pool_pda, program_id)?;
     validate_account_not_empty(pool_pda)?;
 
@@ -1682,6 +1682,10 @@ fn process_burn_asset_admin(
         }
         validate_pool_version(pool)?;
         if pool.admin != admin.key.to_bytes() {
+            return Err(StakeError::Unauthorized.into());
+        }
+        if pool.asset_admin_burned() {
+            msg!("BurnAssetAdmin: asset_admin already burned for this pool");
             return Err(StakeError::Unauthorized.into());
         }
         (pool.slab, pool.percolator_program)
@@ -1710,7 +1714,13 @@ fn process_burn_asset_admin(
         slab,       // market
     )?;
 
-    msg!("BurnAssetAdmin: asset_admin burned to zero — admin's rotate-back capability permanently removed");
+    {
+        let mut pool_data = pool_pda.try_borrow_mut_data()?;
+        let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+        pool.set_asset_admin_burned(true);
+    }
+
+    msg!("BurnAssetAdmin: asset_admin burned to zero — stake rotate-back escape permanently disabled");
     Ok(())
 }
 
@@ -1729,7 +1739,7 @@ fn process_burn_asset_admin(
 ///   1. RotateInsuranceAuthority (tag 20): insurance_authority PDA_A → admin wallet
 ///   2. RotateInsuranceOperator  (tag 22): insurance_operator  PDA_A → admin wallet
 ///   3. Re-bind from NEW program: BindInsuranceAuthority (tags 19) binds both to PDA_B
-///   4. BurnAssetAdmin only if not already burned (idempotent guard applies)
+///   4. BurnAssetAdmin once the new bind is final
 ///
 /// Accounts:
 ///   0. `[signer]` Admin (must equal pool.admin — the stake-side gate)
@@ -1774,6 +1784,10 @@ fn process_rotate_insurance_operator(
         if pool.admin != admin.key.to_bytes() {
             return Err(StakeError::Unauthorized.into());
         }
+        if pool.asset_admin_burned() {
+            msg!("RotateInsuranceOperator: asset_admin burn is final; rotate-back is disabled");
+            return Err(StakeError::Unauthorized.into());
+        }
         (pool.slab, pool.percolator_program)
     };
 
@@ -1813,8 +1827,8 @@ fn process_rotate_insurance_operator(
 /// `new_target` co-signing the outer tx as the NEW authority. The escape from the
 /// otherwise-permanent bind (a stake redeploy must rotate to the admin wallet from
 /// the old program before decommissioning, then re-bind from the new program).
-/// Only succeeds while the PDA is the current authority (i.e. after a bind);
-/// otherwise the wrapper rejects with Unauthorized.
+/// Only succeeds before BurnAssetAdmin has completed and while the PDA is the
+/// current authority; otherwise stake or the wrapper rejects with Unauthorized.
 fn process_rotate_insurance_authority(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -1851,6 +1865,10 @@ fn process_rotate_insurance_authority(
         validate_pool_version(pool)?;
         // Admin-gated: only the pool admin may rotate the insurance authority.
         if pool.admin != admin.key.to_bytes() {
+            return Err(StakeError::Unauthorized.into());
+        }
+        if pool.asset_admin_burned() {
+            msg!("RotateInsuranceAuthority: asset_admin burn is final; rotate-back is disabled");
             return Err(StakeError::Unauthorized.into());
         }
         (pool.slab, pool.percolator_program)

--- a/src/state.rs
+++ b/src/state.rs
@@ -214,7 +214,9 @@ impl StakePool {
     //   [33..41] = junior_balance: u64 (LE)
     //   [41..49] = junior_total_lp: u64 (LE)
     //   [49..51] = junior_fee_mult_bps: u16 (LE, default 20000 = 2x)
-    //   [51..64] = free
+    //   [51..59] = realized_junior_loss: u64 (LE)
+    //   [59]     = asset_admin_burned (0=false, 1=true)
+    //   [60..64] = free
     // ════════════════════════════════════════════════════════════
 
     /// Whether the market has been resolved (blocks new deposits).
@@ -306,6 +308,19 @@ impl StakePool {
         self._reserved[51..59].copy_from_slice(&val.to_le_bytes());
     }
 
+    /// Whether BurnAssetAdmin has completed for this pool's market.
+    ///
+    /// Once true, stake-side rotate escapes stay disabled so the wrapper roles
+    /// cannot be moved back to an admin-controlled key after the final burn.
+    pub fn asset_admin_burned(&self) -> bool {
+        self._reserved[59] == 1
+    }
+
+    /// Set the BurnAssetAdmin completion flag. Stored at `_reserved[59]`.
+    pub fn set_asset_admin_burned(&mut self, burned: bool) {
+        self._reserved[59] = if burned { 1 } else { 0 };
+    }
+
     /// Loss-adjusted junior tranche balance.
     ///
     /// `junior_balance()` (stored) grows monotonically with deposits and withdrawals
@@ -389,7 +404,8 @@ impl StakePool {
     // Bytes 13-15: reserved padding
     // Bytes 16-23: epoch_high_water_tvl (u64 LE)
     // Bytes 24-31: hwm_last_epoch (u64 LE)
-    // Bytes 32-63: used by PERC-303 tranche state (see layout above)
+    // Bytes 32-63: used by PERC-303 tranche state + asset_admin_burned
+    //              (see layout above)
     //
     // CRITICAL: hwm_enabled was previously at byte 9 — the same byte used by
     // market_resolved (PERC-303).  That collision meant enabling HWM caused the
@@ -925,6 +941,28 @@ mod tests {
         pool.set_hwm_enabled(true);
         assert_eq!(pool._reserved[9], 0, "byte 9 should be untouched");
         assert_eq!(pool._reserved[10], 1, "hwm_enabled should be at byte 10");
+    }
+
+    #[test]
+    fn test_asset_admin_burned_flag_uses_reserved_byte_59() {
+        let mut pool = StakePool::zeroed();
+        assert!(!pool.asset_admin_burned());
+
+        pool.set_realized_junior_loss(0x0102_0304_0506_0708);
+        pool.set_asset_admin_burned(true);
+
+        assert!(pool.asset_admin_burned());
+        assert_eq!(pool._reserved[59], 1, "asset_admin_burned should be byte 59");
+        assert_eq!(
+            pool.realized_junior_loss(),
+            0x0102_0304_0506_0708,
+            "asset_admin_burned must not clobber realized_junior_loss"
+        );
+
+        pool.set_asset_admin_burned(false);
+        assert!(!pool.asset_admin_burned());
+        assert_eq!(pool._reserved[59], 0);
+        assert_eq!(pool.realized_junior_loss(), 0x0102_0304_0506_0708);
     }
 
     #[test]

--- a/tests/v17_stake_insurance_e2e.rs
+++ b/tests/v17_stake_insurance_e2e.rs
@@ -8,9 +8,10 @@
 //!    RED before bind (wrapper rejects, auth not set yet).
 //!    GREEN after bind + wrapper D-STAKE-1 guard fires on the drain attempt.
 //!
-//! 2. no-lockout: the full migration round-trip works:
-//!    bind (old program) -> flush -> rotate to admin -> re-bind (new program) -> flush.
-//!    The bind is NOT a permanent weld — the PDA can always recover custody.
+//! 2. no-lockout-before-burn: the full migration round-trip works before the
+//!    final burn:
+//!    bind (old program) -> flush -> rotate to admin -> re-bind (new program)
+//!    -> burn -> flush. The bind can recover custody until BurnAssetAdmin seals it.
 //!
 //! Wire: [65u8][0x00 0x00][0x01][pubkey:32] = 36 bytes (tag 65, asset_index=0,
 //! kind=ASSET_AUTH_INSURANCE=1). Verified at byte level by cpi_tags.rs tests.
@@ -28,6 +29,7 @@
 
 use bytemuck::Zeroable;
 use litesvm::LiteSVM;
+use percolator_stake::error::StakeError;
 use percolator_stake::state::{
     derive_pool_pda, derive_vault_authority, StakePool, STAKE_POOL_SIZE,
 };
@@ -419,7 +421,7 @@ fn withdraw_insurance_asset_ix(args: WithdrawInsuranceArgs) -> Instruction {
 }
 
 /// BurnAssetAdmin (stake tag 21): burns asset_admin to zero via stake CPI.
-/// Accounts: [admin(signer), pool_pda, vault_auth, slab(w), percolator_program]
+/// Accounts: [admin(signer), pool_pda(w), vault_auth, slab(w), percolator_program]
 fn burn_asset_admin_ix(
     ctx: &PoolCtx,
     wrapper_id: Pubkey,
@@ -430,7 +432,7 @@ fn burn_asset_admin_ix(
         program_id: ctx.stake_id,
         accounts: vec![
             AccountMeta::new(*admin, true),
-            AccountMeta::new_readonly(ctx.pool_pda, false),
+            AccountMeta::new(ctx.pool_pda, false),
             AccountMeta::new_readonly(ctx.vault_auth, false),
             AccountMeta::new(market, false),
             AccountMeta::new_readonly(wrapper_id, false),
@@ -646,10 +648,11 @@ fn flush_applies_insurance_after_bind_v17() {
 //   D-STAKE-1 does NOT block path (a) — it only overrides admin_shutdown_authorized.
 //   Result: admin drains insurance even after the bind.
 //
-// THE FIX (secure bind sequence — all three CPIs in one BindInsuranceAuthority tx):
+// THE FIX (secure bind sequence):
 //   CPI 1: insurance_authority (kind=1) → vault_auth PDA (gates FlushToInsurance)
 //   CPI 2: insurance_operator  (kind=2) → vault_auth PDA (blocks path (a))
-//   CPI 3: asset_admin         (kind=0) → [0;32] burn  (blocks rotating op back)
+//   CPI 3: asset_admin         (kind=0) → [0;32] burn  (finalizes the bind and
+//          disables stake's rotate-back escape)
 //
 // OPERATIVE TEST STRUCTURE (non-hollow, no pre-arrangement of secure state):
 //
@@ -657,7 +660,7 @@ fn flush_applies_insurance_after_bind_v17() {
 //   (operator still admin). Admin calls tag-57 → drain SUCCEEDS. This proves the
 //   test bites — without the operator move, the drain works.
 //
-//   GREEN AFTER FULL SECURE BIND: fresh market; full 3-CPI bind issued. Admin calls
+//   GREEN AFTER FULL SECURE BIND: fresh market; bind + burn issued. Admin calls
 //   tag-57 WITHOUT any pre-rotation — drain FAILS (Custom(8) Unauthorized) because
 //   insurance_operator is the PDA (not admin) → local_authorized=false, AND
 //   admin_shutdown_authorized is blocked by asset_index==0 AND D-STAKE-1.
@@ -668,10 +671,9 @@ fn flush_applies_insurance_after_bind_v17() {
 // before the drain attempt (v16_stake_insurance_e2e.rs Phase C), masking the gap
 // in the same way. The gap was present but untested in v16.
 //
-// WIRE NOTE: after the secure bind, asset_admin is burned to [0;32]. The
-// no-lockout RotateInsuranceAuthority (tag 20) remains valid — it signs as the
-// PDA (vault_auth) as the CURRENT insurance_authority, not as asset_admin.
-// So the migration escape is not broken by the burn.
+// WIRE NOTE: after the secure bind, asset_admin is burned to [0;32]. The final
+// burn also sets stake-side state that disables its PDA-signed rotate escapes,
+// so migrations must rotate and re-bind before this step.
 
 /// RED CONTROL: bind insurance_authority ONLY (using a direct tag-65 CPI that
 /// does NOT move the operator or burn asset_admin). Admin still holds operator.
@@ -689,7 +691,7 @@ fn flush_applies_insurance_after_bind_v17() {
 /// Test plan:
 ///   1. Fresh market, no bind at all. Admin has insurance_operator = admin.
 ///      Admin calls tag-57 → drain SUCCEEDS (local_authorized=true). [RED]
-///   2. Second fresh market, full secure bind (3-CPI). Admin calls tag-57 WITHOUT
+///   2. Second fresh market, full secure bind + burn. Admin calls tag-57 WITHOUT
 ///      pre-rotating anything → drain FAILS (Custom(8)). [GREEN]
 #[test]
 fn no_admin_drain_before_and_after_bind() {
@@ -894,6 +896,117 @@ fn no_admin_drain_before_and_after_bind() {
     );
 }
 
+/// Regression for the final secure-bind boundary:
+/// after BurnAssetAdmin succeeds, stake must not use its PDA signer to rotate
+/// insurance_authority or insurance_operator back to the admin wallet.
+///
+/// On the vulnerable implementation, both rotate instructions below succeed
+/// after the burn. Once authority+operator are admin again, the admin can call
+/// wrapper tag 57 (`WithdrawInsuranceAsset`) and drain the flushed insurance via
+/// the local-authorized path. The fixed implementation rejects the first rotate
+/// in stake with StakeError::Unauthorized.
+#[test]
+fn secure_bind_burn_blocks_rotate_back_to_admin() {
+    let mut svm = LiteSVM::new().with_spl_programs();
+    let stake_id = Pubkey::from_str(STAKE_ID).unwrap();
+    let wrapper_id = Pubkey::from_str(WRAPPER_MAINNET).unwrap();
+    let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
+    svm.add_program_from_file(stake_id, stake_so()).unwrap();
+    svm.add_program_from_file(wrapper_id, wrapper_so()).unwrap();
+
+    let admin = Keypair::new();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 100_000_000_000).unwrap();
+    svm.airdrop(&admin.pubkey(), 10_000_000_000).unwrap();
+
+    let (market, mint, wrapper_vault) =
+        build_live_market_v17(&mut svm, wrapper_id, token_program, &admin, &payer);
+    let pool = add_stake_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        mint,
+        &admin.pubkey(),
+        FLUSH_AMOUNT,
+    );
+
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        bind_ix(&pool, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("bind authority+operator to PDA");
+
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        burn_asset_admin_ix(&pool, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("burn asset_admin and seal stake rotate escapes");
+
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        flush_ix(
+            &pool,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            &admin.pubkey(),
+            FLUSH_AMOUNT,
+        ),
+    )
+    .expect("flush insurance into wrapper vault");
+    assert_eq!(token_amount(&svm, &wrapper_vault), FLUSH_AMOUNT);
+
+    svm.expire_blockhash();
+    let err = send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        rotate_ix(&pool, wrapper_id, market, &admin.pubkey(), &admin.pubkey()),
+    )
+    .expect_err("post-burn rotate-back must be rejected by stake");
+    assert!(
+        matches!(
+            err,
+            TransactionError::InstructionError(_, InstructionError::Custom(code))
+                if code == StakeError::Unauthorized as u32
+        ),
+        "expected stake Unauthorized=2, got {err:?}"
+    );
+
+    svm.expire_blockhash();
+    let err = send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        rotate_operator_stake_ix(&pool, wrapper_id, market, &admin.pubkey(), &admin.pubkey()),
+    )
+    .expect_err("post-burn operator rotate-back must be rejected by stake");
+    assert!(
+        matches!(
+            err,
+            TransactionError::InstructionError(_, InstructionError::Custom(code))
+                if code == StakeError::Unauthorized as u32
+        ),
+        "expected stake Unauthorized=2, got {err:?}"
+    );
+
+    assert_eq!(
+        token_amount(&svm, &wrapper_vault),
+        FLUSH_AMOUNT,
+        "post-burn rotate attempts did not move funds"
+    );
+}
+
 /// No-admin-drain: a third-party attacker (not admin, not insurance_operator) also
 /// cannot drain. This is an independent check from the admin case above.
 #[test]
@@ -994,20 +1107,18 @@ fn no_attacker_drain_after_bind() {
 
 // ── NO-LOCKOUT ─────────────────────────────────────────────────────────────────
 //
-// The secure bind is NOT a permanent weld. Full migration round-trip (v17):
-//   1. OLD program: BindInsuranceAuthority (CPI 1+2) + BurnAssetAdmin (CPI 3)
-//      + flush (works)
+// The secure bind allows migration until the final burn. Full migration round-trip (v17):
+//   1. OLD program: BindInsuranceAuthority (CPI 1+2) + flush (works)
 //   2. ROTATE: RotateInsuranceAuthority (tag 20) + RotateInsuranceOperator (tag 22)
 //      → both to admin wallet. Old PDA is now no longer the authority or operator.
 //   3. OLD program flush now REJECTED (PDA no longer the insurance_authority)
 //   4. NEW program: BindInsuranceAuthority (CPI 1+2) — re-binds authority+operator
-//      to new vault_auth_B PDA. BurnAssetAdmin NOT called again (already burned).
-//   5. flush B works.
+//      to new vault_auth_B PDA.
+//   5. BurnAssetAdmin (CPI 3) once the new bind is final.
+//   6. flush B works.
 //
-// The asset_admin burn is a ONCE-per-market operation. After the burn, re-binding
-// from a new program still works because BindInsuranceAuthority only uses CPI 1+2
-// (not CPI 3). The admin IS the current authority+operator after the rotation, so
-// both CPIs succeed.
+// The asset_admin burn is a ONCE-per-market operation and disables stake's
+// PDA-signed rotate escape. Redeploy migrations must rotate before this final step.
 //
 // This proves the no-lockout guarantee holds under the v17 tag-65 wire.
 
@@ -1050,16 +1161,6 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
     )
     .expect("bind A (old program): authority+operator → PDA_A");
 
-    // Step 1b: BurnAssetAdmin — burns asset_admin to zero (once per market).
-    svm.expire_blockhash();
-    send(
-        &mut svm,
-        &payer,
-        &[&admin],
-        burn_asset_admin_ix(&pool_a, wrapper_id, market, &admin.pubkey()),
-    )
-    .expect("burn asset_admin (once per market)");
-
     // Locate insurance_authority in market data to track it across rotations.
     // After bind, insurance_authority == vault_auth_A. We find its offset.
     // Note: insurance_operator is also vault_auth_A — find_pubkey_offset returns
@@ -1088,7 +1189,8 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
     .expect("flush A");
     assert_eq!(token_amount(&svm, &wrapper_vault), 40_000, "flush A applied");
 
-    // Step 2a: ROTATE insurance_authority off PDA_A to the admin wallet (tag 20).
+    // Step 2a: ROTATE insurance_authority off PDA_A to the admin wallet (tag 20)
+    // before the final asset_admin burn.
     // The PDA signs as current insurance_authority; admin co-signs as new target.
     svm.expire_blockhash();
     send(
@@ -1105,7 +1207,8 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
     )
     .expect("rotate insurance_authority: PDA_A → admin wallet");
 
-    // Step 2b: ROTATE insurance_operator off PDA_A to the admin wallet (tag 22).
+    // Step 2b: ROTATE insurance_operator off PDA_A to the admin wallet (tag 22)
+    // before the final asset_admin burn.
     // The PDA signs as current operator; admin co-signs as new target.
     svm.expire_blockhash();
     send(
@@ -1148,7 +1251,7 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
 
     // Step 4: NEW program re-bind. Admin is the current insurance_authority AND
     // insurance_operator (from the rotation in step 2a+2b). BindInsuranceAuthority
-    // issues CPI 1+2 to move both to PDA_B. No BurnAssetAdmin (already burned).
+    // issues CPI 1+2 to move both to PDA_B.
     svm.expire_blockhash();
     let pool_b = add_stake_pool(
         &mut svm,
@@ -1179,7 +1282,41 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
         "insurance_authority re-bound to NEW PDA_B"
     );
 
-    // Step 5: flush B works (PDA_B is the insurance_authority).
+    // Step 5: final burn. After this, stake refuses to rotate authority/operator
+    // back to admin through PDA_B.
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        burn_asset_admin_ix(&pool_b, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("burn asset_admin after final re-bind");
+
+    svm.expire_blockhash();
+    let err_after_burn = send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        rotate_ix(
+            &pool_b,
+            wrapper_id,
+            market,
+            &admin.pubkey(),
+            &admin.pubkey(),
+        ),
+    )
+    .expect_err("post-burn rotate from new program must reject");
+    assert!(
+        matches!(
+            err_after_burn,
+            TransactionError::InstructionError(_, InstructionError::Custom(code))
+                if code == StakeError::Unauthorized as u32
+        ),
+        "expected stake Unauthorized=2 after final burn, got {err_after_burn:?}"
+    );
+
+    // Step 6: flush B works (PDA_B is still the insurance_authority).
     svm.expire_blockhash();
     send(
         &mut svm,


### PR DESCRIPTION
## Summary

Fixes #203.

`BurnAssetAdmin` is documented as the final secure-bind step, but stake previously did not record that the burn had completed. Because `RotateInsuranceAuthority` and `RotateInsuranceOperator` sign as the current `vault_auth` PDA, a pool admin could still call both rotations after the burn and move wrapper authority/operator back to the admin wallet.

This PR records a stake-side `asset_admin_burned` finality bit after the wrapper burn CPI succeeds, then rejects both stake rotate escapes once that bit is set.

## Changes

- Stores `asset_admin_burned` in free `StakePool._reserved[59]` without changing `STAKE_POOL_SIZE`.
- Requires the pool PDA to be writable for `BurnAssetAdmin` and sets the finality bit only after successful wrapper CPI.
- Rejects both `RotateInsuranceAuthority` and `RotateInsuranceOperator` with `StakeError::Unauthorized` after final burn.
- Updates v17 migration semantics so redeploy rotation happens before final burn.
- Adds `secure_bind_burn_blocks_rotate_back_to_admin` e2e regression for the post-burn rotate-back path.

## Validation

```bash
cargo build-sbf --no-default-features
cargo test --test v17_stake_insurance_e2e secure_bind_burn_blocks_rotate_back_to_admin -- --nocapture
cargo test --test v17_stake_insurance_e2e no_lockout_rotate_then_rebind_from_new_program_v17 -- --nocapture
cargo test --all
```

All passed locally. `cargo fmt -- --check` could not run because `cargo-fmt` is not installed in the local stable toolchain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Hardened the asset admin burn security process with enhanced validation and permanent lockdown of authority rotation after burn completion.

* **Documentation**
  * Clarified the secure bind and burn sequence to reflect proper ordering and finalization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->