### PR TITLE
fix(stake): exclude realized_junior_loss from ReturnInsurance returnable cap

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -3060,13 +3060,15 @@ fn process_return_insurance(
         return Err(ProgramError::IllegalOwner);
     }
 
-    // M-1: physical outstanding = (flushed - returned) + realized_junior_loss.
-    // realized_junior_loss was added to total_returned as a bookkeeping settlement
-    // when the last junior exited; adding it back exposes the full physical recovery
-    // capacity that senior holders are entitled to.
-    let outstanding = pool.total_flushed
-        .saturating_sub(pool.total_returned)
-        .saturating_add(pool.realized_junior_loss());
+    // Returnable capacity is the UNSETTLED loss only (total_flushed - total_returned),
+    // via the shared StakePool::insurance_recoverable() so this path and
+    // RecoverFlushedInsurance can never diverge. It deliberately EXCLUDES
+    // realized_junior_loss: the last-junior-exit settlement already booked
+    // `total_returned += L` (phantom) for the forfeited portion, and adding it back here
+    // would let `total_returned += amount` double-count it — pushing total_returned above
+    // total_flushed and windfalling the forfeited junior capital to senior (#161). See the
+    // helper doc for the full rationale.
+    let outstanding = pool.insurance_recoverable();
     if amount > outstanding {
         msg!(
             "ReturnInsurance: amount {} exceeds outstanding insurance {}",
@@ -3207,9 +3209,11 @@ fn process_recover_flushed_insurance(
         return Err(StakeError::ZeroAmount.into());
     }
 
-    // CAP: amount must not exceed outstanding = total_flushed - total_returned.
-    // Use saturating_sub so a stale / already-fully-returned pool yields 0 outstanding.
-    let outstanding = pool.total_flushed.saturating_sub(pool.total_returned);
+    // CAP: amount must not exceed the unsettled flushed loss. Shared with ReturnInsurance
+    // via StakePool::insurance_recoverable() (total_flushed - total_returned, excluding the
+    // already-settled realized_junior_loss). saturating_sub keeps a stale / fully-returned
+    // pool at 0 outstanding.
+    let outstanding = pool.insurance_recoverable();
     if outstanding == 0 {
         msg!(
             "RecoverFlushedInsurance: nothing to recover (total_flushed={} total_returned={})",

--- a/src/state.rs
+++ b/src/state.rs
@@ -306,12 +306,16 @@ impl StakePool {
     ///
     /// When the LAST junior LP exits while a loss is outstanding, the loss it absorbed
     /// (`junior_balance − effective_junior_balance`) is forfeited: the junior took its
-    /// marked-down payout and walked away, so a later `ReturnInsurance` of that portion
-    /// must NOT flow to senior (which was protected). We settle that portion at exit
-    /// (`total_returned += L`) so it leaves the recoverable-loss ledger, and record it
-    /// here so `total_pool_value()` subtracts it — the recovered tokens then sit as DEAD
-    /// (unclaimable) value rather than windfalling senior. Conservation: vault tokens ==
-    /// junior_claims + senior_claims + realized_junior_loss(dead).
+    /// marked-down payout and walked away, so that portion must NOT flow to senior (which
+    /// was protected). We settle it at exit (`total_returned += L`, a phantom booking with
+    /// no token movement) so it leaves the recoverable-loss ledger, and record the same L
+    /// here so `total_pool_value()` subtracts it — netting the phantom `+L` to zero and
+    /// leaving senior at its principal. The forfeited tokens remain in the wrapper
+    /// insurance fund and are NOT returnable to the vault: both `ReturnInsurance` and
+    /// `RecoverFlushedInsurance` cap returns at `total_flushed − total_returned`, which the
+    /// phantom settlement has already driven to exclude this portion. Conservation: vault
+    /// tokens == junior_claims + senior_claims; the forfeited realized_junior_loss stays in
+    /// the insurance fund, unclaimable by any tranche.
     pub fn realized_junior_loss(&self) -> u64 {
         let mut bytes = [0u8; 8];
         bytes.copy_from_slice(&self._reserved[51..59]);
@@ -321,6 +325,23 @@ impl StakePool {
     /// Set the cumulative realized (forfeited) junior loss. See `realized_junior_loss`.
     pub fn set_realized_junior_loss(&mut self, val: u64) {
         self._reserved[51..59].copy_from_slice(&val.to_le_bytes());
+    }
+
+    /// Insurance tokens still recoverable to the pool vault: the unsettled flushed loss,
+    /// `total_flushed − total_returned`.
+    ///
+    /// This is the single source of truth for BOTH the `ReturnInsurance` and
+    /// `RecoverFlushedInsurance` returnable caps, so the two paths can never diverge.
+    /// It deliberately EXCLUDES `realized_junior_loss`: the last-junior-exit settlement
+    /// already books `total_returned += L` (a phantom, no-token-movement settlement) for
+    /// the forfeited junior portion, which this subtraction removes from the returnable
+    /// capacity. Adding `realized_junior_loss` back would re-expose that dead portion; a
+    /// subsequent `total_returned += amount` (with no `realized_junior_loss` decrement)
+    /// would double-count `total_returned` — pushing it above `total_flushed` and
+    /// windfalling the forfeited junior capital to the protected senior tranche (#161).
+    /// `saturating_sub` keeps this panic-free if `total_returned` ever leads.
+    pub fn insurance_recoverable(&self) -> u64 {
+        self.total_flushed.saturating_sub(self.total_returned)
     }
 
     /// Whether BurnAssetAdmin has completed for this pool's market.

--- a/tests/poc_return_insurance_realized_junior_loss_windfall.rs
+++ b/tests/poc_return_insurance_realized_junior_loss_windfall.rs
@@ -1,0 +1,118 @@
+//! Regression — `ReturnInsurance` must not re-open the last-junior-exit windfall.
+//!
+//! ── Background (the last-junior-exit settlement) ──────────────────────────────
+//! When the LAST junior LP exits while an insurance loss is outstanding,
+//! `process_withdraw` "realizes" the loss the junior absorbed
+//! (`L = junior_balance − effective_junior_balance`) by booking, in the same
+//! instruction:
+//!
+//!     pool.total_returned          += L;   // phantom — NO tokens move
+//!     pool.realized_junior_loss()  += L;   // recorded so total_pool_value() subtracts it
+//!
+//! The phantom `+L` and the `−realized_junior_loss` term in `total_pool_value()` cancel,
+//! so pool value is unchanged at exit and the protected SENIOR tranche is NOT windfalled
+//! (see the `#161` unit test `test_161_last_junior_exit_does_not_windfall_recovery_to_senior`
+//! and the `realized_junior_loss` doc-comment: the forfeited portion must "sit as DEAD
+//! (unclaimable) value rather than windfalling senior").
+//!
+//! ── The defect this guards against ────────────────────────────────────────────
+//! `process_return_insurance` previously computed its returnable cap as
+//! `total_flushed − total_returned + realized_junior_loss`, ADDING the realized (dead)
+//! portion back. Because the handler then does `total_returned += amount` with no matching
+//! `realized_junior_loss` decrement, returning that portion double-counts `total_returned`
+//! — pushing it ABOVE `total_flushed` (conservation broken) and canceling the
+//! `−realized_junior_loss` term in `total_pool_value()`, so the forfeited junior capital
+//! flows to senior. The fix routes BOTH `ReturnInsurance` and `RecoverFlushedInsurance`
+//! through `StakePool::insurance_recoverable()` (= `total_flushed − total_returned`), which
+//! excludes the already-settled realized portion.
+//!
+//! This test drives the same scenario as the `#161` unit test one step further into the
+//! real returnable cap (`insurance_recoverable()`, the exact value the processor caps
+//! against) and the return booking. It uses the program's real accounting methods and the
+//! production cap helper, so it fails if the cap ever re-admits the realized/dead portion.
+
+use bytemuck::Zeroable;
+use percolator_stake::state::StakePool;
+
+fn tranche_pool() -> StakePool {
+    let mut p = StakePool::zeroed();
+    p.is_initialized = 1;
+    p.set_discriminator();
+    p.set_tranche_enabled(true);
+    p.set_junior_fee_mult_bps(20_000);
+    p // pool_mode 0 (insurance LP)
+}
+
+#[test]
+fn return_insurance_must_not_windfall_senior_with_realized_junior_loss() {
+    let mut pool = tranche_pool();
+
+    // Junior 100k + senior 100k (each mints 1:1 into its sub-pool).
+    pool.total_deposited = 200_000;
+    pool.total_lp_supply = 200_000;
+    pool.set_junior_balance(100_000);
+    pool.set_junior_total_lp(100_000);
+    assert_eq!(pool.senior_balance().unwrap(), 100_000, "senior 100k pre-loss");
+    assert_eq!(pool.effective_junior_balance(), 100_000, "junior 100k pre-loss");
+
+    // Admin flushes 50k — a junior-absorbed loss (net_loss 50k <= junior 100k).
+    pool.total_flushed = 50_000;
+    assert_eq!(pool.effective_junior_balance(), 50_000, "junior marked down to 50k");
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        100_000,
+        "senior protected by junior first-loss"
+    );
+
+    // ── Last junior exits. Mirror process_withdraw's full-exit branch verbatim ──
+    // (this part is unchanged by the fix): total_withdrawn += payout; total_lp_supply -=
+    // junior_lp; the #161 forfeit booking; then junior_total_lp/balance = 0.
+    let junior_payout = pool.effective_junior_balance(); // 50k
+    pool.total_withdrawn += junior_payout;
+    pool.total_lp_supply -= 100_000;
+    let net_loss = pool.total_flushed.saturating_sub(pool.total_returned);
+    let forfeited = pool
+        .junior_balance()
+        .saturating_sub(pool.effective_junior_balance())
+        .min(net_loss);
+    assert_eq!(forfeited, 50_000, "junior forfeits the 50k loss it absorbed");
+    pool.total_returned += forfeited; // phantom settlement — NO tokens moved
+    pool.set_realized_junior_loss(pool.realized_junior_loss() + forfeited);
+    pool.set_junior_total_lp(0);
+    pool.set_junior_balance(0);
+
+    // #161 invariant holds at exit: senior stays at its 100k principal; the forfeited 50k
+    // is dead value excluded from total_pool_value().
+    assert_eq!(pool.total_pool_value().unwrap(), 100_000, "tpv excludes dead forfeited loss");
+    assert_eq!(pool.senior_balance().unwrap(), 100_000, "senior not windfalled at exit");
+    assert_eq!(pool.total_returned, pool.total_flushed, "ledger loss settled at exit");
+    assert_eq!(pool.realized_junior_loss(), 50_000);
+
+    // ── The returnable cap the processor actually enforces (shared by ReturnInsurance and
+    // RecoverFlushedInsurance). The forfeited/dead portion must NOT be returnable. ──
+    let outstanding = pool.insurance_recoverable();
+    assert_eq!(
+        outstanding, 0,
+        "forfeited realized_junior_loss must NOT be returnable (got {outstanding})"
+    );
+
+    // Simulate the maximum permitted return (ReturnInsurance rejects amount > outstanding,
+    // and rejects amount == 0, so nothing is returnable here). Mirror total_returned += amount.
+    if outstanding > 0 {
+        pool.total_returned += outstanding;
+    }
+
+    // ── Invariants that MUST hold ──
+    assert!(
+        pool.total_returned <= pool.total_flushed,
+        "conservation broken: total_returned ({}) exceeds total_flushed ({})",
+        pool.total_returned,
+        pool.total_flushed
+    );
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        100_000,
+        "senior must NOT be windfalled by the forfeited-junior recovery (got {})",
+        pool.senior_balance().unwrap()
+    );
+}


### PR DESCRIPTION
## What

Fixes the `ReturnInsurance` returnable cap so it can no longer push `total_returned` above `total_flushed` or windfall the senior tranche with capital forfeited by an exited junior tranche.

Closes #269.

## Why

When the last junior LP exits during an outstanding insurance loss, `process_withdraw` settles the forfeited junior loss `L` with a phantom booking (`total_returned += L`) and records it in `realized_junior_loss` so `total_pool_value()` subtracts it — leaving that portion dead/unclaimable, which is what keeps the protected senior tranche from being windfalled (#161).

`process_return_insurance` computed its cap as `total_flushed − total_returned + realized_junior_loss`, adding the dead portion back. Since the handler then does `total_returned += amount` with no matching `realized_junior_loss` decrement, returning that portion double-counts `total_returned`:

- `total_returned` rises above `total_flushed` (conservation invariant broken), and
- the `−realized_junior_loss` term in `total_pool_value()` is canceled, so the forfeited junior capital flows to senior.

This occurs under the normal admin recovery flow (WithdrawInsurance on the wrapper, then `ReturnInsurance`) — no external attacker required. The tokens are physically present, so it is a value-misallocation between tranches rather than a protocol insolvency.

## Change

- Add `StakePool::insurance_recoverable()` = `total_flushed.saturating_sub(total_returned)` as the single source of truth for both returnable caps, so `ReturnInsurance` and `RecoverFlushedInsurance` can never diverge. It excludes `realized_junior_loss` (already settled at exit).
- Route `process_return_insurance` (previously the buggy `+ realized_junior_loss` cap) and `process_recover_flushed_insurance` through the helper.
- Update the `realized_junior_loss` doc-comment to accurately state the forfeited portion stays in the wrapper insurance fund and is not returnable to the vault.

The genuinely-recoverable loss (`total_flushed − total_returned`) remains fully returnable; only the buggy dead-portion capacity is removed.

## Test

Adds `tests/poc_return_insurance_realized_junior_loss_windfall.rs`, which drives the `#161` scenario one step further into the real returnable cap (`insurance_recoverable()`) and the return booking, then asserts `total_returned <= total_flushed` and that senior stays at its principal. It fails against the previous `+ realized_junior_loss` cap and passes with this change.

## Verification

- New regression test passes.
- `cargo test --lib` (incl. `test_161_last_junior_exit_does_not_windfall_recovery_to_senior`) passes.
- Existing tranche / insurance / accounting suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected insurance recovery calculations to exclude losses already settled through junior-loss realization.
  * Prevented settled losses from being returned or counted again through either insurance recovery path.
  * Preserved senior tranche balances during realized-loss scenarios.

* **Tests**
  * Added regression coverage confirming recoverable insurance amounts, balance conservation, and protection against unexpected windfalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->