### PR TITLE
test: clarify SBF artifact requirement for regression #184

### DIFF
--- a/tests/regression_184_set_market_resolved_undersized.rs
+++ b/tests/regression_184_set_market_resolved_undersized.rs
@@ -12,6 +12,9 @@
 //! `SetMarketResolved` against a stake-program-owned account whose data is
 //! shorter than `STAKE_POOL_SIZE`, asserting the program returns
 //! `Custom(16)` (StakeError::InvalidAccount) rather than aborting.
+// Because this regression executes `target/deploy/percolator_stake.so`, rebuild
+// the SBF artifact with `cargo build-sbf --no-default-features` after changing
+// source code; otherwise a stale local artifact can report stale results.
 
 use litesvm::LiteSVM;
 use percolator_stake::state::STAKE_POOL_SIZE;


### PR DESCRIPTION
## Summary

This PR clarifies that `regression_184_set_market_resolved_undersized` runs against the local SBF artifact:

```bash
target/deploy/percolator_stake.so
```

The regression verifies that `SetMarketResolved` rejects undersized stake pool account data with a clean `StakeError::InvalidAccount` instead of aborting.

## Why

When this regression is run locally after source changes, the SBF artifact needs to be rebuilt first:

```bash
cargo build-sbf --no-default-features
```

Without rebuilding, the test may execute an older `target/deploy/percolator_stake.so` and report stale results that do not reflect the current source code.

This clarification helps avoid false positives during local regression testing.

## Changes

- Added a short comment near the regression description.
- Documented that the SBF artifact should be rebuilt before rerunning the test locally after source changes.
- No program logic changed.
- No test behavior changed.

## Testing

Ran:

```bash
cargo build-sbf --no-default-features
cargo test --test regression_184_set_market_resolved_undersized -- --nocapture
```

Result:

```text
test result: ok. 1 passed; 0 failed
```

## Notes

This is a test/documentation-only clarification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test documentation to clarify artifact rebuild requirements for regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->