### PR TITLE
fix(stake): assert vault AccountState::Initialized before reading balance in fee accrual

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2054,7 +2054,14 @@ fn pre_accrue_mode1(pool: &mut state::StakePool, vault: &AccountInfo) -> Program
         }
         let current_balance = {
             let vault_data = vault.try_borrow_data()?;
-            crate::spl_token::state::Account::unpack(&vault_data)?.amount
+            let acct = crate::spl_token::state::Account::unpack(&vault_data)?;
+            // N-8: reject non-Initialized vault (Uninitialized or Frozen). Our
+            // Account::unpack does not error on these states; an explicit check here
+            // ensures fee accounting only runs against a live, transferable token account.
+            if acct.state != crate::spl_token::state::AccountState::Initialized {
+                return Err(ProgramError::InvalidAccountData);
+            }
+            acct.amount
         };
         accrue_fees_inner(pool, current_balance)?;
     }
@@ -2200,6 +2207,13 @@ fn process_accrue_fees(program_id: &Pubkey, accounts: &[AccountInfo]) -> Program
     // Read vault token account balance (key and owner already verified above)
     let vault_data = vault_ai.try_borrow_data()?;
     let vault_state = crate::spl_token::state::Account::unpack(&vault_data)?;
+    // N-8: reject non-Initialized vault. Account::unpack does not error on
+    // Uninitialized/Frozen; an explicit check ensures AccrueFees only runs against
+    // a live token account (Frozen state is impossible today since freeze_authority=None,
+    // but this guard is future-safe if Token-2022 or a refactor changes that invariant).
+    if vault_state.state != crate::spl_token::state::AccountState::Initialized {
+        return Err(ProgramError::InvalidAccountData);
+    }
     let current_balance = vault_state.amount;
 
     let clock = Clock::from_account_info(clock_ai)?;


### PR DESCRIPTION
Fixes #238

## Change

Adds `AccountState::Initialized` check in `pre_accrue_mode1` and `process_accrue_fees` after calling `Account::unpack`, before using `vault_state.amount` for fee accounting.

## Why

`Account::unpack` in `src/spl_token.rs` parses the state byte but returns `Ok` for `Uninitialized` and `Frozen` states. Both callers read `.amount` without checking `.state`. The guard is a no-op today (freeze_authority=None, Uninitialized vault balance=0) but becomes load-bearing if Token-2022 or a future refactor introduces freeze semantics.

## Test plan

- [ ] `cargo test` passes
- [ ] An `Uninitialized` vault account passed to `AccrueFees` returns `InvalidAccountData`