### PR TITLE
fix(stake): #200 delete dead flush_available + #194 discriminator guard + #195 ATA owner check

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -401,15 +401,11 @@ pub fn hwm_withdrawal_allowed(
     }
 }
 
-/// Calculate available flush amount.
-///
-/// `available = deposited - withdrawn - already_flushed`
-/// Uses saturating arithmetic (can't go negative).
-pub fn flush_available(total_deposited: u64, total_withdrawn: u64, total_flushed: u64) -> u64 {
-    total_deposited
-        .saturating_sub(total_withdrawn)
-        .saturating_sub(total_flushed)
-}
+// #200: `flush_available()` removed. It was dead code (no production callers) and
+// buggy (omitted total_returned + used saturating arithmetic that could mask an
+// accounting error). The live FlushToInsurance path computes available capacity via
+// StakePool::total_pool_value() (i128-widened, total_returned- and
+// realized_junior_loss-aware) — see process_flush_to_insurance / #202.
 
 #[cfg(test)]
 mod tests {
@@ -572,30 +568,6 @@ mod tests {
     #[test]
     fn test_pool_value_exact() {
         assert_eq!(pool_value(100, 100), Some(0));
-    }
-
-    // ── Flush ──
-
-    #[test]
-    fn test_flush_available_normal() {
-        assert_eq!(flush_available(1000, 200, 300), 500);
-    }
-
-    #[test]
-    fn test_flush_available_overdrawn() {
-        // withdrawn > deposited → saturates to 0
-        assert_eq!(flush_available(100, 200, 0), 0);
-    }
-
-    #[test]
-    fn test_flush_available_fully_flushed() {
-        assert_eq!(flush_available(1000, 200, 800), 0);
-    }
-
-    #[test]
-    fn test_flush_available_over_flushed() {
-        // More flushed than available → saturates to 0
-        assert_eq!(flush_available(1000, 200, 900), 0);
     }
 
     // ── Rounding Direction ──

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -601,6 +601,13 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
     // Verify user_ata is owned by user (not just delegated) and holds the correct mint.
     // SPL token account layout: bytes [0..32] = mint, bytes [32..64] = owner.
     {
+        // #195: the account must be SPL-Token-program-owned before we read its raw
+        // layout — otherwise a non-token account with crafted bytes could satisfy the
+        // mint/owner field checks below (the SPL CPI would later revert, but fail fast).
+        if *user_ata.owner != crate::spl_token::id() {
+            msg!("Error: user_ata is not owned by the SPL Token program");
+            return Err(StakeError::InvalidAccount.into());
+        }
         let ata_data = user_ata.try_borrow_data()?;
         if ata_data.len() < crate::spl_token::state::ACCOUNT_LEN {
             return Err(StakeError::InvalidAccount.into());
@@ -810,6 +817,10 @@ fn process_deposit(program_id: &Pubkey, accounts: &[AccountInfo], amount: u64) -
 
     if deposit.is_initialized != 1 {
         deposit.set_discriminator();
+    } else if !deposit.validate_discriminator() {
+        // #194: an already-initialized record must carry the correct StakeDeposit
+        // discriminator; reject a forged account that set is_initialized without init.
+        return Err(StakeError::InvalidAccount.into());
     }
 
     // PERC-303: Prevent mixing senior and junior LP in the same deposit PDA.
@@ -943,6 +954,13 @@ fn process_withdraw(
         return Err(StakeError::InvalidAccount.into());
     }
     {
+        // #195: the account must be SPL-Token-program-owned before we read its raw
+        // layout — otherwise a non-token account with crafted bytes could satisfy the
+        // mint/owner field checks below (the SPL CPI would later revert, but fail fast).
+        if *user_ata.owner != crate::spl_token::id() {
+            msg!("Error: user_ata is not owned by the SPL Token program");
+            return Err(StakeError::InvalidAccount.into());
+        }
         let ata_data = user_ata.try_borrow_data()?;
         if ata_data.len() < crate::spl_token::state::ACCOUNT_LEN {
             return Err(StakeError::InvalidAccount.into());
@@ -982,6 +1000,10 @@ fn process_withdraw(
         let deposit_data_ref = deposit_pda.try_borrow_data()?;
         let deposit = deposit_from_data(&deposit_data_ref[..])?;
 
+        // #194: validate the StakeDeposit discriminator before trusting the record.
+        if !deposit.validate_discriminator() {
+            return Err(StakeError::InvalidAccount.into());
+        }
         if deposit.is_initialized != 1
             || deposit.user != user.key.to_bytes()
             || deposit.pool != pool_pda.key.to_bytes()
@@ -2394,6 +2416,13 @@ fn process_deposit_junior(
     // Verify user_ata mint matches pool collateral and is owned by user.
     // AUDIT MED-3: DepositJunior was missing mint check (present in process_deposit).
     {
+        // #195: the account must be SPL-Token-program-owned before we read its raw
+        // layout — otherwise a non-token account with crafted bytes could satisfy the
+        // mint/owner field checks below (the SPL CPI would later revert, but fail fast).
+        if *user_ata.owner != crate::spl_token::id() {
+            msg!("Error: user_ata is not owned by the SPL Token program");
+            return Err(StakeError::InvalidAccount.into());
+        }
         let ata_data = user_ata.try_borrow_data()?;
         if ata_data.len() < crate::spl_token::state::ACCOUNT_LEN {
             return Err(StakeError::InvalidAccount.into());
@@ -2571,6 +2600,10 @@ fn process_deposit_junior(
 
     if deposit.is_initialized != 1 {
         deposit.set_discriminator();
+    } else if !deposit.validate_discriminator() {
+        // #194: an already-initialized record must carry the correct StakeDeposit
+        // discriminator; reject a forged account that set is_initialized without init.
+        return Err(StakeError::InvalidAccount.into());
     }
 
     // PERC-303: Prevent mixing. If deposit PDA is NOT flagged as junior

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -28,7 +28,7 @@
 #[cfg(kani)]
 mod kani_proofs {
     use percolator_stake::math::{
-        calc_collateral_for_withdraw, calc_lp_for_deposit, flush_available, pool_value,
+        calc_collateral_for_withdraw, calc_lp_for_deposit, pool_value,
     };
 
     // ═══════════════════════════════════════════════════════════
@@ -181,14 +181,6 @@ mod kani_proofs {
         let _ = pool_value(deposited, withdrawn);
     }
 
-    /// PROOF: flush_available never panics.
-    #[kani::proof]
-    fn proof_flush_available_no_panic() {
-        let deposited: u64 = kani::any();
-        let withdrawn: u64 = kani::any();
-        let flushed: u64 = kani::any();
-        let _ = flush_available(deposited, withdrawn, flushed);
-    }
 
     // ═══════════════════════════════════════════════════════════
     // 3. Fairness — Monotonicity
@@ -325,33 +317,9 @@ mod kani_proofs {
     // 5. Flush Bounds
     // ═══════════════════════════════════════════════════════════
 
-    /// PROOF: flush_available ≤ deposited (can't flush more than total).
-    #[kani::proof]
-    fn proof_flush_bounded_by_deposited() {
-        let deposited: u64 = kani::any();
-        let withdrawn: u64 = kani::any();
-        let flushed: u64 = kani::any();
-
-        let avail = flush_available(deposited, withdrawn, flushed);
-        assert!(avail <= deposited);
-    }
-
-    /// PROOF: After flushing available amount, flush_available = 0.
-    #[kani::proof]
-    fn proof_flush_max_then_zero() {
-        let deposited: u64 = kani::any();
-        let withdrawn: u64 = kani::any();
-        let flushed: u64 = kani::any();
-
-        kani::assume(withdrawn <= deposited);
-        kani::assume(flushed <= deposited.saturating_sub(withdrawn));
-
-        let avail = flush_available(deposited, withdrawn, flushed);
-        let new_flushed = flushed + avail;
-
-        let remaining = flush_available(deposited, withdrawn, new_flushed);
-        assert_eq!(remaining, 0);
-    }
+    // #200: proof_flush_bounded_by_deposited / proof_flush_max_then_zero removed
+    // along with the dead math::flush_available() they proved. The live flush path's
+    // safety is covered by total_pool_value()'s proofs (see #169).
 
     // ═══════════════════════════════════════════════════════════
     // 6. Pool Value


### PR DESCRIPTION
Three verified findings (credit @v1ktorrr0x):
- **#200** — delete the dead, buggy `math::flush_available()` (no prod callers; live path uses `total_pool_value()` per #202). Removes its inline tests + the 2 kani proofs of the dead fn.
- **#194** — validate the StakeDeposit discriminator on already-init records (deposit/withdraw/deposit_junior); defense-in-depth.
- **#195** — verify user_ata is SPL-Token-owned before raw layout reads; fail-fast vs crafted non-token accounts.

build-sbf clean, 22 test suites green. Closes #200, #194, #195.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed buggy internal calculation code that was no longer in use.

* **Security**
  * Added stricter validation for token accounts and stake records to prevent unauthorized account manipulation.

* **Tests**
  * Updated tests to align with code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->