### PR TITLE
fix(stake): route account deserialization through length-checked bytemuck helpers (#199)

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -192,6 +192,52 @@ use crate::state::{
     self, derive_vault_authority, StakeDeposit, StakePool, STAKE_DEPOSIT_SIZE, STAKE_POOL_SIZE,
 };
 
+// ─────────────────────────────────────────────────────────────────────────
+// #199: length-checked bytemuck reinterpretation helpers.
+//
+// Every handler reinterprets an account's data as a StakePool / StakeDeposit by
+// slicing `data[..SIZE]`. A program-owned but undersized account (e.g. an
+// attacker's own StakeDeposit PDA, which is STAKE_DEPOSIT_SIZE < STAKE_POOL_SIZE,
+// passed where a pool is expected) makes that bare slice PANIC instead of
+// returning a clean ProgramError. These helpers centralize the `len() >= SIZE`
+// guard so it can never be forgotten at a call site, and use `try_from_bytes` so
+// they are also alignment-safe (never panic). Each takes the ALREADY-BORROWED
+// slice (from `try_borrow_mut_data()` / `try_borrow_data()`), so the RefMut/Ref
+// guard stays at the call site and the returned reference borrows that slice for
+// the same scope — identical codegen to the previous inline form on the happy
+// path, with an added early Err for short/misaligned data.
+fn pool_from_data_mut(data: &mut [u8]) -> Result<&mut StakePool, ProgramError> {
+    if data.len() < STAKE_POOL_SIZE {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    bytemuck::try_from_bytes_mut::<StakePool>(&mut data[..STAKE_POOL_SIZE])
+        .map_err(|_| ProgramError::InvalidAccountData)
+}
+
+fn pool_from_data(data: &[u8]) -> Result<&StakePool, ProgramError> {
+    if data.len() < STAKE_POOL_SIZE {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    bytemuck::try_from_bytes::<StakePool>(&data[..STAKE_POOL_SIZE])
+        .map_err(|_| ProgramError::InvalidAccountData)
+}
+
+fn deposit_from_data_mut(data: &mut [u8]) -> Result<&mut StakeDeposit, ProgramError> {
+    if data.len() < STAKE_DEPOSIT_SIZE {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    bytemuck::try_from_bytes_mut::<StakeDeposit>(&mut data[..STAKE_DEPOSIT_SIZE])
+        .map_err(|_| ProgramError::InvalidAccountData)
+}
+
+fn deposit_from_data(data: &[u8]) -> Result<&StakeDeposit, ProgramError> {
+    if data.len() < STAKE_DEPOSIT_SIZE {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    bytemuck::try_from_bytes::<StakeDeposit>(&data[..STAKE_DEPOSIT_SIZE])
+        .map_err(|_| ProgramError::InvalidAccountData)
+}
+
 pub fn process(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -409,7 +455,7 @@ fn process_init_pool(
 
     // Write pool state
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     pool.is_initialized = 1;
     pool.bump = pool_bump;
@@ -486,7 +532,7 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
 
     // Read and validate pool state
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -741,8 +787,7 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
     }
 
     let mut deposit_data = deposit_pda.try_borrow_mut_data()?;
-    let deposit: &mut StakeDeposit =
-        bytemuck::from_bytes_mut(&mut deposit_data[..STAKE_DEPOSIT_SIZE]);
+    let deposit = deposit_from_data_mut(&mut deposit_data[..])?;
 
     if deposit.is_initialized != 1 {
         deposit.set_discriminator();
@@ -817,7 +862,7 @@ fn process_withdraw(
     validate_account_writable(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -916,7 +961,7 @@ fn process_withdraw(
     let is_junior;
     {
         let deposit_data_ref = deposit_pda.try_borrow_data()?;
-        let deposit: &StakeDeposit = bytemuck::from_bytes(&deposit_data_ref[..STAKE_DEPOSIT_SIZE]);
+        let deposit = deposit_from_data(&deposit_data_ref[..])?;
 
         if deposit.is_initialized != 1
             || deposit.user != user.key.to_bytes()
@@ -1146,8 +1191,7 @@ fn process_withdraw(
 
     // Update deposit PDA
     let mut deposit_data_mut = deposit_pda.try_borrow_mut_data()?;
-    let deposit_mut: &mut StakeDeposit =
-        bytemuck::from_bytes_mut(&mut deposit_data_mut[..STAKE_DEPOSIT_SIZE]);
+    let deposit_mut = deposit_from_data_mut(&mut deposit_data_mut[..])?;
     deposit_mut.lp_amount = deposit_mut
         .lp_amount
         .checked_sub(lp_amount)
@@ -1225,7 +1269,7 @@ fn process_flush_to_insurance(
 
     // Read pool
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -1382,7 +1426,7 @@ fn process_update_config(
     validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -1439,7 +1483,7 @@ fn process_propose_admin(
     validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -1483,7 +1527,7 @@ fn process_accept_admin(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -1559,7 +1603,7 @@ fn process_bind_insurance_authority(
     // fields we need so the borrow is released before the CPIs.
     let (pool_slab, pool_percolator) = {
         let pool_data = pool_pda.try_borrow_data()?;
-        let pool: &StakePool = bytemuck::from_bytes(&pool_data[..STAKE_POOL_SIZE]);
+        let pool = pool_from_data(&pool_data[..])?;
         if pool.is_initialized != 1 {
             return Err(StakeError::NotInitialized.into());
         }
@@ -1673,7 +1717,7 @@ fn process_burn_asset_admin(
 
     let (pool_slab, pool_percolator) = {
         let pool_data = pool_pda.try_borrow_data()?;
-        let pool: &StakePool = bytemuck::from_bytes(&pool_data[..STAKE_POOL_SIZE]);
+        let pool = pool_from_data(&pool_data[..])?;
         if pool.is_initialized != 1 {
             return Err(StakeError::NotInitialized.into());
         }
@@ -1763,7 +1807,7 @@ fn process_rotate_insurance_operator(
 
     let (pool_slab, pool_percolator) = {
         let pool_data = pool_pda.try_borrow_data()?;
-        let pool: &StakePool = bytemuck::from_bytes(&pool_data[..STAKE_POOL_SIZE]);
+        let pool = pool_from_data(&pool_data[..])?;
         if pool.is_initialized != 1 {
             return Err(StakeError::NotInitialized.into());
         }
@@ -1841,7 +1885,7 @@ fn process_rotate_insurance_authority(
 
     let (pool_slab, pool_percolator) = {
         let pool_data = pool_pda.try_borrow_data()?;
-        let pool: &StakePool = bytemuck::from_bytes(&pool_data[..STAKE_POOL_SIZE]);
+        let pool = pool_from_data(&pool_data[..])?;
         if pool.is_initialized != 1 {
             return Err(StakeError::NotInitialized.into());
         }
@@ -2005,8 +2049,7 @@ fn process_accrue_fees(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
 
     // Validate pool PDA
     let mut pool_data = pool_ai.try_borrow_mut_data()?;
-    let pool = bytemuck::try_from_bytes_mut::<state::StakePool>(&mut pool_data[..STAKE_POOL_SIZE])
-        .map_err(|_| ProgramError::InvalidAccountData)?;
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -2104,7 +2147,7 @@ fn process_admin_set_hwm_config(
     }
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -2169,7 +2212,7 @@ fn process_admin_set_tranche_config(
     validate_account_not_empty(pool_ai)?;
 
     let mut pool_data = pool_ai.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -2266,7 +2309,7 @@ fn process_deposit_junior(
     validate_account_writable(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -2484,8 +2527,7 @@ fn process_deposit_junior(
     }
 
     let mut deposit_data = deposit_pda.try_borrow_mut_data()?;
-    let deposit: &mut StakeDeposit =
-        bytemuck::from_bytes_mut(&mut deposit_data[..STAKE_DEPOSIT_SIZE]);
+    let deposit = deposit_from_data_mut(&mut deposit_data[..])?;
 
     if deposit.is_initialized != 1 {
         deposit.set_discriminator();
@@ -2540,8 +2582,7 @@ fn process_init_trading_pool(
     let pool_ai = &accounts[INIT_POOL_POOL_PDA_INDEX];
     validate_account_owner(pool_ai, program_id)?;
     let mut pool_data = pool_ai.try_borrow_mut_data()?;
-    let pool = bytemuck::try_from_bytes_mut::<state::StakePool>(&mut pool_data[..STAKE_POOL_SIZE])
-        .map_err(|_| ProgramError::InvalidAccountData)?;
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
     if !pool.validate_discriminator() {
         return Err(StakeError::InvalidAccount.into());
     }
@@ -2579,10 +2620,7 @@ fn process_return_insurance(
     validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    if pool_data.len() < STAKE_POOL_SIZE {
-        return Err(StakeError::InvalidAccount.into());
-    }
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -2670,10 +2708,7 @@ fn process_set_market_resolved(program_id: &Pubkey, accounts: &[AccountInfo]) ->
     validate_account_not_empty(pool_pda)?;
 
     let mut pool_data = pool_pda.try_borrow_mut_data()?;
-    if pool_data.len() < STAKE_POOL_SIZE {
-        return Err(StakeError::InvalidAccount.into());
-    }
-    let pool: &mut StakePool = bytemuck::from_bytes_mut(&mut pool_data[..STAKE_POOL_SIZE]);
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
 
     if pool.is_initialized != 1 {
         return Err(StakeError::NotInitialized.into());
@@ -2746,5 +2781,56 @@ mod tests {
         apply_hwm_config(&mut pool, true, 9000);
         assert!(pool.hwm_enabled());
         assert_eq!(pool.hwm_floor_bps(), 9000);
+    }
+
+    // ── #199: length-checked bytemuck reinterpretation helpers ──
+    //
+    // Every handler reinterprets account data via these helpers. They must return a
+    // clean ProgramError on an undersized/zero-length buffer instead of panicking on
+    // the `[..SIZE]` slice (the #199 bug), and must succeed on a correctly-sized buffer.
+    // The attack shape: a StakeDeposit-sized buffer (STAKE_DEPOSIT_SIZE < STAKE_POOL_SIZE)
+    // passed where a pool is expected.
+
+    #[test]
+    fn test_pool_helpers_reject_undersized_without_panic() {
+        assert!(STAKE_DEPOSIT_SIZE < STAKE_POOL_SIZE, "deposit-sized buffer is a valid undersize");
+        let mut deposit_sized = vec![0u8; STAKE_DEPOSIT_SIZE];
+        assert!(pool_from_data_mut(&mut deposit_sized).is_err(), "mut: undersized -> Err, not panic");
+        assert!(pool_from_data(&deposit_sized).is_err(), "ro: undersized -> Err, not panic");
+
+        let mut one_short = vec![0u8; STAKE_POOL_SIZE - 1];
+        assert!(pool_from_data_mut(&mut one_short).is_err());
+        assert!(pool_from_data(&one_short).is_err());
+
+        let mut empty: Vec<u8> = Vec::new();
+        assert!(pool_from_data_mut(&mut empty).is_err());
+        assert!(pool_from_data(&empty).is_err());
+    }
+
+    #[test]
+    fn test_pool_helpers_accept_exact_and_oversized() {
+        let mut buf = vec![0u8; STAKE_POOL_SIZE];
+        let pool = pool_from_data_mut(&mut buf).expect("exact-size buffer must be Ok (mut)");
+        assert_eq!(pool.is_initialized, 0);
+        assert!(pool_from_data(&buf).is_ok(), "exact-size buffer must be Ok (ro)");
+        // Real Solana accounts may carry trailing bytes; only the first SIZE are read.
+        let mut over = vec![0u8; STAKE_POOL_SIZE + 32];
+        assert!(pool_from_data_mut(&mut over).is_ok(), "oversized buffer must be Ok");
+    }
+
+    #[test]
+    fn test_deposit_helpers_reject_undersized_without_panic() {
+        let mut short = vec![0u8; STAKE_DEPOSIT_SIZE - 1];
+        assert!(deposit_from_data_mut(&mut short).is_err());
+        assert!(deposit_from_data(&short).is_err());
+        let empty: Vec<u8> = Vec::new();
+        assert!(deposit_from_data(&empty).is_err());
+    }
+
+    #[test]
+    fn test_deposit_helpers_accept_exact_size() {
+        let mut buf = vec![0u8; STAKE_DEPOSIT_SIZE];
+        assert!(deposit_from_data_mut(&mut buf).is_ok());
+        assert!(deposit_from_data(&buf).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Routes every account deserialization through length-checked, alignment-safe `bytemuck` helpers so an undersized account can no longer panic the program. Fixes #199.

Most handlers reinterpreted account data with a bare `bytemuck::from_bytes[_mut](&mut data[..STAKE_POOL_SIZE])` (resp. `STAKE_DEPOSIT_SIZE`) with no preceding length check. A program-owned but undersized account — e.g. an attacker's own `StakeDeposit` PDA (`STAKE_DEPOSIT_SIZE` < `STAKE_POOL_SIZE`) passed where a pool is expected — passes the owner/non-empty checks, then the `[..SIZE]` slice is out of bounds and the program **panics** (opaque `ProgramFailedToComplete`) instead of returning a clean error. Only `ReturnInsurance`, `SetMarketResolved`, and the `process_withdraw` deposit read were guarded. The `try_from_bytes_mut` sites (`AccrueFees`, `InitTradingPool`) were not protected either: the `[..SIZE]` slice is evaluated *before* `try_from`, so it panics on an undersized buffer.

This is **not exploitable for fund loss** — a Solana panic just aborts the transaction with the same on-chain outcome as a clean `Err`, and Rust slice indexing is bounds-checked (no out-of-bounds read) — but it degrades client-facing error quality and is an inconsistent-hardening gap. Classified informational/low.

## Fix

Four length-checked helpers, each `len() >= SIZE` (→ `StakeError::InvalidAccount`) then `try_from_bytes` (→ `ProgramError::InvalidAccountData` on the theoretical misalignment, preserving the prior `try_from` behavior):

- `pool_from_data_mut` / `pool_from_data`
- `deposit_from_data_mut` / `deposit_from_data`

Every `StakePool`/`StakeDeposit` reinterpretation site is routed through them, eliminating the raw slice idiom entirely so the pattern cannot drift again. The helpers take the already-borrowed slice, so the `RefMut`/`Ref` guard stays at the call site (no lifetime change). The two now-redundant inline pool length guards are removed (the helper subsumes them); behavior is identical (undersized → `Custom(16)` `InvalidAccount`), so the existing `regression_184` e2e still holds.

## Correctness / no behavior change for valid accounts

For a real, correctly-sized, 8-aligned account (every genuine PDA), `try_from_bytes` on an exactly-size-matched aligned slice returns the **same reference** `from_bytes` did — so all handlers behave identically on the happy path. The only behavior change is: undersized → was a panic, now a clean `InvalidAccount`.

## Tests

In-file unit tests assert each helper returns `Err` (never panics) on undersized, one-short, and zero-length buffers, and succeeds on exact-size and oversized buffers.

```
cargo build-sbf            # deployable BPF program compiles with the fix (exit 0)
cargo test --lib           # 126 passed, 0 failed (122 pre-existing + 4 new)
```

The litesvm e2e suite (`regression_184`, v16/v17 insurance e2e) is exercised by CI.

## Severity

Informational / Low (panic vs clean error — identical on-chain outcome, no fund loss, no state corruption). See #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability by improving error handling when processing account data. Invalid or corrupted data now returns clear error messages instead of causing crashes.

* **Tests**
  * Added validation tests for account data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->