### PR TITLE
security(#240): upgrade-authority gate — script + runbook + opt-in CI

### DIFF
--- a/.github/workflows/upgrade-authority-gate.yml
+++ b/.github/workflows/upgrade-authority-gate.yml
@@ -1,0 +1,51 @@
+name: upgrade-authority-gate
+
+# #240 — pre-mainnet gate: every fund-custody program's upgrade authority must be
+# burned or held by an allowlisted governance multisig. Manual / opt-in: it only runs
+# on demand (or other workflows can `uses:`/call it), and no-ops cleanly when the
+# UPGRADE_AUTH_* repo variables are not configured, so it never blocks unrelated PRs.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: "RPC cluster URL"
+        required: false
+        default: "https://api.mainnet-beta.solana.com"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      # Configure these as repo/org Variables (Settings → Secrets and variables → Actions → Variables):
+      #   UPGRADE_AUTH_PROGRAMS  — comma-separated program IDs to check
+      #   UPGRADE_AUTH_ALLOWLIST — comma-separated acceptable governance authorities
+      #                            (empty ⇒ policy is "must be burned")
+      UPGRADE_AUTH_PROGRAMS: ${{ vars.UPGRADE_AUTH_PROGRAMS }}
+      UPGRADE_AUTH_ALLOWLIST: ${{ vars.UPGRADE_AUTH_ALLOWLIST }}
+      SOLANA_CLUSTER: ${{ github.event.inputs.cluster }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Skip when unconfigured
+        id: guard
+        run: |
+          if [ -z "${UPGRADE_AUTH_PROGRAMS}" ]; then
+            echo "UPGRADE_AUTH_PROGRAMS not set — nothing to check. Configure it to enable the gate."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Solana CLI
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      - name: Check upgrade authorities
+        if: steps.guard.outputs.run == 'true'
+        run: bash scripts/check-upgrade-authority.sh

--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ solana program set-upgrade-authority <PROGRAM_ID> --final
 
 The current deployment upgrade authority pubkey and governance process should be documented here by the maintainers.
 
+**Enforcement (#240):** this requirement is gated by
+[`scripts/check-upgrade-authority.sh`](scripts/check-upgrade-authority.sh) — it fails CI
+unless every checked program's authority is burned or held by an allowlisted governance
+multisig. Full runbook (transfer-to-Squads / burn / verify):
+[`docs/SECURITY-UPGRADE-AUTHORITY.md`](docs/SECURITY-UPGRADE-AUTHORITY.md). The opt-in
+[`upgrade-authority-gate`](.github/workflows/upgrade-authority-gate.yml) workflow runs it
+in CI once the `UPGRADE_AUTH_*` repo variables are configured.
+
 ## Related Repositories
 
 | Repository | Description |

--- a/scripts/check-upgrade-authority.sh
+++ b/scripts/check-upgrade-authority.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# #240 — Pre-mainnet upgrade-authority gate.
+#
+# A BPF program's upgrade authority can replace the program bytecode at will. On a
+# fund-custody program (this stake/insurance vault, the wrapper, etc.) a SINGLE-EOA
+# upgrade authority is a full-TVL-drain risk: one compromised key → malicious upgrade →
+# drain. A program CANNOT constrain its own deployer's key choice, so this is enforced
+# operationally: before mainnet use, every program's upgrade authority MUST be either
+#   (a) BURNED (immutable — deployed/last-upgraded with `--final`), or
+#   (b) held by an ALLOWLISTED governance multisig (e.g. a Squads vault PDA).
+#
+# This script is that gate. Run it in CI and as a manual pre-mainnet check. It exits
+# non-zero if ANY checked program's authority is neither burned nor allowlisted.
+#
+# Usage:
+#   scripts/check-upgrade-authority.sh \
+#     --cluster https://api.mainnet-beta.solana.com \
+#     --allow <GOVERNANCE_MULTISIG_AUTHORITY> [--allow <ANOTHER>] \
+#     --program <PROGRAM_ID> [--program <PROGRAM_ID> ...]
+#
+# Env fallbacks: SOLANA_CLUSTER, UPGRADE_AUTH_ALLOWLIST (comma-separated),
+#                UPGRADE_AUTH_PROGRAMS (comma-separated).
+#
+# Notes:
+#   * An EMPTY allowlist means the policy is "must be burned" (strictest).
+#   * The System Program id (all-1s) is treated as "no authority" (burned).
+#   * Requires the `solana` CLI on PATH.
+#
+set -euo pipefail
+
+CLUSTER="${SOLANA_CLUSTER:-https://api.mainnet-beta.solana.com}"
+ALLOW=()
+PROGRAMS=()
+
+# Seed from env (comma-separated) so CI can configure via secrets/vars.
+if [[ -n "${UPGRADE_AUTH_ALLOWLIST:-}" ]]; then
+  IFS=',' read -r -a _env_allow <<< "$UPGRADE_AUTH_ALLOWLIST"
+  ALLOW+=("${_env_allow[@]}")
+fi
+if [[ -n "${UPGRADE_AUTH_PROGRAMS:-}" ]]; then
+  IFS=',' read -r -a _env_progs <<< "$UPGRADE_AUTH_PROGRAMS"
+  PROGRAMS+=("${_env_progs[@]}")
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster) CLUSTER="$2"; shift 2;;
+    --allow)   ALLOW+=("$2"); shift 2;;
+    --program) PROGRAMS+=("$2"); shift 2;;
+    -h|--help) sed -n '2,40p' "$0"; exit 0;;
+    *) echo "unknown argument: $1" >&2; exit 2;;
+  esac
+done
+
+if [[ ${#PROGRAMS[@]} -eq 0 ]]; then
+  echo "error: no --program given (and UPGRADE_AUTH_PROGRAMS unset)" >&2
+  exit 2
+fi
+if ! command -v solana >/dev/null 2>&1; then
+  echo "error: solana CLI not found on PATH" >&2
+  exit 2
+fi
+
+SYSTEM_PROGRAM="11111111111111111111111111111111"
+fail=0
+
+echo "Upgrade-authority gate — cluster: $CLUSTER"
+if [[ ${#ALLOW[@]} -eq 0 ]]; then
+  echo "policy: authority MUST be burned (no governance allowlist provided)"
+else
+  echo "policy: authority must be burned OR one of: ${ALLOW[*]}"
+fi
+echo "------------------------------------------------------------------"
+
+for pid in "${PROGRAMS[@]}"; do
+  [[ -z "$pid" ]] && continue
+  out="$(solana program show --url "$CLUSTER" "$pid" 2>&1 || true)"
+
+  # Burned / immutable: solana reports the program as not upgradeable.
+  if printf '%s' "$out" | grep -qiE 'not upgradeable|is not upgradeable|immutable'; then
+    echo "PASS  $pid — immutable (upgrade authority burned)"
+    continue
+  fi
+
+  # Otherwise parse the "Authority: <pubkey>" line.
+  auth="$(printf '%s\n' "$out" | awk -F'Authority:' '/Authority:/{gsub(/[[:space:]]/,"",$2); print $2; exit}')"
+
+  if [[ -z "$auth" || "$auth" == "none" || "$auth" == "None" || "$auth" == "$SYSTEM_PROGRAM" ]]; then
+    echo "PASS  $pid — no upgrade authority (burned)"
+    continue
+  fi
+
+  ok=0
+  for a in "${ALLOW[@]:-}"; do
+    [[ -n "$a" && "$auth" == "$a" ]] && ok=1
+  done
+  if [[ $ok -eq 1 ]]; then
+    echo "PASS  $pid — authority $auth is an allowlisted governance signer"
+  else
+    echo "FAIL  $pid — upgrade authority $auth is NEITHER burned NOR allowlisted"
+    echo "        → single-EOA / unknown authority on a fund-custody program is a"
+    echo "          full-TVL-drain risk. Transfer to a Squads multisig or burn (--final)."
+    echo "          See docs/SECURITY-UPGRADE-AUTHORITY.md."
+    fail=1
+  fi
+done
+
+echo "------------------------------------------------------------------"
+if [[ $fail -eq 0 ]]; then
+  echo "OK — all checked programs satisfy the upgrade-authority policy."
+else
+  echo "BLOCKED — at least one program fails the upgrade-authority policy (#240)."
+fi
+exit $fail


### PR DESCRIPTION
A program can't constrain its own deployer's upgrade-authority key, so the single-EOA full-TVL-drain risk (#240) is mitigated operationally + by an enforced external gate (not in-program, which would brick the program and is redundant with publicly-readable ProgramData).

- **`scripts/check-upgrade-authority.sh`** — fails unless every checked program's upgrade authority is **burned** or an **allowlisted governance multisig**. Validated against a mocked `solana` CLI: multisig/burned/immutable → PASS; single-EOA/unknown → FAIL; empty allowlist ⇒ must-be-burned.
- **`docs/SECURITY-UPGRADE-AUTHORITY.md`** — runbook (transfer to Squads vault / burn with `--final` / verify) + rationale for not enforcing in-program.
- **`.github/workflows/upgrade-authority-gate.yml`** — opt-in (manual); no-ops until `UPGRADE_AUTH_*` repo vars are set, so it never blocks unrelated PRs.
- README Deployment Security section links the gate + runbook.

Accepts arbitrary program IDs → gates **all** percolator fund-custody programs. Operational finding: the gate must pass before mainnet (cutover gate). Refs #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)