### PR TITLE
fix(stake): promote cooldown-timelock fields out of colliding _reserved bytes

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -101,8 +101,9 @@ const MAX_COOLDOWN_SLOTS: u64 = 78_840_000;
 /// UpdateConfig tx and lock LP withdrawals. That increase is now IMPLEMENTED as a
 /// two-phase timelock — ProposeCooldownIncrease (tag 7) records the pending value and
 /// proposal slot in StakePool (`pending_cooldown_slots` / `cooldown_proposed_at_slot`,
-/// stored in the previously-free `_reserved[10..26]` — no struct-size change / version
-/// bump), and CommitCooldownIncrease (tag 8) applies it only after TIMELOCK_SLOTS have
+/// real struct fields as of #250/#258 (the original packing aliased the PERC-313 HWM
+/// fields that already own that byte range; see the state.rs doc comments),
+/// and CommitCooldownIncrease (tag 8) applies it only after TIMELOCK_SLOTS have
 /// elapsed, giving LP holders a guaranteed ≥48h exit window. CancelCooldownIncrease
 /// (tag 9) withdraws a pending proposal. UpdateConfig now REJECTS a cooldown increase
 /// (`CooldownIncreaseRequiresTimelock`); decreases (LP-friendly) and `deposit_cap`
@@ -3382,13 +3383,21 @@ mod tests {
 
     #[test]
     fn pending_cooldown_bytes_do_not_collide_with_neighbors() {
-        // _reserved[10..26] must not disturb the discriminator/version[0..9],
-        // market_resolved[9], tranche[32+], or realized_junior_loss[51..59].
+        // #250/#258: pending_cooldown_slots/cooldown_proposed_at_slot are now real
+        // struct fields, not packed into _reserved[10..26] — so they can no longer
+        // collide with the discriminator/version[0..9], market_resolved[9],
+        // tranche[32+], realized_junior_loss[51..59], OR (the gap the original
+        // version of this test missed) the PERC-313 HWM fields, which actually
+        // own _reserved[10..32].
         let mut pool = StakePool::zeroed();
         pool.set_discriminator();
         pool.set_market_resolved(true);
         pool.set_realized_junior_loss(7_777);
         pool.set_tranche_enabled(true);
+        pool.set_hwm_enabled(true);
+        pool.set_hwm_floor_bps(5_000);
+        pool.set_epoch_high_water_tvl(1_000_000);
+        pool.set_hwm_last_epoch(10);
         pool.set_pending_cooldown_slots(u64::MAX);
         pool.set_cooldown_proposed_at_slot(123);
         assert!(pool.validate_discriminator());
@@ -3398,6 +3407,12 @@ mod tests {
         assert_eq!(pool.realized_junior_loss(), 7_777);
         assert_eq!(pool.pending_cooldown_slots(), u64::MAX);
         assert_eq!(pool.cooldown_proposed_at_slot(), 123);
+        // The fields the original test never checked against — these are exactly
+        // what #250/#258 showed getting corrupted under the old _reserved packing.
+        assert!(pool.hwm_enabled());
+        assert_eq!(pool.hwm_floor_bps(), 5_000);
+        assert_eq!(pool.epoch_high_water_tvl(), 1_000_000);
+        assert_eq!(pool.hwm_last_epoch(), 10);
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -129,9 +129,13 @@ pub struct StakePool {
     /// a real field rather than packed into `_reserved`.
     pub cooldown_proposed_at_slot: u64,
 
-    /// Reserved for future use. Bytes [10..26] are no longer written by the
-    /// cooldown timelock (see `pending_cooldown_slots`/`cooldown_proposed_at_slot`
-    /// above) and are genuinely free again.
+    /// Reserved for future use. Bytes [10..32] are still owned by the PERC-313
+    /// HWM fields (`hwm_enabled` at [10], `hwm_floor_bps` at [11..13],
+    /// `epoch_high_water_tvl` at [16..24], `hwm_last_epoch` at [24..32]) — that
+    /// ownership is unchanged by this fix. What changed is that the cooldown
+    /// timelock no longer ALSO writes into that range (see
+    /// `pending_cooldown_slots`/`cooldown_proposed_at_slot` above, now real
+    /// fields outside `_reserved` entirely).
     pub _reserved: [u8; 64],
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -109,7 +109,29 @@ pub struct StakePool {
     /// Fresh-start cutover: no v1 pools exist, so no migration is needed.
     pub pending_admin: [u8; 32],
 
-    /// Reserved for future use
+    /// #242/#250/#258 timelock (v3): the `cooldown_slots` INCREASE awaiting commit.
+    /// Meaningful only while `cooldown_proposed_at_slot != 0`.
+    ///
+    /// This is a real struct field, NOT carved from `_reserved`: the original
+    /// #242 PR packed this into `_reserved[10..18]`, believing `[10..32]` was
+    /// "previously-free" — but PERC-313 HWM already owns that entire range
+    /// (`hwm_enabled` at [10], `hwm_floor_bps` at [11..13], `epoch_high_water_tvl`
+    /// at [16..24], `hwm_last_epoch` at [24..32]). Every cooldown-timelock write
+    /// silently corrupted HWM state and vice versa. Promoting both timelock
+    /// fields to real fields removes the collision entirely; adding them grows
+    /// STAKE_POOL_SIZE 384 -> 400 and is why CURRENT_VERSION bumps 2 -> 3.
+    /// Fresh-start cutover: no v2 pools exist, so no migration is needed.
+    pub pending_cooldown_slots: u64,
+
+    /// #242/#250/#258 timelock (v3): the slot at which the pending cooldown
+    /// increase was proposed. `0` = no active proposal (the sentinel; a live
+    /// mainnet slot is never 0). See [`pending_cooldown_slots`] for why this is
+    /// a real field rather than packed into `_reserved`.
+    pub cooldown_proposed_at_slot: u64,
+
+    /// Reserved for future use. Bytes [10..26] are no longer written by the
+    /// cooldown timelock (see `pending_cooldown_slots`/`cooldown_proposed_at_slot`
+    /// above) and are genuinely free again.
     pub _reserved: [u8; 64],
 }
 
@@ -336,34 +358,30 @@ impl StakePool {
         self._reserved[59] = if burned { 1 } else { 0 };
     }
 
-    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Stored at
-    /// `_reserved[10..18]` (LE u64), in the previously-free `[10..32]` region — no
-    /// struct-size change, no version bump. Meaningful only while
+    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Real struct
+    /// field — see the doc comment on [`StakePool::pending_cooldown_slots`] for why
+    /// this is no longer packed into `_reserved`. Meaningful only while
     /// `cooldown_proposed_at_slot() != 0`.
     pub fn pending_cooldown_slots(&self) -> u64 {
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&self._reserved[10..18]);
-        u64::from_le_bytes(bytes)
+        self.pending_cooldown_slots
     }
 
     /// Set the pending cooldown-increase value. See [`pending_cooldown_slots`].
     pub fn set_pending_cooldown_slots(&mut self, val: u64) {
-        self._reserved[10..18].copy_from_slice(&val.to_le_bytes());
+        self.pending_cooldown_slots = val;
     }
 
     /// #242 timelock: the slot at which the pending cooldown increase was proposed.
-    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Stored
-    /// at `_reserved[18..26]` (LE u64).
+    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Real
+    /// struct field — see [`StakePool::cooldown_proposed_at_slot`] doc comment.
     pub fn cooldown_proposed_at_slot(&self) -> u64 {
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&self._reserved[18..26]);
-        u64::from_le_bytes(bytes)
+        self.cooldown_proposed_at_slot
     }
 
     /// Set the cooldown-increase proposal slot (`0` clears the proposal). See
     /// [`cooldown_proposed_at_slot`].
     pub fn set_cooldown_proposed_at_slot(&mut self, val: u64) {
-        self._reserved[18..26].copy_from_slice(&val.to_le_bytes());
+        self.cooldown_proposed_at_slot = val;
     }
 
     /// Loss-adjusted junior tranche balance.
@@ -412,7 +430,11 @@ impl StakePool {
 
     /// Current struct version. Increment when layout changes.
     /// v2 (size 352 -> 384): added `pending_admin` for two-step admin rotation.
-    pub const CURRENT_VERSION: u8 = 2;
+    /// v3 (size 384 -> 400): added `pending_cooldown_slots` / `cooldown_proposed_at_slot`
+    /// as real fields (#250/#258) — they were previously packed into
+    /// `_reserved[10..26]`, which silently aliased the PERC-313 HWM fields
+    /// already occupying `_reserved[10..32]`.
+    pub const CURRENT_VERSION: u8 = 3;
 
     /// Set discriminator in first 8 bytes of _reserved and version in byte 8.
     /// Call on init.
@@ -631,10 +653,11 @@ mod tests {
     fn test_stake_pool_size() {
         // Ensure struct is packed correctly (no surprise padding)
         assert_eq!(STAKE_POOL_SIZE, std::mem::size_of::<StakePool>());
-        // v2 size: prior 352 + pending_admin[32] = 384.
+        // v3 size: prior 384 + pending_cooldown_slots(8) + cooldown_proposed_at_slot(8) = 400.
         // 1+1+1+1+4 + 5*32 + 7*8 + 32(percolator_program) + 24(PERC-272 u64s)
-        //   + 1(pool_mode) + 7(mode_pad) + 32(pending_admin) + 64(_reserved) = 384
-        assert_eq!(STAKE_POOL_SIZE, 384);
+        //   + 1(pool_mode) + 7(mode_pad) + 32(pending_admin) + 8 + 8(#250/#258 timelock fields)
+        //   + 64(_reserved) = 400
+        assert_eq!(STAKE_POOL_SIZE, 400);
     }
 
     #[test]

--- a/tests/poc_cooldown_timelock_hwm_overlap.rs
+++ b/tests/poc_cooldown_timelock_hwm_overlap.rs
@@ -1,0 +1,124 @@
+//! Regression for #250/#258 — the #242 cooldown-increase timelock fields
+//! (`pending_cooldown_slots`, `cooldown_proposed_at_slot`) used to be packed into
+//! `StakePool::_reserved[10..26]`, which the PERC-313 high-water-mark feature already
+//! owned in full (`hwm_enabled` at [10], `hwm_floor_bps` at [11..13],
+//! `epoch_high_water_tvl` at [16..24], `hwm_last_epoch` at [24..32]). Every write to
+//! one feature silently corrupted the other's stored state.
+//!
+//! The fix promotes both cooldown-timelock fields to real `StakePool` struct fields
+//! (CURRENT_VERSION 2 -> 3, STAKE_POOL_SIZE 384 -> 400), so they can no longer alias
+//! any `_reserved` byte. These tests mirror the exact corruption sequences from the
+//! original bug reports and assert the corruption no longer happens.
+
+use bytemuck::Zeroable;
+use percolator_stake::state::StakePool;
+
+#[test]
+fn cooldown_timelock_and_hwm_no_longer_share_storage() {
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    // Start with HWM enabled and a normal 50% floor.
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(5_000);
+    pool.set_epoch_high_water_tvl(1_000_000);
+    pool.set_hwm_last_epoch(10);
+
+    assert!(pool.hwm_enabled());
+    assert_eq!(pool.hwm_floor_bps(), 5_000);
+    assert_eq!(pool.epoch_high_water_tvl(), 1_000_000);
+    assert_eq!(pool.hwm_last_epoch(), 10);
+
+    // Proposing a cooldown increase used to write _reserved[10..18] and
+    // _reserved[18..26], which aliased every HWM field except the high bytes of
+    // hwm_last_epoch. With real fields, this must leave HWM state untouched.
+    pool.set_pending_cooldown_slots(43_200_000);
+    pool.set_cooldown_proposed_at_slot(123_456_789);
+
+    assert!(pool.hwm_enabled(), "cooldown proposal must not disturb hwm_enabled");
+    assert_eq!(
+        pool.hwm_floor_bps(),
+        5_000,
+        "cooldown proposal must not disturb hwm_floor_bps"
+    );
+    assert_eq!(
+        pool.epoch_high_water_tvl(),
+        1_000_000,
+        "cooldown proposal must not disturb epoch_high_water_tvl"
+    );
+    assert_eq!(
+        pool.hwm_last_epoch(),
+        10,
+        "cooldown proposal must not disturb hwm_last_epoch"
+    );
+
+    // Now the reverse direction: a later HWM refresh must not corrupt the active
+    // cooldown proposal.
+    let pending_before = pool.pending_cooldown_slots();
+    let proposed_at_before = pool.cooldown_proposed_at_slot();
+
+    pool.refresh_hwm(11, 2_000_000);
+
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        pending_before,
+        "refresh_hwm must not change pending_cooldown_slots"
+    );
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        proposed_at_before,
+        "refresh_hwm must not change cooldown_proposed_at_slot"
+    );
+}
+
+#[test]
+fn enabling_hwm_does_not_mutate_a_pending_cooldown_value() {
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    pool.set_pending_cooldown_slots(10_000_000);
+    pool.set_cooldown_proposed_at_slot(500_000);
+
+    let pending_before = pool.pending_cooldown_slots();
+    let proposed_at_before = pool.cooldown_proposed_at_slot();
+
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(9_000);
+
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        pending_before,
+        "set_hwm_enabled/set_hwm_floor_bps must not overwrite pending_cooldown_slots"
+    );
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        proposed_at_before,
+        "set_hwm_enabled/set_hwm_floor_bps must not overwrite cooldown_proposed_at_slot"
+    );
+}
+
+#[test]
+fn hwm_activity_does_not_fabricate_a_phantom_cooldown_proposal() {
+    // #250 Direction C: with the old _reserved packing, enabling HWM with a nonzero
+    // epoch_high_water_tvl made cooldown_proposed_at_slot() read as nonzero — a
+    // "phantom" proposal nobody made. With real fields, an untouched cooldown
+    // timelock must report no pending proposal regardless of HWM activity.
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(5_000);
+    pool.refresh_hwm(1, 2_000_000_000);
+    pool.refresh_hwm(2, 5_000_000_000);
+
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        0,
+        "HWM activity must never fabricate a pending cooldown proposal"
+    );
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        0,
+        "HWM activity must never fabricate a pending cooldown value"
+    );
+}

--- a/tests/struct_layout.rs
+++ b/tests/struct_layout.rs
@@ -6,13 +6,14 @@
 use percolator_stake::state::{StakeDeposit, StakePool, STAKE_DEPOSIT_SIZE, STAKE_POOL_SIZE};
 
 #[test]
-fn test_stake_pool_size_is_384() {
-    // v2 layout: prior 352 + pending_admin[32] (two-step admin rotation) = 384.
+fn test_stake_pool_size_is_400() {
+    // v3 layout: prior 384 + pending_cooldown_slots(8) + cooldown_proposed_at_slot(8)
+    // (#250/#258 — promoted out of the colliding _reserved[10..26] packing) = 400.
     // If this changes, existing on-chain data becomes unreadable.
     // NEVER change this without a version bump + (if not fresh-start) a migration.
-    // v16 sync is a fresh-start cutover, so no v1 (352-byte) pools exist.
-    assert_eq!(STAKE_POOL_SIZE, 384);
-    assert_eq!(std::mem::size_of::<StakePool>(), 384);
+    // v17 sync is a fresh-start cutover, so no v2 (384-byte) pools exist.
+    assert_eq!(STAKE_POOL_SIZE, 400);
+    assert_eq!(std::mem::size_of::<StakePool>(), 400);
 }
 
 #[test]
@@ -151,7 +152,12 @@ fn test_stake_pool_field_offsets() {
     assert_eq!(&pool.last_vault_snapshot as *const _ as usize - base, 272);
     assert_eq!(&pool.pool_mode as *const _ as usize - base, 280);
     assert_eq!(&pool._mode_padding as *const _ as usize - base, 281);
-    // v2: pending_admin[32] inserted at 288, pushing _reserved to 320.
+    // v2: pending_admin[32] inserted at 288, pushing the next field to 320.
     assert_eq!(&pool.pending_admin as *const _ as usize - base, 288);
-    assert_eq!(&pool._reserved as *const _ as usize - base, 320);
+    // v3 (#250/#258): pending_cooldown_slots/cooldown_proposed_at_slot promoted out
+    // of the colliding _reserved[10..26] packing into real fields at 320/328,
+    // pushing _reserved to 336.
+    assert_eq!(&pool.pending_cooldown_slots as *const _ as usize - base, 320);
+    assert_eq!(&pool.cooldown_proposed_at_slot as *const _ as usize - base, 328);
+    assert_eq!(&pool._reserved as *const _ as usize - base, 336);
 }


### PR DESCRIPTION
## Problem
`#242`'s two-phase cooldown-increase timelock packed `pending_cooldown_slots` and `cooldown_proposed_at_slot` into `StakePool::_reserved[10..26]`, believing that range was free ("the previously-free `_reserved[10..26]` region"). It wasn't: PERC-313's high-water-mark feature already owns the entire `_reserved[10..32]` range (`hwm_enabled` at [10], `hwm_floor_bps` at [11..13], `epoch_high_water_tvl` at [16..24], `hwm_last_epoch` at [24..32]).

Both features are reachable on the same pool with no guard preventing co-use:
- Proposing a cooldown increase overwrites `hwm_enabled`/`hwm_floor_bps`/part of `epoch_high_water_tvl`, silently disabling HWM or wedging the withdrawal floor so it can never be satisfied.
- `refresh_hwm()` — called on every deposit/withdraw/junior-deposit once HWM is enabled — overwrites `cooldown_proposed_at_slot` and part of `pending_cooldown_slots`, corrupting or fabricating a pending cooldown proposal and voiding the timelock's 48h LP exit-window guarantee.

The existing collision regression test (`pending_cooldown_bytes_do_not_collide_with_neighbors`) checked against the discriminator, version, `market_resolved`, the tranche flag, and `realized_junior_loss` — every neighbor *except* the HWM region it actually overlaps, which is why this shipped unnoticed.

## Fix
Promoted both fields to real `StakePool` struct fields, mirroring exactly how `pending_admin` was added for the v1→v2 bump (same rationale: `_reserved` didn't have enough contiguous free bytes, so this is a real field, not more `_reserved` packing): `STAKE_POOL_SIZE` 384 → 400, `CURRENT_VERSION` 2 → 3. Fresh-start cutover per existing project convention — no v2 pools exist, so no migration is needed.

- Updated the two stale hardcoded-`384` size assertions (`tests/struct_layout.rs`, `src/state.rs`) and the field-offset test's stale `_reserved` offset (320 → 336, accounting for the two new 8-byte fields at 320/328).
- Strengthened the existing collision test to also assert against every HWM accessor — the exact check that was missing.
- Added `tests/poc_cooldown_timelock_hwm_overlap.rs`, a dedicated regression covering all three corruption directions from the bug reports (cooldown-proposal-corrupts-HWM, HWM-refresh-corrupts-cooldown-proposal, HWM-activity-fabricates-a-phantom-cooldown-proposal).

## Proof of Fix
- Verified the negative: temporarily swapped back the old `_reserved`-packed `state.rs` and confirmed all three new regression tests fail with exactly the corruption described in the issues (e.g. `hwm_enabled` flips after a cooldown proposal; a phantom `cooldown_proposed_at_slot` of `562949953497605` appears from HWM activity alone with no cooldown instruction ever issued). Restoring the fix makes all three pass.
- Full `cargo test --lib` (142 tests) and every non-SBF-dependent integration/proptest file (197 more tests, 339 total) pass with no regressions.
- The two v16/v17 LiteSVM e2e suites require a pre-built `target/deploy/percolator_stake.so` via `cargo build-sbf`, which isn't available in this sandbox (`cargo-build-sbf not found`) — this is a pre-existing environment limitation, not something this change causes; the same suites fail identically against unpatched `main` here for the same reason.

## Related
Closes #250
Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stake pool state now supports the v3 cooldown timelock layout.
  * State version and size expectations were updated to reflect the new on-chain format.

* **Bug Fixes**
  * Fixed cooldown timing data from overlapping with high-water-mark values.
  * Writing cooldown settings no longer corrupts nearby stake pool fields.
  * High-water-mark updates no longer alter cooldown values unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->