### PR TITLE
fix(stake): verify wrapper_vault SPL Token ownership before raw mint read in FlushToInsurance

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1399,6 +1399,13 @@ fn process_flush_to_insurance(
     // The percolator CPI also validates this, but an explicit check here gives a clear
     // error and prevents tokens of the wrong type from being routed to the insurance vault.
     // SPL token account layout: bytes [0..32] = mint.
+    // N-5: verify SPL Token ownership before reading raw bytes — mirrors the guard in
+    // pre_accrue_mode1 (line ~1902) and process_return_insurance (line ~2618). Without
+    // this, a crafted non-token account with forged bytes at [0..32] passes the mint check.
+    if *wrapper_vault.owner != crate::spl_token::id() {
+        msg!("Error: wrapper_vault is not owned by the SPL Token program");
+        return Err(StakeError::InvalidAccount.into());
+    }
     {
         let wv_data = wrapper_vault.try_borrow_data()?;
         if wv_data.len() < crate::spl_token::state::ACCOUNT_LEN {


### PR DESCRIPTION
Fixes #226

## Change

Adds `wrapper_vault.owner == spl_token::id()` check in `process_flush_to_insurance` before the raw `data[0..32]` mint read, matching the guard already present in `pre_accrue_mode1`, `process_accrue_fees`, and `process_return_insurance`.

## Why

A non-token account with forged bytes at offset `[0..32]` matching `pool.collateral_mint` passes the existing mint check. The SPL Token program's CPI validates the account on its side, but an explicit owner check here is consistent with every other vault-touching handler in the file and eliminates the inconsistency.

## Test plan

- [ ] Existing test suite passes (`cargo test`)
- [ ] Passing a non-SPL-Token-owned account as `wrapper_vault` now returns `StakeError::InvalidAccount` instead of propagating to the CPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to verify token account ownership before processing, preventing potential errors when handling invalid accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->