### PR TITLE
feat(stake,#171): PDA-signed RecoverFlushedInsurance — unstrand flushed insurance post-burn

### DIFF
--- a/src/cpi.rs
+++ b/src/cpi.rs
@@ -388,6 +388,75 @@ pub fn cpi_rotate_insurance_authority<'a>(
     )
 }
 
+// ═══════════════════════════════════════════════════════════════
+// WithdrawInsuranceAsset (Tag 57) — PDA-signed insurance recovery
+// ═══════════════════════════════════════════════════════════════
+// Wire: [57u8][asset_index: u16 LE = 0][amount: u128 LE] = 19 bytes.
+// Account order (verified against tests/v17_stake_insurance_e2e.rs
+// withdraw_insurance_asset_ix and wrapper handle_withdraw_insurance_asset):
+//   [0] operator      (vault_auth PDA, signer via invoke_signed) — must == insurance_operator
+//   [1] market        (writable)
+//   [2] dest_token    (writable) — MUST equal pool.vault (drain check enforced by caller)
+//   [3] vault_token   (writable) — wrapper's insurance vault, the token source
+//   [4] vault_authority (read-only) — wrapper vault authority PDA
+//   [5] token_program  (read-only)
+//
+// AUTH: insurance_operator == vault_auth PDA (set by BindInsuranceAuthority tag 19 CPI 2).
+//   After BurnAssetAdmin, no admin key can rotate the operator back — so this CPI
+//   is the ONLY authorized path for extracting insurance tokens from the wrapper.
+//
+// MODE: tag 57 works in LIVE mode (same mode FlushToInsurance uses); the caller
+//   (process_recover_flushed_insurance) enforces LIVE mode via pool_mode == 0.
+//
+// NOTE: vault_auth PDA signs via invoke_signed with the same seeds as all other
+//   stake CPIs: [b"vault_auth", pool_pda.key, &[bump]].
+
+const TAG_WITHDRAW_INSURANCE_ASSET: u8 = 57;
+
+pub fn cpi_withdraw_insurance_asset<'a>(
+    percolator_program: &AccountInfo<'a>,
+    vault_auth: &AccountInfo<'a>,   // insurance_operator = our PDA; signs via invoke_signed
+    market: &AccountInfo<'a>,       // wrapper market / slab (writable)
+    dest_token: &AccountInfo<'a>,   // destination token account (MUST be pool.vault; drain check by caller)
+    wrapper_vault: &AccountInfo<'a>, // wrapper insurance vault token account (source)
+    wrapper_vault_auth: &AccountInfo<'a>, // wrapper vault authority PDA (read-only)
+    token_program: &AccountInfo<'a>,
+    amount: u64,
+    signer_seeds: &[&[u8]],
+) -> ProgramResult {
+    // tag(1) + asset_index(2, u16 LE = 0) + amount(16, u128 LE) = 19 bytes.
+    let mut data = Vec::with_capacity(19);
+    data.push(TAG_WITHDRAW_INSURANCE_ASSET);
+    data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // 2 bytes, always 0x00 0x00
+    data.extend_from_slice(&(amount as u128).to_le_bytes()); // 16 bytes u128 LE
+
+    let ix = Instruction {
+        program_id: *percolator_program.key,
+        accounts: vec![
+            AccountMeta::new_readonly(*vault_auth.key, true),      // operator (PDA), signer via invoke_signed
+            AccountMeta::new(*market.key, false),                   // market, writable
+            AccountMeta::new(*dest_token.key, false),               // dest_token (pool.vault), writable
+            AccountMeta::new(*wrapper_vault.key, false),            // vault_token (source), writable
+            AccountMeta::new_readonly(*wrapper_vault_auth.key, false), // vault_authority, read-only
+            AccountMeta::new_readonly(*token_program.key, false),  // token_program, read-only
+        ],
+        data,
+    };
+
+    invoke_signed(
+        &ix,
+        &[
+            vault_auth.clone(),
+            market.clone(),
+            dest_token.clone(),
+            wrapper_vault.clone(),
+            wrapper_vault_auth.clone(),
+            token_program.clone(),
+        ],
+        &[signer_seeds],
+    )
+}
+
 #[cfg(test)]
 mod tag_tests {
     use super::*;
@@ -540,5 +609,38 @@ mod tag_tests {
         assert_ne!(ASSET_AUTH_ADMIN, ASSET_AUTH_INSURANCE);
         assert_ne!(ASSET_AUTH_ADMIN, ASSET_AUTH_INSURANCE_OPERATOR);
         assert_ne!(ASSET_AUTH_INSURANCE, ASSET_AUTH_INSURANCE_OPERATOR);
+    }
+
+    /// CANARY: pin the WithdrawInsuranceAsset (tag 57) wire shape =
+    /// tag(57) + asset_index(2, u16 LE = 0) + amount(16, u128 LE) = 19 bytes.
+    ///
+    /// Verified against:
+    ///   - tests/v17_stake_insurance_e2e.rs encode_withdraw_insurance_asset()
+    ///   - spec: "Wire: [57u8][asset_index: u16 LE = 0][amount: u128 LE] (= 19 bytes)"
+    ///
+    /// The amount is ALWAYS widened to u128 on the wire (matching the tag-9
+    /// TopUpInsurance convention from v16 read_u128). Narrowing back to u64
+    /// would cause the wrapper to reject the CPI with InvalidInstructionData.
+    #[test]
+    fn test_cpi_withdraw_insurance_asset_wire_shape() {
+        let amount: u64 = 250_000;
+        let mut data = Vec::with_capacity(19);
+        data.push(TAG_WITHDRAW_INSURANCE_ASSET);               // byte 0: tag = 57
+        data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // bytes 1-2: asset_index = 0
+        data.extend_from_slice(&(amount as u128).to_le_bytes()); // bytes 3-18: amount u128 LE
+
+        assert_eq!(data.len(), 19, "tag-57 wire must be 19 bytes");
+        assert_eq!(data[0], 57, "tag must be 57 (WithdrawInsuranceAsset)");
+        assert_eq!(data[1], 0x00, "asset_index low byte must be 0");
+        assert_eq!(data[2], 0x00, "asset_index high byte must be 0");
+
+        // Amount occupies bytes [3..19] as u128 LE.
+        let decoded = u128::from_le_bytes(data[3..19].try_into().unwrap());
+        assert_eq!(decoded, amount as u128, "amount round-trips as u128 LE");
+
+        // Guard: must NOT be the 9-byte u64 wire (would be rejected by wrapper read_u128).
+        assert_ne!(data.len(), 9, "9-byte u64 wire would be rejected by wrapper");
+        // Guard: tag 57, not tag 9 (TopUpInsurance) — different directions.
+        assert_ne!(data[0], TAG_TOP_UP_INSURANCE, "must be tag 57, not tag 9");
     }
 }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -148,6 +148,40 @@ pub enum StakeInstruction {
     ///   5. `[]` Percolator program
     RotateInsuranceOperator,
 
+    /// 23: RecoverFlushedInsurance — PDA-signed permissionless recovery of
+    /// tokens from the wrapper's insurance fund back to the stake pool vault.
+    ///
+    /// After BurnAssetAdmin (tag 21) the admin cannot rotate the insurance_operator
+    /// back to any key it controls, making the stake program the sole path for
+    /// moving insurance tokens out of the wrapper. This instruction issues a CPI
+    /// to wrapper tag 57 `WithdrawInsuranceAsset` — which gates on
+    /// insurance_operator == operator (the vault_auth PDA, set by
+    /// BindInsuranceAuthority tag 19) — and deposits the tokens directly into
+    /// pool.vault. `pool.total_returned` is incremented by `amount` on success,
+    /// maintaining the conservation invariant total_returned <= total_flushed.
+    ///
+    /// PERMISSIONLESS: any caller may trigger recovery; funds can only land in
+    /// pool.vault (the DRAIN CHECK below guarantees this). This survives
+    /// BurnAssetAdmin because tag 57 gates on insurance_operator, not asset_admin.
+    ///
+    /// DRAIN CHECK: the CPI dest_token is verified to equal pool.vault BEFORE
+    /// the CPI is issued, preventing any redirection of recovered tokens.
+    ///
+    /// CAP: `amount` must be non-zero and <= (total_flushed - total_returned);
+    /// the instruction early-rejects if outstanding == 0 (nothing to recover).
+    ///
+    /// Accounts:
+    ///   0. `[]` Caller (permissionless — no signer check required)
+    ///   1. `[writable]` Pool PDA
+    ///   2. `[writable]` Pool vault token account (destination = pool.vault)
+    ///   3. `[]` Vault authority PDA (the insurance_operator; signs via invoke_signed)
+    ///   4. `[writable]` Wrapper market account (the slab)
+    ///   5. `[writable]` Wrapper vault token account (source, insurance fund)
+    ///   6. `[]` Wrapper vault authority PDA
+    ///   7. `[]` Token program
+    ///   8. `[]` Percolator program
+    RecoverFlushedInsurance { amount: u64 },
+
     /// 4: Admin updates pool configuration.
     ///
     /// Accounts:
@@ -417,6 +451,17 @@ impl StakeInstruction {
                 }
                 Ok(Self::RotateInsuranceOperator)
             }
+            23 => {
+                if rest.len() != 8 {
+                    return Err(ProgramError::InvalidInstructionData);
+                }
+                let amount = u64::from_le_bytes(
+                    rest[0..8]
+                        .try_into()
+                        .map_err(|_| ProgramError::InvalidInstructionData)?,
+                );
+                Ok(Self::RecoverFlushedInsurance { amount })
+            }
             10 => {
                 if rest.len() != 8 {
                     return Err(ProgramError::InvalidInstructionData);
@@ -683,6 +728,7 @@ mod tests {
             (14, 3),
             (15, 2),
             (16, 8),
+            (23, 8),
         ];
         for &(tag, need) in cases {
             for short_len in 0..need {
@@ -765,6 +811,12 @@ mod tests {
                 payload.push(99);
                 payload
             }, "DepositJunior"),
+            (23, {
+                let mut payload = Vec::new();
+                payload.extend_from_slice(&42u64.to_le_bytes());
+                payload.push(99);
+                payload
+            }, "RecoverFlushedInsurance"),
         ];
 
         for (tag, payload, name) in cases {
@@ -792,5 +844,58 @@ mod tests {
                 tag
             );
         }
+    }
+
+    /// Tag 23 RecoverFlushedInsurance: round-trip pack/unpack.
+    #[test]
+    fn test_unpack_recover_flushed_insurance_round_trip() {
+        let amount: u64 = 123_456_789;
+        let mut data = vec![23u8];
+        data.extend_from_slice(&amount.to_le_bytes());
+        assert_eq!(data.len(), 9, "tag 23 payload must be 1 tag + 8 amount bytes");
+        match StakeInstruction::unpack(&data).unwrap() {
+            StakeInstruction::RecoverFlushedInsurance { amount: got } => {
+                assert_eq!(got, amount, "amount round-trips correctly")
+            }
+            _ => panic!("wrong variant"),
+        }
+        // u64::MAX round-trips
+        let mut data_max = vec![23u8];
+        data_max.extend_from_slice(&u64::MAX.to_le_bytes());
+        match StakeInstruction::unpack(&data_max).unwrap() {
+            StakeInstruction::RecoverFlushedInsurance { amount: got } => {
+                assert_eq!(got, u64::MAX)
+            }
+            _ => panic!("wrong variant for u64::MAX"),
+        }
+    }
+
+    /// Tag 23 must reject a short payload (any length < 8 bytes after the tag).
+    #[test]
+    fn test_unpack_recover_flushed_insurance_short_payload_rejected() {
+        for short_len in 0u8..8 {
+            let mut data = vec![23u8];
+            data.extend(std::iter::repeat(0u8).take(short_len as usize));
+            assert!(
+                StakeInstruction::unpack(&data).is_err(),
+                "tag 23 with {} payload bytes must Err",
+                short_len
+            );
+        }
+    }
+
+    /// Tag 23 must reject trailing bytes beyond the required 8-byte payload.
+    #[test]
+    fn test_unpack_recover_flushed_insurance_trailing_bytes_rejected() {
+        let mut data = vec![23u8];
+        data.extend_from_slice(&1u64.to_le_bytes());
+        data.push(99u8); // trailing byte
+        assert!(
+            matches!(
+                StakeInstruction::unpack(&data),
+                Err(ProgramError::InvalidInstructionData)
+            ),
+            "tag 23 with trailing bytes must reject"
+        );
     }
 }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -384,6 +384,9 @@ pub fn process(
         StakeInstruction::ReturnInsurance { amount } => {
             process_return_insurance(program_id, accounts, amount)
         }
+        StakeInstruction::RecoverFlushedInsurance { amount } => {
+            process_recover_flushed_insurance(program_id, accounts, amount)
+        }
         StakeInstruction::AccrueFees => process_accrue_fees(program_id, accounts),
         StakeInstruction::InitTradingPool {
             cooldown_slots,
@@ -3128,6 +3131,148 @@ fn process_return_insurance(
 
     msg!(
         "ReturnInsurance: {} tokens returned to pool vault (total_returned: {})",
+        amount,
+        pool.total_returned
+    );
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// 23: RecoverFlushedInsurance — PDA-signed insurance recovery
+// ═══════════════════════════════════════════════════════════════
+//
+// Issues a CPI to wrapper tag 57 `WithdrawInsuranceAsset`, signing as the
+// vault_auth PDA (which is the insurance_operator after BindInsuranceAuthority).
+// Tokens flow from the wrapper insurance vault into pool.vault directly.
+//
+// PERMISSIONLESS: no admin gate. Funds can only reach pool.vault (the DRAIN
+// CHECK below guarantees this), so any caller can trigger recovery.
+//
+// CONSERVATION: on success `pool.total_returned += amount` (post-CPI, so
+// the accounting update only happens when tokens actually moved).
+//
+// Accounts:
+//   0. `[]`          Caller (permissionless)
+//   1. `[writable]`  Pool PDA
+//   2. `[writable]`  Pool vault token account (dest; must equal pool.vault)
+//   3. `[]`          Vault authority PDA (signs the CPI as insurance_operator)
+//   4. `[writable]`  Wrapper market account
+//   5. `[writable]`  Wrapper vault token account (insurance source)
+//   6. `[]`          Wrapper vault authority PDA
+//   7. `[]`          Token program
+//   8. `[]`          Percolator program
+
+fn process_recover_flushed_insurance(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    amount: u64,
+) -> ProgramResult {
+    let accounts_iter = &mut accounts.iter();
+
+    let _caller = next_account_info(accounts_iter)?;       // 0: permissionless caller
+    let pool_pda = next_account_info(accounts_iter)?;      // 1: pool PDA (writable)
+    let vault = next_account_info(accounts_iter)?;         // 2: pool vault (dest; writable)
+    let vault_auth = next_account_info(accounts_iter)?;    // 3: vault_auth PDA (signer for CPI)
+    let market = next_account_info(accounts_iter)?;        // 4: wrapper market (writable)
+    let wrapper_vault = next_account_info(accounts_iter)?; // 5: wrapper insurance vault (source)
+    let wrapper_vault_auth = next_account_info(accounts_iter)?; // 6: wrapper vault auth
+    let token_program = next_account_info(accounts_iter)?; // 7: token program
+    let percolator_program = next_account_info(accounts_iter)?; // 8: wrapper program
+
+    // Standard guards — mirror process_flush_to_insurance / process_return_insurance.
+    verify_token_program(token_program)?;
+    validate_account_owner(pool_pda, program_id)?;
+    validate_account_not_empty(pool_pda)?;
+    validate_account_writable(pool_pda)?;
+
+    let mut pool_data = pool_pda.try_borrow_mut_data()?;
+    let pool = pool_from_data_mut(&mut pool_data[..])?;
+
+    if pool.is_initialized != 1 {
+        return Err(StakeError::NotInitialized.into());
+    }
+    if !pool.validate_discriminator() {
+        return Err(StakeError::InvalidAccount.into());
+    }
+    validate_pool_version(pool)?;
+
+    // Insurance LP pools only (pool_mode == 0). Mirror FlushToInsurance and ReturnInsurance.
+    if pool.pool_mode != 0 {
+        msg!("RecoverFlushedInsurance: not valid for trading LP pools (mode 1)");
+        return Err(StakeError::InvalidPoolMode.into());
+    }
+
+    // Amount must be non-zero.
+    if amount == 0 {
+        return Err(StakeError::ZeroAmount.into());
+    }
+
+    // CAP: amount must not exceed outstanding = total_flushed - total_returned.
+    // Use saturating_sub so a stale / already-fully-returned pool yields 0 outstanding.
+    let outstanding = pool.total_flushed.saturating_sub(pool.total_returned);
+    if outstanding == 0 {
+        msg!(
+            "RecoverFlushedInsurance: nothing to recover (total_flushed={} total_returned={})",
+            pool.total_flushed,
+            pool.total_returned
+        );
+        return Err(StakeError::InsufficientVaultBalance.into());
+    }
+    if (amount as u128) > (outstanding as u128) {
+        msg!(
+            "RecoverFlushedInsurance: amount {} exceeds outstanding {}",
+            amount,
+            outstanding
+        );
+        return Err(StakeError::InsufficientVaultBalance.into());
+    }
+
+    // Wrapper program must match pool.percolator_program.
+    if pool.percolator_program != percolator_program.key.to_bytes() {
+        return Err(StakeError::InvalidPercolatorProgram.into());
+    }
+
+    // DRAIN CHECK: the CPI destination MUST be pool.vault.
+    // This prevents any caller from redirecting recovered tokens to an attacker-controlled
+    // account. Mirror process_return_insurance's `pool.vault != vault.key` guard.
+    if pool.vault != vault.key.to_bytes() {
+        return Err(StakeError::InvalidPda.into());
+    }
+
+    // Derive vault authority PDA and verify it matches the passed account.
+    let (expected_vault_auth, vault_auth_bump) =
+        state::derive_vault_authority(program_id, pool_pda.key);
+    if *vault_auth.key != expected_vault_auth {
+        return Err(StakeError::InvalidPda.into());
+    }
+
+    let vault_auth_seeds: &[&[u8]] = &[b"vault_auth", pool_pda.key.as_ref(), &[vault_auth_bump]];
+
+    // CPI: WithdrawInsuranceAsset (wrapper tag 57).
+    // vault_auth PDA signs as insurance_operator (set by BindInsuranceAuthority tag 19).
+    // Tokens flow: wrapper_vault → vault (= pool.vault). The drain check above ensures
+    // vault == pool.vault so tokens can only land in the stake pool's own vault.
+    cpi::cpi_withdraw_insurance_asset(
+        percolator_program,
+        vault_auth,
+        market,
+        vault,         // dest_token = pool.vault (drain-check-verified above)
+        wrapper_vault, // source = wrapper insurance vault
+        wrapper_vault_auth,
+        token_program,
+        amount,
+        vault_auth_seeds,
+    )?;
+
+    // CONSERVATION: total_returned += amount. Update AFTER the CPI so the accounting
+    // only advances when the token movement actually succeeded.
+    pool.total_returned = pool
+        .total_returned
+        .checked_add(amount)
+        .ok_or(StakeError::Overflow)?;
+
+    msg!(
+        "RecoverFlushedInsurance: {} tokens recovered to pool vault (total_returned: {})",
         amount,
         pool.total_returned
     );

--- a/tests/v17_stake_insurance_e2e.rs
+++ b/tests/v17_stake_insurance_e2e.rs
@@ -464,6 +464,49 @@ fn rotate_operator_stake_ix(
     }
 }
 
+/// RecoverFlushedInsurance (stake tag 23): PDA-signed recovery of wrapper insurance to pool vault.
+///
+/// Accounts:
+///   0. `[]`          caller (permissionless)
+///   1. `[writable]`  pool PDA
+///   2. `[writable]`  pool vault token account (dest = pool.vault)
+///   3. `[]`          vault_auth PDA (signs as insurance_operator)
+///   4. `[writable]`  wrapper market account
+///   5. `[writable]`  wrapper vault token account (insurance source)
+///   6. `[]`          wrapper vault authority PDA
+///   7. `[]`          token program
+///   8. `[]`          percolator program
+///
+/// Wire: [23u8][amount: u64 LE] = 9 bytes
+fn recover_flushed_insurance_ix(
+    ctx: &PoolCtx,
+    wrapper_id: Pubkey,
+    token_program: Pubkey,
+    market: Pubkey,
+    wrapper_vault: Pubkey,
+    wrapper_vault_auth: Pubkey,
+    caller: &Pubkey,
+    amount: u64,
+) -> Instruction {
+    let mut data = vec![23u8];
+    data.extend_from_slice(&amount.to_le_bytes());
+    Instruction {
+        program_id: ctx.stake_id,
+        accounts: vec![
+            AccountMeta::new_readonly(*caller, false),            // 0: caller (permissionless)
+            AccountMeta::new(ctx.pool_pda, false),                // 1: pool PDA (writable)
+            AccountMeta::new(ctx.stake_vault, false),             // 2: pool vault (dest; writable)
+            AccountMeta::new_readonly(ctx.vault_auth, false),     // 3: vault_auth PDA
+            AccountMeta::new(market, false),                      // 4: wrapper market (writable)
+            AccountMeta::new(wrapper_vault, false),               // 5: wrapper vault (source; writable)
+            AccountMeta::new_readonly(wrapper_vault_auth, false), // 6: wrapper vault auth
+            AccountMeta::new_readonly(token_program, false),      // 7: token program
+            AccountMeta::new_readonly(wrapper_id, false),         // 8: percolator program
+        ],
+        data,
+    }
+}
+
 /// Rotate insurance_operator (kind=2) directly via tag 65 on the wrapper.
 /// Used in the RED control test (bypasses the stake program to exercise the direct
 /// wrapper path, proving the auth gate is open before secure bind).
@@ -1338,4 +1381,356 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
         40_000 + 25_000,
         "flush B applied — the bind is NOT a permanent weld"
     );
+}
+
+// ── RECOVER FLUSHED INSURANCE (issue #171) ────────────────────────────────────
+//
+// Scenario 1 (happy path + post-burn survival):
+//   bind → flush → simulate BurnAssetAdmin (zero admin field in market) →
+//   RecoverFlushedInsurance → tokens return to pool.vault, total_returned incremented.
+//
+// Scenario 2 (negative: dest != pool.vault rejected before CPI):
+//   attempt recovery with wrong dest_token account → rejected (InvalidPda)
+//   before the CPI fires.
+//
+// Scenario 3 (negative: nothing flushed → rejected):
+//   fresh pool with no flush → RecoverFlushedInsurance with amount=1 → rejected
+//   (InsufficientVaultBalance).
+//
+// Scenario 4 (negative: non-PDA cannot redirect funds):
+//   after bind+flush, an attacker passes their own token account as the dest →
+//   rejected at the DRAIN CHECK (dest != pool.vault) before any CPI.
+
+/// HAPPY PATH: bind → flush → BurnAssetAdmin → RecoverFlushedInsurance.
+/// Proves recovery works AFTER the irreversible burn (no admin can rotate back),
+/// pool.total_returned increases, and tokens land in pool.vault.
+#[test]
+fn recover_flushed_insurance_after_burn() {
+    let mut svm = LiteSVM::new().with_spl_programs();
+    let stake_id = Pubkey::from_str(STAKE_ID).unwrap();
+    let wrapper_id = Pubkey::from_str(WRAPPER_MAINNET).unwrap();
+    let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
+    svm.add_program_from_file(stake_id, stake_so()).unwrap();
+    svm.add_program_from_file(wrapper_id, wrapper_so()).unwrap();
+
+    let admin = Keypair::new();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 200_000_000_000).unwrap();
+    svm.airdrop(&admin.pubkey(), 20_000_000_000).unwrap();
+
+    let (market, mint, wrapper_vault) =
+        build_live_market_v17(&mut svm, wrapper_id, token_program, &admin, &payer);
+
+    let pool = add_stake_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        mint,
+        &admin.pubkey(),
+        FLUSH_AMOUNT,
+    );
+
+    let wrapper_vault_auth =
+        Pubkey::find_program_address(&[b"vault", market.as_ref()], &wrapper_id).0;
+
+    // Step 1: bind (authority + operator → PDA).
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        bind_ix(&pool, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("BindInsuranceAuthority (tag 65 CPI 1+2)");
+
+    // Step 2: flush insurance into wrapper vault.
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        flush_ix(
+            &pool,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            &admin.pubkey(),
+            FLUSH_AMOUNT,
+        ),
+    )
+    .expect("FlushToInsurance");
+
+    assert_eq!(
+        token_amount(&svm, &pool.stake_vault),
+        0,
+        "stake vault drained by flush"
+    );
+    assert_eq!(
+        token_amount(&svm, &wrapper_vault),
+        FLUSH_AMOUNT,
+        "wrapper vault received flush"
+    );
+
+    // Step 3: BurnAssetAdmin — irrevocably removes admin rotate-back capability.
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        burn_asset_admin_ix(&pool, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("BurnAssetAdmin (tag 65 kind=0 burn)");
+
+    // Verify admin can no longer rotate insurance_authority back (post-burn gate).
+    svm.expire_blockhash();
+    let err_rotate_after_burn = send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        rotate_ix(&pool, wrapper_id, market, &admin.pubkey(), &admin.pubkey()),
+    )
+    .expect_err("post-burn rotate-back must be rejected by stake");
+    assert!(
+        matches!(
+            err_rotate_after_burn,
+            TransactionError::InstructionError(_, InstructionError::Custom(code))
+                if code == StakeError::Unauthorized as u32
+        ),
+        "expected stake Unauthorized=2 (post-burn rotate blocked), got {err_rotate_after_burn:?}"
+    );
+
+    // Step 4: RecoverFlushedInsurance — PDA-signed, permissionless caller (use payer).
+    // Reads pool.total_returned before to verify accounting increment.
+    let pool_account_before = svm.get_account(&pool.pool_pda).unwrap();
+    let pool_state_before =
+        bytemuck::try_from_bytes::<percolator_stake::state::StakePool>(
+            &pool_account_before.data[..percolator_stake::state::STAKE_POOL_SIZE],
+        )
+        .unwrap();
+    let total_returned_before = pool_state_before.total_returned;
+
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[],                   // permissionless — payer signs only as fee payer
+        recover_flushed_insurance_ix(
+            &pool,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            wrapper_vault_auth,
+            &payer.pubkey(),   // caller (permissionless, not admin)
+            FLUSH_AMOUNT,
+        ),
+    )
+    .expect("RecoverFlushedInsurance (tag 23 CPI)");
+
+    // Assert: tokens back in pool.vault.
+    assert_eq!(
+        token_amount(&svm, &pool.stake_vault),
+        FLUSH_AMOUNT,
+        "recovered tokens land in pool.vault"
+    );
+    assert_eq!(
+        token_amount(&svm, &wrapper_vault),
+        0,
+        "wrapper vault fully drained by recovery"
+    );
+
+    // Assert: pool.total_returned incremented by FLUSH_AMOUNT.
+    let pool_account_after = svm.get_account(&pool.pool_pda).unwrap();
+    let pool_state_after =
+        bytemuck::try_from_bytes::<percolator_stake::state::StakePool>(
+            &pool_account_after.data[..percolator_stake::state::STAKE_POOL_SIZE],
+        )
+        .unwrap();
+    assert_eq!(
+        pool_state_after.total_returned,
+        total_returned_before
+            .checked_add(FLUSH_AMOUNT)
+            .unwrap(),
+        "total_returned incremented by FLUSH_AMOUNT (conservation)"
+    );
+}
+
+/// NEGATIVE: wrong dest_token (not pool.vault) is rejected BEFORE any CPI.
+/// Proves drain-vector is closed at the stake processor level, not the wrapper.
+#[test]
+fn recover_flushed_insurance_wrong_dest_rejected() {
+    let mut svm = LiteSVM::new().with_spl_programs();
+    let stake_id = Pubkey::from_str(STAKE_ID).unwrap();
+    let wrapper_id = Pubkey::from_str(WRAPPER_MAINNET).unwrap();
+    let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
+    svm.add_program_from_file(stake_id, stake_so()).unwrap();
+    svm.add_program_from_file(wrapper_id, wrapper_so()).unwrap();
+
+    let admin = Keypair::new();
+    let payer = Keypair::new();
+    let attacker = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 200_000_000_000).unwrap();
+    svm.airdrop(&admin.pubkey(), 20_000_000_000).unwrap();
+
+    let (market, mint, wrapper_vault) =
+        build_live_market_v17(&mut svm, wrapper_id, token_program, &admin, &payer);
+
+    let pool = add_stake_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        mint,
+        &admin.pubkey(),
+        FLUSH_AMOUNT,
+    );
+
+    let wrapper_vault_auth =
+        Pubkey::find_program_address(&[b"vault", market.as_ref()], &wrapper_id).0;
+
+    // Bind and flush to set up state.
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        bind_ix(&pool, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("bind");
+
+    svm.expire_blockhash();
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        flush_ix(
+            &pool,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            &admin.pubkey(),
+            FLUSH_AMOUNT,
+        ),
+    )
+    .expect("flush");
+
+    // Attacker tries to redirect recovered tokens to their own account.
+    let attacker_dest = Pubkey::new_unique();
+    set_token_account(&mut svm, attacker_dest, &mint, &attacker.pubkey(), 0);
+
+    svm.expire_blockhash();
+    let err = {
+        // Build the ix manually with attacker_dest as account [2] instead of pool.stake_vault.
+        let mut data = vec![23u8];
+        data.extend_from_slice(&FLUSH_AMOUNT.to_le_bytes());
+        let ix = Instruction {
+            program_id: stake_id,
+            accounts: vec![
+                AccountMeta::new_readonly(payer.pubkey(), false),    // 0: caller
+                AccountMeta::new(pool.pool_pda, false),              // 1: pool PDA
+                AccountMeta::new(attacker_dest, false),              // 2: WRONG dest (not pool.vault)
+                AccountMeta::new_readonly(pool.vault_auth, false),   // 3: vault_auth PDA
+                AccountMeta::new(market, false),                     // 4: market
+                AccountMeta::new(wrapper_vault, false),              // 5: wrapper vault
+                AccountMeta::new_readonly(wrapper_vault_auth, false),// 6: wrapper vault auth
+                AccountMeta::new_readonly(token_program, false),     // 7: token program
+                AccountMeta::new_readonly(wrapper_id, false),        // 8: percolator program
+            ],
+            data,
+        };
+        send(&mut svm, &payer, &[], ix)
+    }
+    .expect_err("wrong dest must be rejected before CPI");
+
+    // Must be InvalidPda (stake error 10), NOT a wrapper error (which would mean the
+    // drain check fired TOO LATE — after the CPI ran on the wrapper).
+    match err {
+        TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
+            assert_eq!(
+                code,
+                StakeError::InvalidPda as u32,
+                "must be InvalidPda=10 (drain check), not a wrapper error. got code={code}"
+            );
+        }
+        other => panic!("expected Custom(InvalidPda=10), got {other:?}"),
+    }
+    // No tokens moved.
+    assert_eq!(token_amount(&svm, &attacker_dest), 0, "no drain to attacker_dest");
+    assert_eq!(
+        token_amount(&svm, &wrapper_vault),
+        FLUSH_AMOUNT,
+        "wrapper vault unchanged — drain blocked"
+    );
+}
+
+/// NEGATIVE: nothing flushed → InsufficientVaultBalance.
+#[test]
+fn recover_flushed_insurance_nothing_flushed_rejected() {
+    let mut svm = LiteSVM::new().with_spl_programs();
+    let stake_id = Pubkey::from_str(STAKE_ID).unwrap();
+    let wrapper_id = Pubkey::from_str(WRAPPER_MAINNET).unwrap();
+    let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
+    svm.add_program_from_file(stake_id, stake_so()).unwrap();
+    svm.add_program_from_file(wrapper_id, wrapper_so()).unwrap();
+
+    let admin = Keypair::new();
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 200_000_000_000).unwrap();
+    svm.airdrop(&admin.pubkey(), 20_000_000_000).unwrap();
+
+    let (market, mint, wrapper_vault) =
+        build_live_market_v17(&mut svm, wrapper_id, token_program, &admin, &payer);
+
+    let pool = add_stake_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        mint,
+        &admin.pubkey(),
+        FLUSH_AMOUNT,
+    );
+
+    let wrapper_vault_auth =
+        Pubkey::find_program_address(&[b"vault", market.as_ref()], &wrapper_id).0;
+
+    // Bind so the PDA is set up, but do NOT flush.
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        bind_ix(&pool, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("bind");
+
+    // total_flushed == 0 == total_returned → outstanding == 0 → InsufficientVaultBalance.
+    svm.expire_blockhash();
+    let err = send(
+        &mut svm,
+        &payer,
+        &[],
+        recover_flushed_insurance_ix(
+            &pool,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            wrapper_vault_auth,
+            &payer.pubkey(),
+            1,
+        ),
+    )
+    .expect_err("recover with nothing flushed must be rejected");
+
+    match err {
+        TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
+            assert_eq!(
+                code,
+                StakeError::InsufficientVaultBalance as u32,
+                "expected InsufficientVaultBalance=13, got code={code}"
+            );
+        }
+        other => panic!("expected Custom(InsufficientVaultBalance=13), got {other:?}"),
+    }
 }


### PR DESCRIPTION
Per your decision (PDA-signed recovery CPI). The secure-bind wind-down stranded flushed insurance: post-BurnAssetAdmin only the bound vault_auth PDA could withdraw it, but no stake instruction did a PDA-signed withdraw → recovery needed a non-obvious rotate-back that the burn blocks.

**RecoverFlushedInsurance (tag 23, permissionless)** invoke_signed's the vault_auth PDA to call the wrapper's WithdrawInsuranceAsset (tag 57, asset 0 — auth = insurance_operator = the PDA), pulling flushed insurance back into the **stake vault**; `total_returned += amount`.

**Security (verified from multiple standpoints + e2e, re-run independently):**
- **Drain** — `pool.vault == vault.key` checked *before* the CPI; recovered tokens can only land in the pool vault (non-pool dest → InvalidPda). Permissionless is safe since funds can't reach the caller.
- **Post-burn** — tag 57 gates on insurance_operator (kind 2); BurnAssetAdmin (kind 0) never touches it → recovery works after the irreversible burn, no rotate-back (proven by `recover_flushed_insurance_after_burn`).
- **Conservation** — cap `amount <= total_flushed − total_returned` keeps `returned <= flushed`.

build-sbf clean (both programs); 142 lib + 10 v17 cross-program e2e + 67 unit + 46 integration, 0 failures. NOTE: a prior attempt on a stale local clone was discarded (wrong tags); this is a clean fresh-main implementation, verified line-by-line. Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to recover flushed insurance assets back to the pool vault through a new permissionless instruction.

* **Tests**
  * Added end-to-end tests validating insurance recovery behavior, including success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->