### PR TITLE
fix(ci): route automatic CI to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Fix the primary GitHub Actions CI routing so the repository's current default branch, `main`, is covered by automatic CI.

The existing workflow in `.github/workflows/ci.yml` still filters both `push` and `pull_request` events to `master`:

```yaml
on:
  push:
    branches: [master]
  pull_request:
    branches: [master]
```

However, the repository's current default and active development branch is `main`.

Because the same workflow contains the automatic:

- `Test`
- `Build`
- `Clippy`
- `Format`

jobs, normal pushes to `main` and pull requests targeting `main` currently fall outside this workflow's branch routing.

This PR updates only the two stale branch filters:

```diff
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
```

No CI jobs, commands, runners, action versions, timeouts, environment variables, or concurrency behavior are changed.

### Root cause

The `master` routing was historically intentional when `master` was an active integration branch.

The repository later moved its default development path to `main`, but `.github/workflows/ci.yml` retained the previous `master` filters.

The resulting configuration is:

```text
default branch     = main
CI push filter     = master
CI PR base filter  = master
```

This is therefore a branch-transition configuration drift rather than an issue with the CI jobs themselves.

### Scope

This PR intentionally keeps the fix minimal:

- one file changed: `.github/workflows/ci.yml`
- two branch-filter values changed
- no Rust source changes
- no test logic changes
- no math, proof, or invariant changes
- no CI job-definition changes

Fixes #276

---

## How to test

### 1. Verify the patch scope

```bash
git diff --check
git diff -- .github/workflows/ci.yml
```

Expected change:

```diff
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
```

No other workflow content should change.

---

### 2. Deterministic CI-routing regression

A repository-specific routing verifier was used to validate the workflow configuration before and after the patch.

#### Before

With the existing `master` filters:

```text
default branch        : main
push branches         : ['master']
pull_request branches : ['master']

push                 main     -> SKIP
pull_request base    main     -> SKIP
push                 master   -> RUN
pull_request base    master   -> RUN

FAIL: default branch is NOT covered by automatic CI
```

Exit code:

```text
1
```

#### After

After changing only the two branch filters to `main`:

```text
default branch        : main
push branches         : ['main']
pull_request branches : ['main']

push                 main     -> RUN
pull_request base    main     -> RUN
push                 master   -> SKIP
pull_request base    master   -> SKIP

PASS: default branch is covered by automatic CI
```

Exit code:

```text
0
```

The deterministic `1 -> 0` regression confirms that the stale branch filters are the routing root cause.

---

### 3. Build validation

```bash
cargo build --features no-entrypoint
```

Result:

```text
Finished `dev` profile [unoptimized + debuginfo]
```

Build completed successfully.

---

### 4. Patch integrity

The staged patch was checked with:

```bash
git diff --cached --check
```

Result:

```text
PASS — no whitespace errors
```

The committed change is limited to:

```text
.github/workflows/ci.yml
```

with:

```text
1 file changed, 2 insertions(+), 2 deletions(-)
```

---

## Checklist

- [ ] Tests pass (`cargo test --features no-entrypoint`)
- [ ] Clippy clean (`cargo clippy --features no-entrypoint -- -D warnings`)
- [ ] Format check (`cargo fmt --all -- --check`)
- [x] Build passes (`cargo build --features no-entrypoint`)
- [x] `git diff --cached --check` passes
- [x] Deterministic CI-routing regression passes (`exit 1 -> exit 0`)
- [x] Only `.github/workflows/ci.yml` is changed
- [x] No Rust source code is modified
- [x] No math, proof logic, or invariant code is modified

Kani is **not** required for this change because this PR only updates GitHub Actions branch routing.

Kani is not run automatically on every PR. Use the [Kani (Manual)](../../actions/workflows/kani-manual.yml) workflow for on-demand verification when changes affect math, proof logic, or invariants.

---

## Impact

After this change, the primary CI workflow is aligned with the repository's current default development branch:

```text
push -> main
PR base -> main
```

This restores automatic routing of the existing:

- Test
- Build
- Clippy
- Format

jobs for the repository's current development path.

This PR does not introduce new CI jobs and does not modify the behavior of the existing jobs themselves. It only corrects the branch events that are eligible to trigger them.

---

## Related

Fixes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run for pushes and pull requests targeting the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->