### PR TITLE
fix(stake): resolve _reserved collision between cooldown-increase timelock and PERC-313 HWM

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -101,8 +101,9 @@ const MAX_COOLDOWN_SLOTS: u64 = 78_840_000;
 /// UpdateConfig tx and lock LP withdrawals. That increase is now IMPLEMENTED as a
 /// two-phase timelock — ProposeCooldownIncrease (tag 7) records the pending value and
 /// proposal slot in StakePool (`pending_cooldown_slots` / `cooldown_proposed_at_slot`,
-/// stored in the previously-free `_reserved[10..26]` — no struct-size change / version
-/// bump), and CommitCooldownIncrease (tag 8) applies it only after TIMELOCK_SLOTS have
+/// backed by the dedicated v3 `cooldown_pending_slots` / `cooldown_proposal_slot` fields —
+/// they previously aliased `_reserved[10..26]`, which collided with the PERC-313 HWM
+/// fields), and CommitCooldownIncrease (tag 8) applies it only after TIMELOCK_SLOTS have
 /// elapsed, giving LP holders a guaranteed ≥48h exit window. CancelCooldownIncrease
 /// (tag 9) withdraws a pending proposal. UpdateConfig now REJECTS a cooldown increase
 /// (`CooldownIncreaseRequiresTimelock`); decreases (LP-friendly) and `deposit_cap`
@@ -605,6 +606,9 @@ fn process_init_pool(
     pool.last_vault_snapshot = 0;
     pool.pool_mode = 0; // InitTradingPool overrides to 1 after this call
     pool.pending_admin = [0u8; 32];
+    // v3 #242 timelock fields: no active cooldown proposal at genesis.
+    pool.cooldown_pending_slots = 0;
+    pool.cooldown_proposal_slot = 0;
     pool.set_discriminator();
 
     msg!(
@@ -3382,13 +3386,21 @@ mod tests {
 
     #[test]
     fn pending_cooldown_bytes_do_not_collide_with_neighbors() {
-        // _reserved[10..26] must not disturb the discriminator/version[0..9],
-        // market_resolved[9], tranche[32+], or realized_junior_loss[51..59].
+        // The #242 timelock values live in dedicated v3 fields (cooldown_pending_slots /
+        // cooldown_proposal_slot), so writing them must not disturb the discriminator/
+        // version[0..9], market_resolved[9], the PERC-313 HWM fields ([10..32]), the
+        // tranche state ([32+]), or realized_junior_loss[51..59].
         let mut pool = StakePool::zeroed();
         pool.set_discriminator();
         pool.set_market_resolved(true);
         pool.set_realized_junior_loss(7_777);
         pool.set_tranche_enabled(true);
+        // Seed HWM state, then write the timelock values, then confirm HWM is intact —
+        // this is the regression guard for the _reserved collision the v3 fields resolved.
+        pool.set_hwm_enabled(true);
+        pool.set_hwm_floor_bps(5_000);
+        pool.set_epoch_high_water_tvl(1_000_000);
+        pool.set_hwm_last_epoch(42);
         pool.set_pending_cooldown_slots(u64::MAX);
         pool.set_cooldown_proposed_at_slot(123);
         assert!(pool.validate_discriminator());
@@ -3396,6 +3408,11 @@ mod tests {
         assert!(pool.market_resolved());
         assert!(pool.tranche_enabled());
         assert_eq!(pool.realized_junior_loss(), 7_777);
+        // HWM state survives the timelock writes (no byte collision).
+        assert!(pool.hwm_enabled());
+        assert_eq!(pool.hwm_floor_bps(), 5_000);
+        assert_eq!(pool.epoch_high_water_tvl(), 1_000_000);
+        assert_eq!(pool.hwm_last_epoch(), 42);
         assert_eq!(pool.pending_cooldown_slots(), u64::MAX);
         assert_eq!(pool.cooldown_proposed_at_slot(), 123);
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -111,6 +111,24 @@ pub struct StakePool {
 
     /// Reserved for future use
     pub _reserved: [u8; 64],
+
+    /// #242 cooldown-increase timelock: the pending (larger) `cooldown_slots` awaiting
+    /// commit. Dedicated struct field (v3, offset 384), NOT carved from `_reserved`.
+    ///
+    /// This value previously lived in `_reserved[10..18]`, which collided with the
+    /// PERC-313 HWM fields (`hwm_enabled`/`hwm_floor_bps`/`epoch_high_water_tvl` occupy
+    /// `_reserved[10..24]`): proposing a cooldown increase corrupted HWM and an HWM
+    /// refresh corrupted a pending proposal. `_reserved` has no free 16-byte run, so the
+    /// two timelock values were promoted to real fields (appended after `_reserved` so no
+    /// existing offset shifts). Growing STAKE_POOL_SIZE 384 -> 400 is why CURRENT_VERSION
+    /// bumps 2 -> 3. Fresh-start cutover: no prior pools exist, so no migration is needed.
+    /// Meaningful only while `cooldown_proposed_at_slot() != 0`.
+    pub cooldown_pending_slots: u64,
+
+    /// #242 cooldown-increase timelock: the slot at which the pending increase was
+    /// proposed. `0` = no active proposal (the sentinel; a live mainnet slot is never 0).
+    /// Dedicated struct field (v3, offset 392). See [`cooldown_pending_slots`].
+    pub cooldown_proposal_slot: u64,
 }
 
 /// Size of StakePool in bytes
@@ -336,34 +354,30 @@ impl StakePool {
         self._reserved[59] = if burned { 1 } else { 0 };
     }
 
-    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Stored at
-    /// `_reserved[10..18]` (LE u64), in the previously-free `[10..32]` region — no
-    /// struct-size change, no version bump. Meaningful only while
-    /// `cooldown_proposed_at_slot() != 0`.
+    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Backed by the
+    /// dedicated `cooldown_pending_slots` field (v3) — previously stored in
+    /// `_reserved[10..18]`, which collided with the PERC-313 HWM fields. Meaningful only
+    /// while `cooldown_proposed_at_slot() != 0`.
     pub fn pending_cooldown_slots(&self) -> u64 {
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&self._reserved[10..18]);
-        u64::from_le_bytes(bytes)
+        self.cooldown_pending_slots
     }
 
     /// Set the pending cooldown-increase value. See [`pending_cooldown_slots`].
     pub fn set_pending_cooldown_slots(&mut self, val: u64) {
-        self._reserved[10..18].copy_from_slice(&val.to_le_bytes());
+        self.cooldown_pending_slots = val;
     }
 
     /// #242 timelock: the slot at which the pending cooldown increase was proposed.
-    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Stored
-    /// at `_reserved[18..26]` (LE u64).
+    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Backed by
+    /// the dedicated `cooldown_proposal_slot` field (v3) — previously `_reserved[18..26]`.
     pub fn cooldown_proposed_at_slot(&self) -> u64 {
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&self._reserved[18..26]);
-        u64::from_le_bytes(bytes)
+        self.cooldown_proposal_slot
     }
 
     /// Set the cooldown-increase proposal slot (`0` clears the proposal). See
     /// [`cooldown_proposed_at_slot`].
     pub fn set_cooldown_proposed_at_slot(&mut self, val: u64) {
-        self._reserved[18..26].copy_from_slice(&val.to_le_bytes());
+        self.cooldown_proposal_slot = val;
     }
 
     /// Loss-adjusted junior tranche balance.
@@ -412,7 +426,10 @@ impl StakePool {
 
     /// Current struct version. Increment when layout changes.
     /// v2 (size 352 -> 384): added `pending_admin` for two-step admin rotation.
-    pub const CURRENT_VERSION: u8 = 2;
+    /// v3 (size 384 -> 400): promoted the #242 cooldown-increase timelock values to
+    /// dedicated `cooldown_pending_slots` / `cooldown_proposal_slot` fields, resolving the
+    /// `_reserved` byte collision with the PERC-313 HWM fields.
+    pub const CURRENT_VERSION: u8 = 3;
 
     /// Set discriminator in first 8 bytes of _reserved and version in byte 8.
     /// Call on init.
@@ -631,10 +648,11 @@ mod tests {
     fn test_stake_pool_size() {
         // Ensure struct is packed correctly (no surprise padding)
         assert_eq!(STAKE_POOL_SIZE, std::mem::size_of::<StakePool>());
-        // v2 size: prior 352 + pending_admin[32] = 384.
+        // v3 size: prior 384 + cooldown_pending_slots(u64) + cooldown_proposal_slot(u64) = 400.
         // 1+1+1+1+4 + 5*32 + 7*8 + 32(percolator_program) + 24(PERC-272 u64s)
-        //   + 1(pool_mode) + 7(mode_pad) + 32(pending_admin) + 64(_reserved) = 384
-        assert_eq!(STAKE_POOL_SIZE, 384);
+        //   + 1(pool_mode) + 7(mode_pad) + 32(pending_admin) + 64(_reserved)
+        //   + 8(cooldown_pending_slots) + 8(cooldown_proposal_slot) = 400
+        assert_eq!(STAKE_POOL_SIZE, 400);
     }
 
     #[test]

--- a/tests/poc_hwm_cooldown_timelock_state_collision.rs
+++ b/tests/poc_hwm_cooldown_timelock_state_collision.rs
@@ -23,7 +23,9 @@
 //!
 //! This is the same class of defect the codebase previously flagged CRITICAL for the
 //! byte-9 `market_resolved`/`hwm_enabled` collision. This test asserts the independence
-//! invariant using the program's real accessors; it fails on current code.
+//! invariant using the program's real accessors; it fails on the pre-fix layout that
+//! packed both features into `_reserved` — revert the dedicated fields and it goes red
+//! again.
 
 use bytemuck::Zeroable;
 use percolator_stake::state::StakePool;

--- a/tests/poc_hwm_cooldown_timelock_state_collision.rs
+++ b/tests/poc_hwm_cooldown_timelock_state_collision.rs
@@ -1,0 +1,95 @@
+//! PoC / regression — the #242 cooldown-increase timelock fields collide with the
+//! PERC-313 high-water-mark fields in `StakePool._reserved`.
+//!
+//! ── The bug ──────────────────────────────────────────────────────────────────
+//! PERC-313 HWM occupies `_reserved[10..32]`:
+//!   [10]    hwm_enabled
+//!   [11..13] hwm_floor_bps
+//!   [16..24] epoch_high_water_tvl
+//!   [24..32] hwm_last_epoch
+//!
+//! The #242 cooldown-increase timelock stores its two fields in the SAME region:
+//!   [10..18] pending_cooldown_slots     (overlaps hwm_enabled, hwm_floor_bps, and the
+//!                                         low bytes of epoch_high_water_tvl)
+//!   [18..26] cooldown_proposed_at_slot  (overlaps epoch_high_water_tvl and the low bytes
+//!                                         of hwm_last_epoch)
+//!
+//! The #242 doc-comment claims `[10..32]` is "previously-free", but PERC-313 reserved and
+//! uses that whole region. As a result the two features corrupt each other's state:
+//!   * Proposing a cooldown increase silently disables/garbles HWM (the withdrawal-drain
+//!     floor — an LP protection).
+//!   * `refresh_hwm` (invoked on EVERY deposit/withdraw while HWM is enabled) corrupts a
+//!     pending cooldown proposal's value and timer.
+//!
+//! This is the same class of defect the codebase previously flagged CRITICAL for the
+//! byte-9 `market_resolved`/`hwm_enabled` collision. This test asserts the independence
+//! invariant using the program's real accessors; it fails on current code.
+
+use bytemuck::Zeroable;
+use percolator_stake::state::StakePool;
+
+#[test]
+fn hwm_and_cooldown_timelock_state_must_be_independent() {
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    // Admin enables HWM with a real floor and seeds a water mark (as refresh_hwm would).
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(5_000);
+    pool.set_epoch_high_water_tvl(1_000_000);
+    pool.set_hwm_last_epoch(42);
+
+    // Admin proposes a cooldown increase (#242 two-phase timelock).
+    pool.set_pending_cooldown_slots(500_000);
+    pool.set_cooldown_proposed_at_slot(123_456);
+
+    // The cooldown proposal must not have destroyed HWM state — the features are independent.
+    assert!(pool.hwm_enabled(), "cooldown proposal disabled HWM (byte 10 collision)");
+    assert_eq!(
+        pool.hwm_floor_bps(),
+        5_000,
+        "cooldown proposal corrupted HWM floor (bytes 11-12 collision)"
+    );
+    assert_eq!(
+        pool.epoch_high_water_tvl(),
+        1_000_000,
+        "cooldown proposal corrupted HWM water mark (bytes 16-23 collision)"
+    );
+    assert_eq!(
+        pool.hwm_last_epoch(),
+        42,
+        "cooldown proposal corrupted HWM epoch (bytes 24-25 collision)"
+    );
+
+    // And the cooldown proposal itself must be intact.
+    assert_eq!(pool.pending_cooldown_slots(), 500_000);
+    assert_eq!(pool.cooldown_proposed_at_slot(), 123_456);
+}
+
+#[test]
+fn hwm_refresh_must_not_corrupt_a_pending_cooldown_proposal() {
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    // A cooldown increase is pending.
+    pool.set_pending_cooldown_slots(500_000);
+    pool.set_cooldown_proposed_at_slot(123_456);
+
+    // HWM is enabled; a deposit/withdraw triggers refresh_hwm, which writes
+    // epoch_high_water_tvl[16..24] and hwm_last_epoch[24..32] — overlapping the
+    // cooldown proposal bytes.
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(5_000);
+    pool.refresh_hwm(43, 2_000_000);
+
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        500_000,
+        "HWM refresh corrupted pending_cooldown_slots"
+    );
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        123_456,
+        "HWM refresh corrupted cooldown_proposed_at_slot (timelock timer)"
+    );
+}

--- a/tests/struct_layout.rs
+++ b/tests/struct_layout.rs
@@ -6,13 +6,15 @@
 use percolator_stake::state::{StakeDeposit, StakePool, STAKE_DEPOSIT_SIZE, STAKE_POOL_SIZE};
 
 #[test]
-fn test_stake_pool_size_is_384() {
-    // v2 layout: prior 352 + pending_admin[32] (two-step admin rotation) = 384.
-    // If this changes, existing on-chain data becomes unreadable.
+fn test_stake_pool_size_is_400() {
+    // v3 layout: prior 384 + cooldown_pending_slots(u64) + cooldown_proposal_slot(u64) = 400.
+    // The two timelock fields were promoted out of _reserved (they collided with the
+    // PERC-313 HWM bytes) into dedicated fields, appended after _reserved so no existing
+    // field offset shifts. If this changes, existing on-chain data becomes unreadable.
     // NEVER change this without a version bump + (if not fresh-start) a migration.
-    // v16 sync is a fresh-start cutover, so no v1 (352-byte) pools exist.
-    assert_eq!(STAKE_POOL_SIZE, 384);
-    assert_eq!(std::mem::size_of::<StakePool>(), 384);
+    // Fresh-start cutover, so no prior (352/384-byte) pools exist.
+    assert_eq!(STAKE_POOL_SIZE, 400);
+    assert_eq!(std::mem::size_of::<StakePool>(), 400);
 }
 
 #[test]
@@ -154,4 +156,8 @@ fn test_stake_pool_field_offsets() {
     // v2: pending_admin[32] inserted at 288, pushing _reserved to 320.
     assert_eq!(&pool.pending_admin as *const _ as usize - base, 288);
     assert_eq!(&pool._reserved as *const _ as usize - base, 320);
+    // v3: cooldown timelock fields appended after _reserved[64] (320 + 64 = 384),
+    // so no existing offset shifts. Both u64, 8-aligned, no padding -> size 400.
+    assert_eq!(&pool.cooldown_pending_slots as *const _ as usize - base, 384);
+    assert_eq!(&pool.cooldown_proposal_slot as *const _ as usize - base, 392);
 }


### PR DESCRIPTION
## What

Resolves the `StakePool._reserved` byte collision between the #242 cooldown-increase timelock and the PERC-313 high-water-mark state by promoting the two timelock values to dedicated struct fields.

Closes #272.

## Why

The timelock stored `pending_cooldown_slots` in `_reserved[10..18]` and `cooldown_proposed_at_slot` in `_reserved[18..26]`, but PERC-313 HWM already owns `_reserved[10..32]` (`hwm_enabled` at 10, `hwm_floor_bps` at 11-12, `epoch_high_water_tvl` at 16-23, `hwm_last_epoch` at 24-31). The ranges overlap, so:

- `ProposeCooldownIncrease` overwrote `hwm_enabled` / `hwm_floor_bps` / `epoch_high_water_tvl` — silently disabling or corrupting the withdrawal-drain floor.
- `refresh_hwm` (invoked on every deposit/withdraw while HWM is enabled) overwrote `cooldown_proposed_at_slot` and the high bytes of `pending_cooldown_slots` — corrupting a pending proposal's value and timelock timer.

Both are supported admin operations, so this triggered under normal use with no attacker. It is the same class of defect previously flagged CRITICAL for the byte-9 `market_resolved` / `hwm_enabled` collision.

## Change

`_reserved` has no free 16-byte run, so the values cannot be relocated within it without another overlap or lossy packing. This change:

- Adds dedicated `cooldown_pending_slots: u64` and `cooldown_proposal_slot: u64` fields, **appended after `_reserved`** so every existing field offset is byte-identical (external parsers of the pre-existing fields and of `_reserved` are unaffected).
- Repoints the `pending_cooldown_slots` / `cooldown_proposed_at_slot` accessors to the new fields (method names unchanged, so the processor logic is untouched).
- Bumps `CURRENT_VERSION` 2 → 3 (size 384 → 400) so the old layout is rejected; explicit zero-init of the new fields in `InitPool`.
- Updates the size assertions (384 → 400) and strengthens `pending_cooldown_bytes_do_not_collide_with_neighbors` to also assert HWM state survives the timelock writes.

Layout safety: `_reserved` ends at offset 384 (8-aligned); two `u64` extend the struct to 400 with no internal or trailing padding, and `align_of::<StakePool>()` stays 8, so bytemuck `Pod` is preserved.

This is a fresh-start cutover (no prior pools to migrate), appropriate for the devnet v2 deploy.

## Test

Adds `tests/poc_hwm_cooldown_timelock_state_collision.rs`, which uses the real accessors (`set_hwm_*`, `set_pending_cooldown_slots`, `set_cooldown_proposed_at_slot`, `refresh_hwm`) to assert the two feature states are independent. It fails against the previous `_reserved`-aliased layout and passes with the dedicated fields.

## Verification

- New collision test passes; the previously-failing assertions now hold.
- `cargo test --lib` and the full integration / poc / proptest / regression suites pass (size, alignment, bytemuck round-trip, version, and all tranche/HWM/insurance behavior).
- The v16/v17 litesvm e2e and Kani targets require an external wrapper `.so` / the Kani toolchain and are not run in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cooldown timelock updates could overwrite high-water-mark state.
  * Preserved pool metadata, tranche information, and realized-loss state when updating cooldown values.

* **Tests**
  * Added regression coverage confirming cooldown and high-water-mark data remain intact after updates.
  * Updated layout validation for the latest pool state format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->