### PR TITLE
feat(stake): two-phase timelock on cooldown_slots increases (#242)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -60,6 +60,17 @@ pub enum StakeError {
     /// would inherit a pre-existing loss it was never exposed to (and the mirror
     /// case could snipe the recovery). Deposits resume once insurance is returned.
     InsuranceLossOutstanding = 24,
+    /// #242 timelock: a `cooldown_slots` INCREASE must go through the two-phase
+    /// timelock (ProposeCooldownIncrease → wait TIMELOCK_SLOTS → CommitCooldownIncrease),
+    /// not the immediate UpdateConfig path. A decrease or unchanged value is still
+    /// allowed via UpdateConfig.
+    CooldownIncreaseRequiresTimelock = 25,
+    /// #242 timelock: CommitCooldownIncrease was called before TIMELOCK_SLOTS had
+    /// elapsed since the proposal. LP holders are still inside their exit window.
+    TimelockNotElapsed = 26,
+    /// #242 timelock: CommitCooldownIncrease / CancelCooldownIncrease with no active
+    /// proposal (cooldown_proposed_at_slot == 0).
+    NoPendingCooldownProposal = 27,
 }
 
 impl From<StakeError> for ProgramError {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -182,9 +182,37 @@ pub enum StakeInstruction {
     ///   1. `[writable]` Pool PDA
     AcceptAdmin,
 
-    // Tags 7-9, 11 removed: were admin CPI proxies (SetOracleAuthority,
-    // SetRiskThreshold, SetMaintenanceFee, ResolveMarket, SetInsurancePolicy).
-    // Human admin now calls wrapper directly. Tags 5/6 reclaimed for admin rotation.
+    /// 7: ProposeCooldownIncrease — step 1 of the #242 cooldown-increase timelock.
+    /// The admin proposes a NEW (larger) `cooldown_slots`; it does not take effect until
+    /// CommitCooldownIncrease is called after TIMELOCK_SLOTS (≈48h), guaranteeing LP
+    /// holders an exit window. A decrease/unchanged value is rejected here (use
+    /// UpdateConfig, which applies decreases immediately).
+    ///
+    /// Accounts:
+    ///   0. `[signer]` Admin
+    ///   1. `[writable]` Pool PDA
+    ///   2. `[]` Clock sysvar
+    ProposeCooldownIncrease { new_cooldown_slots: u64 },
+
+    /// 8: CommitCooldownIncrease — step 2 of the #242 timelock. Applies the pending
+    /// cooldown increase, but only after TIMELOCK_SLOTS have elapsed since the proposal.
+    ///
+    /// Accounts:
+    ///   0. `[signer]` Admin
+    ///   1. `[writable]` Pool PDA
+    ///   2. `[]` Clock sysvar
+    CommitCooldownIncrease,
+
+    /// 9: CancelCooldownIncrease — withdraw an outstanding #242 cooldown proposal.
+    ///
+    /// Accounts:
+    ///   0. `[signer]` Admin
+    ///   1. `[writable]` Pool PDA
+    CancelCooldownIncrease,
+
+    // Tag 11 removed: was an admin CPI proxy (SetInsurancePolicy). Human admin now
+    // calls the wrapper directly. Tags 5/6 reclaimed for admin rotation; tags 7/8/9
+    // reclaimed for the #242 cooldown-increase timelock.
     /// 10: Return insurance funds to the pool vault.
     /// Admin calls WithdrawInsurance on the wrapper directly (gets USDC to admin ATA),
     /// then calls this to transfer from admin ATA to pool vault and update accounting.
@@ -338,7 +366,33 @@ impl StakeInstruction {
                 }
                 Ok(Self::AcceptAdmin)
             }
-            // Tags 7-9, 11 tombstoned — were admin CPI proxies, now removed.
+            7 => {
+                // #242: ProposeCooldownIncrease { new_cooldown_slots: u64 }
+                if rest.len() != 8 {
+                    return Err(ProgramError::InvalidInstructionData);
+                }
+                let new_cooldown_slots = u64::from_le_bytes(
+                    rest[0..8]
+                        .try_into()
+                        .map_err(|_| ProgramError::InvalidInstructionData)?,
+                );
+                Ok(Self::ProposeCooldownIncrease { new_cooldown_slots })
+            }
+            8 => {
+                // #242: CommitCooldownIncrease
+                if !rest.is_empty() {
+                    return Err(ProgramError::InvalidInstructionData);
+                }
+                Ok(Self::CommitCooldownIncrease)
+            }
+            9 => {
+                // #242: CancelCooldownIncrease
+                if !rest.is_empty() {
+                    return Err(ProgramError::InvalidInstructionData);
+                }
+                Ok(Self::CancelCooldownIncrease)
+            }
+            // Tag 11 tombstoned — was an admin CPI proxy, now removed.
             19 => {
                 if !rest.is_empty() {
                     return Err(ProgramError::InvalidInstructionData);
@@ -511,8 +565,9 @@ mod tests {
 
     #[test]
     fn test_tombstoned_tags_rejected() {
-        // Tags 7-9, 11, 17 remain tombstoned (5/6 reclaimed for admin rotation).
-        for tag in [7u8, 8, 9, 11, 17] {
+        // Tags 11, 17 remain tombstoned (5/6 reclaimed for admin rotation; 7/8/9
+        // reclaimed for the #242 cooldown-increase timelock).
+        for tag in [11u8, 17] {
             let data = vec![tag];
             assert!(
                 StakeInstruction::unpack(&data).is_err(),
@@ -520,6 +575,36 @@ mod tests {
                 tag
             );
         }
+    }
+
+    #[test]
+    fn test_unpack_propose_cooldown_increase() {
+        let mut data = vec![7u8];
+        data.extend_from_slice(&123_456u64.to_le_bytes());
+        match StakeInstruction::unpack(&data).unwrap() {
+            StakeInstruction::ProposeCooldownIncrease { new_cooldown_slots } => {
+                assert_eq!(new_cooldown_slots, 123_456)
+            }
+            _ => panic!("wrong variant"),
+        }
+        // wrong length is rejected
+        assert!(StakeInstruction::unpack(&[7u8]).is_err());
+        assert!(StakeInstruction::unpack(&[7u8, 1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn test_unpack_commit_and_cancel_cooldown_increase() {
+        match StakeInstruction::unpack(&[8u8]).unwrap() {
+            StakeInstruction::CommitCooldownIncrease => {}
+            _ => panic!("wrong variant"),
+        }
+        match StakeInstruction::unpack(&[9u8]).unwrap() {
+            StakeInstruction::CancelCooldownIncrease => {}
+            _ => panic!("wrong variant"),
+        }
+        // trailing bytes rejected
+        assert!(StakeInstruction::unpack(&[8u8, 0]).is_err());
+        assert!(StakeInstruction::unpack(&[9u8, 0]).is_err());
     }
 
     #[test]

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -94,21 +94,42 @@ fn create_or_adopt_pda<'a>(
 /// withdrawals — `clock.slot` would never reach the saturating deadline (#121).
 const MAX_COOLDOWN_SLOTS: u64 = 78_840_000;
 
-/// Minimum delay before a proposed config change takes effect (≈48 hours at 2.5 slots/sec).
+/// Minimum delay before a proposed cooldown increase takes effect (≈48 hours at 2.5 slots/sec).
 ///
-/// N-2 — Timelock requirement: UpdateConfig, FlushToInsurance, and SetMarketResolved
-/// can all be called atomically today. A compromised admin can combine them in one tx
-/// to: set cooldown = MAX_COOLDOWN_SLOTS (~1 year), drain vault via FlushToInsurance,
-/// and resolve the market — permanently locking LP capital. A two-phase commit on
-/// these instructions, enforced by this constant, would require a 48-hour window
-/// before the change takes effect, giving LP holders time to exit.
+/// N-2 — Timelock (#242). The capital-LOCK vector is a `cooldown_slots` INCREASE: a
+/// compromised admin could set cooldown = MAX_COOLDOWN_SLOTS (~1 year) in a single
+/// UpdateConfig tx and lock LP withdrawals. That increase is now IMPLEMENTED as a
+/// two-phase timelock — ProposeCooldownIncrease (tag 7) records the pending value and
+/// proposal slot in StakePool (`pending_cooldown_slots` / `cooldown_proposed_at_slot`,
+/// stored in the previously-free `_reserved[10..26]` — no struct-size change / version
+/// bump), and CommitCooldownIncrease (tag 8) applies it only after TIMELOCK_SLOTS have
+/// elapsed, giving LP holders a guaranteed ≥48h exit window. CancelCooldownIncrease
+/// (tag 9) withdraws a pending proposal. UpdateConfig now REJECTS a cooldown increase
+/// (`CooldownIncreaseRequiresTimelock`); decreases (LP-friendly) and `deposit_cap`
+/// changes remain immediate.
 ///
-/// IMPLEMENTATION NOTE: Full two-phase commit requires `pending_cooldown_slots: u64`
-/// and `proposed_at_slot: u64` fields in StakePool state (a protocol version bump).
-/// This constant defines the minimum delay for that implementation. See issue #242.
-/// The full implementation is deferred to a protocol upgrade; this constant
-/// documents the required value and guards future implementations.
+/// FlushToInsurance and SetMarketResolved are intentionally NOT timelocked: flush moves
+/// collateral into the PDA-custodied insurance fund (recoverable via ReturnInsurance,
+/// and guarded by #227 vault-ownership + #229 post-resolve block — it is not an
+/// admin-extractable drain), and resolution is a one-way operational action. Delaying
+/// either would trade real operational liveness for no capital-lock protection beyond
+/// what the cooldown timelock already provides.
 pub const TIMELOCK_SLOTS: u64 = 432_000; // ~48 hours at 2.5 slots/sec
+
+/// #242: returns whether the timelock window has elapsed for a proposal made at slot
+/// `proposed_at`, given the current slot `now` and `timelock_slots`. Pure + checked
+/// (a `proposed_at + timelock_slots` overflow ⇒ `Err`, never a panic). The caller is
+/// responsible for confirming an active proposal (`proposed_at != 0`) before calling.
+pub fn timelock_window_elapsed(
+    proposed_at: u64,
+    timelock_slots: u64,
+    now: u64,
+) -> Result<bool, ProgramError> {
+    let earliest = proposed_at
+        .checked_add(timelock_slots)
+        .ok_or(StakeError::Overflow)?;
+    Ok(now >= earliest)
+}
 
 /// Upper bound on `hwm_floor_bps` (90%). The high-water-mark floor is a per-epoch
 /// drain RATE LIMITER, not a withdrawal kill switch. At 10_000 (100%) the floor
@@ -339,6 +360,15 @@ pub fn process(
             process_propose_admin(program_id, accounts, new_admin)
         }
         StakeInstruction::AcceptAdmin => process_accept_admin(program_id, accounts),
+        StakeInstruction::ProposeCooldownIncrease { new_cooldown_slots } => {
+            process_propose_cooldown_increase(program_id, accounts, new_cooldown_slots)
+        }
+        StakeInstruction::CommitCooldownIncrease => {
+            process_commit_cooldown_increase(program_id, accounts)
+        }
+        StakeInstruction::CancelCooldownIncrease => {
+            process_cancel_cooldown_increase(program_id, accounts)
+        }
         StakeInstruction::BindInsuranceAuthority => {
             process_bind_insurance_authority(program_id, accounts)
         }
@@ -1580,6 +1610,13 @@ fn process_update_config(
 
     if let Some(cooldown) = new_cooldown_slots {
         validate_cooldown_slots(cooldown)?;
+        // #242: a cooldown INCREASE is the capital-lock vector — route it through the
+        // two-phase timelock (ProposeCooldownIncrease → CommitCooldownIncrease) so LP
+        // holders get a ≥48h exit window. Decreases / unchanged are LP-friendly and stay
+        // immediate.
+        if cooldown > pool.cooldown_slots {
+            return Err(StakeError::CooldownIncreaseRequiresTimelock.into());
+        }
         pool.cooldown_slots = cooldown;
     }
     if let Some(cap) = new_deposit_cap {
@@ -1689,6 +1726,184 @@ fn process_accept_admin(program_id: &Pubkey, accounts: &[AccountInfo]) -> Progra
     pool.pending_admin = [0u8; 32];
 
     msg!("AcceptAdmin: admin rotation complete");
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 7: ProposeCooldownIncrease — step 1 of the #242 cooldown-increase timelock
+// ═══════════════════════════════════════════════════════════════
+
+/// The admin proposes a NEW (larger) `cooldown_slots`. Records the pending value and
+/// the current slot; the increase does not take effect until CommitCooldownIncrease is
+/// called after TIMELOCK_SLOTS have elapsed — guaranteeing LP holders a ≥48h exit window
+/// before withdrawals can be slowed. Re-proposing overwrites the pending value AND resets
+/// the timer (the new, longer window applies). A decrease/unchanged value is rejected here
+/// (those go through UpdateConfig immediately).
+///
+/// Accounts:
+///   0. `[signer]` Admin
+///   1. `[writable]` Pool PDA
+///   2. `[]` Clock sysvar
+fn process_propose_cooldown_increase(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    new_cooldown_slots: u64,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+    let admin = next_account_info(accounts_iter)?;
+    let pool_pda = next_account_info(accounts_iter)?;
+    let clock_sysvar = next_account_info(accounts_iter)?;
+
+    if !admin.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    validate_account_owner(pool_pda, program_id)?;
+    validate_account_not_empty(pool_pda)?;
+    validate_account_writable(pool_pda)?;
+
+    let clock = Clock::from_account_info(clock_sysvar)?;
+
+    let mut pool_data = pool_pda.try_borrow_mut_data()?;
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
+
+    if pool.is_initialized != 1 {
+        return Err(StakeError::NotInitialized.into());
+    }
+    if !pool.validate_discriminator() {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    validate_pool_version(pool)?;
+    if pool.admin != admin.key.to_bytes() {
+        return Err(StakeError::Unauthorized.into());
+    }
+
+    // Same absolute cap as the immediate path.
+    validate_cooldown_slots(new_cooldown_slots)?;
+    // Propose is ONLY for increases; a decrease/unchanged value goes through UpdateConfig.
+    if new_cooldown_slots <= pool.cooldown_slots {
+        return Err(StakeError::CooldownIncreaseRequiresTimelock.into());
+    }
+
+    pool.set_pending_cooldown_slots(new_cooldown_slots);
+    // clock.slot is never 0 on a live chain, so it is a safe "active proposal" sentinel.
+    pool.set_cooldown_proposed_at_slot(clock.slot);
+
+    msg!("ProposeCooldownIncrease: pending; commit after TIMELOCK_SLOTS");
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 8: CommitCooldownIncrease — step 2 of the #242 cooldown-increase timelock
+// ═══════════════════════════════════════════════════════════════
+
+/// Applies a previously-proposed cooldown increase, but ONLY after TIMELOCK_SLOTS have
+/// elapsed since the proposal. Clears the pending state on success.
+///
+/// Accounts:
+///   0. `[signer]` Admin
+///   1. `[writable]` Pool PDA
+///   2. `[]` Clock sysvar
+fn process_commit_cooldown_increase(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+    let admin = next_account_info(accounts_iter)?;
+    let pool_pda = next_account_info(accounts_iter)?;
+    let clock_sysvar = next_account_info(accounts_iter)?;
+
+    if !admin.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    validate_account_owner(pool_pda, program_id)?;
+    validate_account_not_empty(pool_pda)?;
+    validate_account_writable(pool_pda)?;
+
+    let clock = Clock::from_account_info(clock_sysvar)?;
+
+    let mut pool_data = pool_pda.try_borrow_mut_data()?;
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
+
+    if pool.is_initialized != 1 {
+        return Err(StakeError::NotInitialized.into());
+    }
+    if !pool.validate_discriminator() {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    validate_pool_version(pool)?;
+    if pool.admin != admin.key.to_bytes() {
+        return Err(StakeError::Unauthorized.into());
+    }
+
+    let proposed_at = pool.cooldown_proposed_at_slot();
+    if proposed_at == 0 {
+        return Err(StakeError::NoPendingCooldownProposal.into());
+    }
+    if !timelock_window_elapsed(proposed_at, TIMELOCK_SLOTS, clock.slot)? {
+        return Err(StakeError::TimelockNotElapsed.into());
+    }
+
+    let pending = pool.pending_cooldown_slots();
+    // Defensive re-validation: the cap may matter even though propose enforced it.
+    validate_cooldown_slots(pending)?;
+
+    pool.cooldown_slots = pending;
+    pool.set_pending_cooldown_slots(0);
+    pool.set_cooldown_proposed_at_slot(0);
+
+    msg!("CommitCooldownIncrease: applied");
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 9: CancelCooldownIncrease — withdraw a pending #242 cooldown proposal
+// ═══════════════════════════════════════════════════════════════
+
+/// The admin cancels an outstanding cooldown-increase proposal, clearing the pending
+/// state. No clock needed.
+///
+/// Accounts:
+///   0. `[signer]` Admin
+///   1. `[writable]` Pool PDA
+fn process_cancel_cooldown_increase(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+    let admin = next_account_info(accounts_iter)?;
+    let pool_pda = next_account_info(accounts_iter)?;
+
+    if !admin.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    validate_account_owner(pool_pda, program_id)?;
+    validate_account_not_empty(pool_pda)?;
+    validate_account_writable(pool_pda)?;
+
+    let mut pool_data = pool_pda.try_borrow_mut_data()?;
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
+
+    if pool.is_initialized != 1 {
+        return Err(StakeError::NotInitialized.into());
+    }
+    if !pool.validate_discriminator() {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    validate_pool_version(pool)?;
+    if pool.admin != admin.key.to_bytes() {
+        return Err(StakeError::Unauthorized.into());
+    }
+
+    if pool.cooldown_proposed_at_slot() == 0 {
+        return Err(StakeError::NoPendingCooldownProposal.into());
+    }
+    pool.set_pending_cooldown_slots(0);
+    pool.set_cooldown_proposed_at_slot(0);
+
+    msg!("CancelCooldownIncrease: pending proposal cleared");
     Ok(())
 }
 
@@ -2968,6 +3183,77 @@ fn process_set_market_resolved(program_id: &Pubkey, accounts: &[AccountInfo]) ->
 mod tests {
     use super::*;
     use bytemuck::Zeroable;
+
+    // ── #242 timelock_window_elapsed (pure helper) ──────────────────────────
+    #[test]
+    fn timelock_not_elapsed_before_window() {
+        // proposed at 1000, 432_000-slot window ⇒ earliest = 433_000.
+        assert_eq!(
+            timelock_window_elapsed(1_000, TIMELOCK_SLOTS, 1_000).unwrap(),
+            false
+        );
+        assert_eq!(
+            timelock_window_elapsed(1_000, TIMELOCK_SLOTS, 433_000 - 1).unwrap(),
+            false
+        );
+    }
+
+    #[test]
+    fn timelock_elapsed_at_or_after_window() {
+        // Boundary is inclusive: now == proposed + window ⇒ elapsed.
+        assert_eq!(
+            timelock_window_elapsed(1_000, TIMELOCK_SLOTS, 1_000 + TIMELOCK_SLOTS).unwrap(),
+            true
+        );
+        assert_eq!(
+            timelock_window_elapsed(1_000, TIMELOCK_SLOTS, 1_000 + TIMELOCK_SLOTS + 5).unwrap(),
+            true
+        );
+    }
+
+    #[test]
+    fn timelock_overflow_is_error_not_panic() {
+        assert_eq!(
+            timelock_window_elapsed(u64::MAX, TIMELOCK_SLOTS, u64::MAX),
+            Err(StakeError::Overflow.into())
+        );
+    }
+
+    // ── #242 StakePool pending-cooldown accessors round-trip ────────────────
+    #[test]
+    fn pending_cooldown_accessors_roundtrip_and_default_zero() {
+        let mut pool = StakePool::zeroed();
+        // Fresh (zeroed) pool ⇒ no active proposal.
+        assert_eq!(pool.pending_cooldown_slots(), 0);
+        assert_eq!(pool.cooldown_proposed_at_slot(), 0);
+        pool.set_pending_cooldown_slots(987_654);
+        pool.set_cooldown_proposed_at_slot(42);
+        assert_eq!(pool.pending_cooldown_slots(), 987_654);
+        assert_eq!(pool.cooldown_proposed_at_slot(), 42);
+        // Clearing the proposal slot restores the sentinel.
+        pool.set_cooldown_proposed_at_slot(0);
+        assert_eq!(pool.cooldown_proposed_at_slot(), 0);
+    }
+
+    #[test]
+    fn pending_cooldown_bytes_do_not_collide_with_neighbors() {
+        // _reserved[10..26] must not disturb the discriminator/version[0..9],
+        // market_resolved[9], tranche[32+], or realized_junior_loss[51..59].
+        let mut pool = StakePool::zeroed();
+        pool.set_discriminator();
+        pool.set_market_resolved(true);
+        pool.set_realized_junior_loss(7_777);
+        pool.set_tranche_enabled(true);
+        pool.set_pending_cooldown_slots(u64::MAX);
+        pool.set_cooldown_proposed_at_slot(123);
+        assert!(pool.validate_discriminator());
+        assert_eq!(pool.version(), StakePool::CURRENT_VERSION);
+        assert!(pool.market_resolved());
+        assert!(pool.tranche_enabled());
+        assert_eq!(pool.realized_junior_loss(), 7_777);
+        assert_eq!(pool.pending_cooldown_slots(), u64::MAX);
+        assert_eq!(pool.cooldown_proposed_at_slot(), 123);
+    }
 
     #[test]
 fn return_insurance_rejects_admin_ata_not_owned_by_admin() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -336,6 +336,36 @@ impl StakePool {
         self._reserved[59] = if burned { 1 } else { 0 };
     }
 
+    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Stored at
+    /// `_reserved[10..18]` (LE u64), in the previously-free `[10..32]` region — no
+    /// struct-size change, no version bump. Meaningful only while
+    /// `cooldown_proposed_at_slot() != 0`.
+    pub fn pending_cooldown_slots(&self) -> u64 {
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&self._reserved[10..18]);
+        u64::from_le_bytes(bytes)
+    }
+
+    /// Set the pending cooldown-increase value. See [`pending_cooldown_slots`].
+    pub fn set_pending_cooldown_slots(&mut self, val: u64) {
+        self._reserved[10..18].copy_from_slice(&val.to_le_bytes());
+    }
+
+    /// #242 timelock: the slot at which the pending cooldown increase was proposed.
+    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Stored
+    /// at `_reserved[18..26]` (LE u64).
+    pub fn cooldown_proposed_at_slot(&self) -> u64 {
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&self._reserved[18..26]);
+        u64::from_le_bytes(bytes)
+    }
+
+    /// Set the cooldown-increase proposal slot (`0` clears the proposal). See
+    /// [`cooldown_proposed_at_slot`].
+    pub fn set_cooldown_proposed_at_slot(&mut self, val: u64) {
+        self._reserved[18..26].copy_from_slice(&val.to_le_bytes());
+    }
+
     /// Loss-adjusted junior tranche balance.
     ///
     /// `junior_balance()` (stored) grows monotonically with deposits and withdrawals

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -727,9 +727,31 @@ fn test_all_standard_instruction_tags_decode() {
         _ => panic!("Expected FlushToInsurance"),
     }
 
-    // Tags 5, 9 removed (were admin CPI proxies)
-    assert!(StakeInstruction::unpack(&[5u8]).is_err());
-    assert!(StakeInstruction::unpack(&[9u8]).is_err());
+    // Tag 5: ProposeAdmin (reclaimed for admin rotation).
+    let mut data = vec![5u8];
+    data.extend_from_slice(&[3u8; 32]);
+    assert!(matches!(
+        StakeInstruction::unpack(&data).unwrap(),
+        StakeInstruction::ProposeAdmin { .. }
+    ));
+
+    // Tags 7/8/9: #242 cooldown-increase timelock (reclaimed from tombstones).
+    let mut data = vec![7u8];
+    data.extend_from_slice(&999u64.to_le_bytes());
+    assert!(matches!(
+        StakeInstruction::unpack(&data).unwrap(),
+        StakeInstruction::ProposeCooldownIncrease {
+            new_cooldown_slots: 999
+        }
+    ));
+    assert!(matches!(
+        StakeInstruction::unpack(&[8u8]).unwrap(),
+        StakeInstruction::CommitCooldownIncrease
+    ));
+    assert!(matches!(
+        StakeInstruction::unpack(&[9u8]).unwrap(),
+        StakeInstruction::CancelCooldownIncrease
+    ));
 
     // Tag 10: ReturnInsurance (was AdminWithdrawInsurance)
     let mut data = vec![10u8];

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -768,4 +768,28 @@ mod kani_proofs {
         // Ratio should be 50_000 : 10_000 = 5:1
         kani::cover!(jf > sf);
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // #242 — cooldown-increase timelock window (exhaustive, non-vacuous)
+    // ═══════════════════════════════════════════════════════════
+
+    /// PROOF: `timelock_window_elapsed` matches its spec over ALL u64 inputs —
+    /// `Err` exactly when `proposed_at + timelock` overflows (never a panic),
+    /// otherwise `Ok(now >= proposed_at + timelock)`. The two `cover!`s prove both
+    /// the elapsed and not-elapsed verdicts are reachable (the gate is neither
+    /// constant-true nor constant-false).
+    #[kani::proof]
+    fn kani_timelock_window_elapsed_matches_spec() {
+        let proposed_at: u64 = kani::any();
+        let timelock: u64 = kani::any();
+        let now: u64 = kani::any();
+        let res =
+            percolator_stake::processor::timelock_window_elapsed(proposed_at, timelock, now);
+        match proposed_at.checked_add(timelock) {
+            None => assert!(res.is_err()),
+            Some(earliest) => assert_eq!(res, Ok(now >= earliest)),
+        }
+        kani::cover!(res == Ok(true));
+        kani::cover!(res == Ok(false));
+    }
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -509,16 +509,21 @@ fn test_decode_update_config_none() {
 
 #[test]
 fn test_tombstoned_admin_tags_rejected() {
-    // Tags 7, 8, 9, 11 remain tombstoned (former admin CPI proxies).
-    // Tags 5/6 were RECLAIMED for two-step admin rotation (ProposeAdmin/AcceptAdmin)
-    // in v2 — see instruction.rs tests for their positive decode coverage.
-    for tag in [7u8, 8, 9, 11] {
+    // Tag 11 remains tombstoned (former admin CPI proxy).
+    // Tags 5/6 were RECLAIMED for two-step admin rotation (ProposeAdmin/AcceptAdmin) in v2;
+    // tags 7/8/9 were RECLAIMED for the #242 cooldown-increase timelock
+    // (ProposeCooldownIncrease/CommitCooldownIncrease/CancelCooldownIncrease) — see
+    // instruction.rs tests for their positive decode coverage.
+    for tag in [11u8] {
         assert!(
             StakeInstruction::unpack(&[tag]).is_err(),
             "tag {} should be rejected",
             tag
         );
     }
+    // Tags 7/8/9 now decode successfully (empty-data forms for 8/9).
+    assert!(StakeInstruction::unpack(&[8u8]).is_ok());
+    assert!(StakeInstruction::unpack(&[9u8]).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Implements the N-2 timelock #243 prepared. A compromised admin could set `cooldown_slots = MAX` (~1yr) in one `UpdateConfig` tx and instantly lock LP withdrawals. Now a cooldown **increase** requires a two-phase, ~48h-delayed commit, giving LPs a guaranteed exit window.

- **ProposeCooldownIncrease** (tag 7) → **CommitCooldownIncrease** (tag 8, only after `TIMELOCK_SLOTS`) → **CancelCooldownIncrease** (tag 9). `UpdateConfig` now rejects an increase (`CooldownIncreaseRequiresTimelock`); decreases + `deposit_cap` stay immediate.
- Pending state in the free `_reserved[10..26]` — no struct-size change / version bump (fresh cutover). 3 new errors (25/26/27).
- `FlushToInsurance`/`SetMarketResolved` intentionally stay immediate (PDA-custody + #227/#229 guards / one-way operational — documented in the N-2 comment).

**Verification:** `timelock_window_elapsed` pure helper + **Kani proof** (293 properties, 2/2 covers satisfied — non-vacuous); unit tests for helper/accessors/neighbor-collision; instruction round-trip + tombstone tests updated; **138 lib + full integration suite (incl. LiteSVM e2e) pass, 0 failures**; `build-sbf` clean. NOT deployed (cutover-gated).

Closes #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a two-phase timelock mechanism for cooldown increases. Administrators can now propose a cooldown increase, wait for the timelock window to elapse, then commit or cancel the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->