### PR TITLE
ci: point at main, build both .so, fail loudly on missing artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
+# NOTE: these were `master`, a branch that does not exist in this repository, so
+# CI had NEVER run on any push or pull request. Three defects reached the deployed
+# devnet program under that blind spot.
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,13 +20,58 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          path: percolator-stake
+
+      # The e2e suites run the REAL programs under LiteSVM, loading
+      # `percolator-stake/target/deploy/percolator_stake.so` and the sibling
+      # `percolator-prog/target/deploy/percolator_prog.so`. Both are gitignored
+      # build artifacts, so they must be built here or those suites do not
+      # exercise the on-chain code at all.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: dcccrypto/percolator-prog
+          path: percolator-prog
+          token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
+
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
         with:
           toolchain: stable
-      - run: cargo test --features no-entrypoint
+
+      - name: Install Solana CLI (provides cargo-build-sbf)
+        run: |
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      - name: Build stake BPF program
+        working-directory: percolator-stake
+        run: cargo build-sbf -- --features devnet
+
+      - name: Build wrapper BPF program
+        working-directory: percolator-prog
+        run: cargo build-sbf
+
+      # Guard: `common_svm_setup()` in the e2e suites returns None and the test
+      # passes VACUOUSLY when either .so is missing — 23 tests across 7 suites
+      # behave that way. Fail loudly here instead, so a green run always means
+      # those suites really executed.
+      - name: Assert both .so artifacts exist
+        run: |
+          stake_so=percolator-stake/target/deploy/percolator_stake.so
+          wrapper_so=percolator-prog/target/deploy/percolator_prog.so
+          missing=0
+          for f in "$stake_so" "$wrapper_so"; do
+            if [ ! -f "$f" ]; then echo "::error::missing $f — e2e suites would silently skip"; missing=1; fi
+          done
+          [ "$missing" -eq 0 ] || exit 1
+          ls -l "$stake_so" "$wrapper_so"
+
+      - name: Test
+        working-directory: percolator-stake
+        run: cargo test --features no-entrypoint --no-fail-fast
 
   build:
     name: Build
@@ -46,6 +94,9 @@ jobs:
         with:
           toolchain: stable
           components: clippy
+      # Library only. `--all-targets` currently reports pre-existing lints in the
+      # test suites (large Err variants, argument counts); tightening that is a
+      # separate cleanup, not a gate to add mid-flight.
       - run: cargo clippy --features no-entrypoint -- -D warnings
 
   fmt:

--- a/src/cpi.rs
+++ b/src/cpi.rs
@@ -234,13 +234,13 @@ pub fn cpi_bind_insurance_authority<'a>(
     let mut data = Vec::with_capacity(36);
     data.push(TAG_UPDATE_ASSET_AUTHORITY);
     data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // 2 bytes, always 0x00 0x00
-    data.push(ASSET_AUTH_INSURANCE);                         // kind = 1
-    data.extend_from_slice(vault_auth.key.as_ref());         // new_pubkey = PDA
+    data.push(ASSET_AUTH_INSURANCE); // kind = 1
+    data.extend_from_slice(vault_auth.key.as_ref()); // new_pubkey = PDA
 
     let ix = Instruction {
         program_id: *percolator_program.key,
         accounts: vec![
-            AccountMeta::new_readonly(*admin.key, true),      // current authority, signer
+            AccountMeta::new_readonly(*admin.key, true), // current authority, signer
             AccountMeta::new_readonly(*vault_auth.key, true), // new authority (PDA), signer via invoke_signed
             AccountMeta::new(*market.key, false),             // market, writable
         ],
@@ -271,22 +271,22 @@ pub fn cpi_bind_insurance_authority<'a>(
 
 pub fn cpi_bind_insurance_operator<'a>(
     percolator_program: &AccountInfo<'a>,
-    admin: &AccountInfo<'a>,     // current insurance_operator (== admin at bootstrap); signer
+    admin: &AccountInfo<'a>, // current insurance_operator (== admin at bootstrap); signer
     vault_auth: &AccountInfo<'a>, // new operator = our PDA; co-signs via invoke_signed
-    market: &AccountInfo<'a>,    // the slab/market account (writable, wrapper-owned)
-    signer_seeds: &[&[u8]],      // vault_auth PDA seeds
+    market: &AccountInfo<'a>, // the slab/market account (writable, wrapper-owned)
+    signer_seeds: &[&[u8]],  // vault_auth PDA seeds
 ) -> ProgramResult {
     // tag(1) + asset_index(2, u16 LE = 0) + kind(1) + new_pubkey(32) = 36 bytes.
     let mut data = Vec::with_capacity(36);
     data.push(TAG_UPDATE_ASSET_AUTHORITY);
     data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // 2 bytes, always 0x00 0x00
-    data.push(ASSET_AUTH_INSURANCE_OPERATOR);                // kind = 2
-    data.extend_from_slice(vault_auth.key.as_ref());         // new_pubkey = PDA
+    data.push(ASSET_AUTH_INSURANCE_OPERATOR); // kind = 2
+    data.extend_from_slice(vault_auth.key.as_ref()); // new_pubkey = PDA
 
     let ix = Instruction {
         program_id: *percolator_program.key,
         accounts: vec![
-            AccountMeta::new_readonly(*admin.key, true),      // current operator (admin), signer
+            AccountMeta::new_readonly(*admin.key, true), // current operator (admin), signer
             AccountMeta::new_readonly(*vault_auth.key, true), // new operator (PDA), signer via invoke_signed
             AccountMeta::new(*market.key, false),             // market, writable
         ],
@@ -323,21 +323,21 @@ pub fn cpi_bind_insurance_operator<'a>(
 
 pub fn cpi_burn_asset_admin<'a>(
     percolator_program: &AccountInfo<'a>,
-    admin: &AccountInfo<'a>,     // current asset_admin; signer
+    admin: &AccountInfo<'a>,      // current asset_admin; signer
     vault_auth: &AccountInfo<'a>, // placeholder new_authority slot (not checked by wrapper for zero burn)
-    market: &AccountInfo<'a>,    // the slab/market account (writable, wrapper-owned)
+    market: &AccountInfo<'a>,     // the slab/market account (writable, wrapper-owned)
 ) -> ProgramResult {
     // tag(1) + asset_index(2, u16 LE = 0) + kind(1) + new_pubkey(32, all zeros) = 36 bytes.
     let mut data = Vec::with_capacity(36);
     data.push(TAG_UPDATE_ASSET_AUTHORITY);
     data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // 2 bytes, always 0x00 0x00
-    data.push(ASSET_AUTH_ADMIN);                             // kind = 0
-    data.extend_from_slice(&[0u8; 32]);                      // new_pubkey = burn (all zeros)
+    data.push(ASSET_AUTH_ADMIN); // kind = 0
+    data.extend_from_slice(&[0u8; 32]); // new_pubkey = burn (all zeros)
 
     let ix = Instruction {
         program_id: *percolator_program.key,
         accounts: vec![
-            AccountMeta::new_readonly(*admin.key, true),       // current asset_admin, signer
+            AccountMeta::new_readonly(*admin.key, true), // current asset_admin, signer
             AccountMeta::new_readonly(*vault_auth.key, false), // new_authority slot (any; not checked for zero-burn)
             AccountMeta::new(*market.key, false),              // market, writable
         ],
@@ -345,10 +345,7 @@ pub fn cpi_burn_asset_admin<'a>(
     };
 
     // Plain invoke (not signed) — admin signs as the outer tx signer; no PDA co-sign needed.
-    invoke(
-        &ix,
-        &[admin.clone(), vault_auth.clone(), market.clone()],
-    )
+    invoke(&ix, &[admin.clone(), vault_auth.clone(), market.clone()])
 }
 
 // ═══════════════════════════════════════════════════════════════
@@ -375,8 +372,8 @@ pub fn cpi_rotate_insurance_operator<'a>(
     let mut data = Vec::with_capacity(36);
     data.push(TAG_UPDATE_ASSET_AUTHORITY);
     data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // 2 bytes, always 0x00 0x00
-    data.push(ASSET_AUTH_INSURANCE_OPERATOR);                // kind = 2
-    data.extend_from_slice(new_target.key.as_ref());         // new_pubkey = rotation target
+    data.push(ASSET_AUTH_INSURANCE_OPERATOR); // kind = 2
+    data.extend_from_slice(new_target.key.as_ref()); // new_pubkey = rotation target
 
     let ix = Instruction {
         program_id: *percolator_program.key,
@@ -428,8 +425,8 @@ pub fn cpi_rotate_insurance_authority<'a>(
     let mut data = Vec::with_capacity(36);
     data.push(TAG_UPDATE_ASSET_AUTHORITY);
     data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // 2 bytes, always 0x00 0x00
-    data.push(ASSET_AUTH_INSURANCE);                         // kind = 1
-    data.extend_from_slice(new_target.key.as_ref());         // new_pubkey = rotation target
+    data.push(ASSET_AUTH_INSURANCE); // kind = 1
+    data.extend_from_slice(new_target.key.as_ref()); // new_pubkey = rotation target
 
     let ix = Instruction {
         program_id: *percolator_program.key,
@@ -475,9 +472,9 @@ const TAG_WITHDRAW_INSURANCE_ASSET: u8 = 57;
 
 pub fn cpi_withdraw_insurance_asset<'a>(
     percolator_program: &AccountInfo<'a>,
-    vault_auth: &AccountInfo<'a>,   // insurance_operator = our PDA; signs via invoke_signed
-    market: &AccountInfo<'a>,       // wrapper market / slab (writable)
-    dest_token: &AccountInfo<'a>,   // destination token account (MUST be pool.vault; drain check by caller)
+    vault_auth: &AccountInfo<'a>, // insurance_operator = our PDA; signs via invoke_signed
+    market: &AccountInfo<'a>,     // wrapper market / slab (writable)
+    dest_token: &AccountInfo<'a>, // destination token account (MUST be pool.vault; drain check by caller)
     wrapper_vault: &AccountInfo<'a>, // wrapper insurance vault token account (source)
     wrapper_vault_auth: &AccountInfo<'a>, // wrapper vault authority PDA (read-only)
     token_program: &AccountInfo<'a>,
@@ -493,12 +490,12 @@ pub fn cpi_withdraw_insurance_asset<'a>(
     let ix = Instruction {
         program_id: *percolator_program.key,
         accounts: vec![
-            AccountMeta::new_readonly(*vault_auth.key, true),      // operator (PDA), signer via invoke_signed
-            AccountMeta::new(*market.key, false),                   // market, writable
-            AccountMeta::new(*dest_token.key, false),               // dest_token (pool.vault), writable
-            AccountMeta::new(*wrapper_vault.key, false),            // vault_token (source), writable
+            AccountMeta::new_readonly(*vault_auth.key, true), // operator (PDA), signer via invoke_signed
+            AccountMeta::new(*market.key, false),             // market, writable
+            AccountMeta::new(*dest_token.key, false),         // dest_token (pool.vault), writable
+            AccountMeta::new(*wrapper_vault.key, false),      // vault_token (source), writable
             AccountMeta::new_readonly(*wrapper_vault_auth.key, false), // vault_authority, read-only
-            AccountMeta::new_readonly(*token_program.key, false),  // token_program, read-only
+            AccountMeta::new_readonly(*token_program.key, false), // token_program, read-only
         ],
         data,
     };
@@ -588,7 +585,7 @@ pub fn cpi_resolve_market<'a>(
         program_id: *percolator_program.key,
         accounts: vec![
             AccountMeta::new_readonly(*pool_pda.key, true), // admin == marketauth, signer
-            AccountMeta::new(*slab.key, false),              // market, writable
+            AccountMeta::new(*slab.key, false),             // market, writable
         ],
         data,
     };
@@ -728,7 +725,11 @@ pub fn cpi_update_backing_fee_policy<'a>(
         data,
     };
 
-    invoke_signed(&ix, &[vault_auth.clone(), slab.clone()], &[vault_auth_seeds])
+    invoke_signed(
+        &ix,
+        &[vault_auth.clone(), slab.clone()],
+        &[vault_auth_seeds],
+    )
 }
 
 /// Wrapper tag 55 `UpdateTradeFeePolicy`. Gated on ASSET 0's
@@ -759,7 +760,11 @@ pub fn cpi_update_trade_fee_policy<'a>(
         data,
     };
 
-    invoke_signed(&ix, &[vault_auth.clone(), slab.clone()], &[vault_auth_seeds])
+    invoke_signed(
+        &ix,
+        &[vault_auth.clone(), slab.clone()],
+        &[vault_auth_seeds],
+    )
 }
 
 #[cfg(test)]
@@ -791,17 +796,24 @@ mod tag_tests {
     fn test_cpi_bind_asset_authority_wire_shape_v17() {
         let pda = [9u8; 32];
         let mut data = Vec::with_capacity(36);
-        data.push(TAG_UPDATE_ASSET_AUTHORITY);            // byte 0: tag = 65
+        data.push(TAG_UPDATE_ASSET_AUTHORITY); // byte 0: tag = 65
         data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // bytes 1-2: asset_index = 0
-        data.push(ASSET_AUTH_INSURANCE);                 // byte 3: kind = 1
-        data.extend_from_slice(&pda);                    // bytes 4-35: new_pubkey
+        data.push(ASSET_AUTH_INSURANCE); // byte 3: kind = 1
+        data.extend_from_slice(&pda); // bytes 4-35: new_pubkey
 
         // Total length: 36 bytes (was 34 bytes in v16)
-        assert_eq!(data.len(), 36, "v17 tag-65 wire must be 36 bytes (was 34 in v16)");
+        assert_eq!(
+            data.len(),
+            36,
+            "v17 tag-65 wire must be 36 bytes (was 34 in v16)"
+        );
 
         // (1) tag = 65, NOT 32
         assert_eq!(data[0], 65, "tag must be 65 (UpdateAssetAuthority), not 32");
-        assert_ne!(data[0], 32, "tag 32 is the OLD UpdateAuthority — MUST NOT ship");
+        assert_ne!(
+            data[0], 32,
+            "tag 32 is the OLD UpdateAuthority — MUST NOT ship"
+        );
 
         // (2) asset_index = 0 (little-endian u16)
         assert_eq!(data[1], 0x00, "asset_index low byte must be 0");
@@ -809,7 +821,10 @@ mod tag_tests {
 
         // (3) kind = 1 (ASSET_AUTH_INSURANCE), NOT 2 (old AUTHORITY_INSURANCE)
         assert_eq!(data[3], 1, "kind must be 1 (ASSET_AUTH_INSURANCE)");
-        assert_ne!(data[3], 2, "kind=2 is the OLD AUTHORITY_INSURANCE — MUST NOT ship");
+        assert_ne!(
+            data[3], 2,
+            "kind=2 is the OLD AUTHORITY_INSURANCE — MUST NOT ship"
+        );
 
         // pubkey bytes in position
         assert_eq!(&data[4..36], &pda, "new_pubkey at bytes [4..36]");
@@ -825,8 +840,8 @@ mod tag_tests {
         // Reconstruct the v16 wire
         let pda = [9u8; 32];
         let mut old_data = Vec::with_capacity(34);
-        old_data.push(32u8);  // old tag
-        old_data.push(2u8);   // old kind = AUTHORITY_INSURANCE
+        old_data.push(32u8); // old tag
+        old_data.push(2u8); // old kind = AUTHORITY_INSURANCE
         old_data.extend_from_slice(&pda);
 
         // These are the wrong values for v17
@@ -835,7 +850,10 @@ mod tag_tests {
         assert_eq!(old_data.len(), 34, "old wire was 34 bytes");
 
         // Assertions that must NOT hold in v17
-        assert_ne!(old_data[0], TAG_UPDATE_ASSET_AUTHORITY, "v17 tag must be 65");
+        assert_ne!(
+            old_data[0], TAG_UPDATE_ASSET_AUTHORITY,
+            "v17 tag must be 65"
+        );
         // kind byte in old wire is at position 1, in new wire it's at position 3
         assert_ne!(old_data.len(), 36, "v17 wire must be 36 bytes");
     }
@@ -871,10 +889,10 @@ mod tag_tests {
     fn test_cpi_bind_operator_wire_shape() {
         let pda = [7u8; 32];
         let mut data = Vec::with_capacity(36);
-        data.push(TAG_UPDATE_ASSET_AUTHORITY);             // byte 0: tag = 65
+        data.push(TAG_UPDATE_ASSET_AUTHORITY); // byte 0: tag = 65
         data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // bytes 1-2
-        data.push(ASSET_AUTH_INSURANCE_OPERATOR);         // byte 3: kind = 2
-        data.extend_from_slice(&pda);                     // bytes 4-35
+        data.push(ASSET_AUTH_INSURANCE_OPERATOR); // byte 3: kind = 2
+        data.extend_from_slice(&pda); // bytes 4-35
 
         assert_eq!(data.len(), 36, "operator bind wire must be 36 bytes");
         assert_eq!(data[0], 65, "tag must be 65");
@@ -889,18 +907,25 @@ mod tag_tests {
     #[test]
     fn test_cpi_burn_asset_admin_wire_shape() {
         let mut data = Vec::with_capacity(36);
-        data.push(TAG_UPDATE_ASSET_AUTHORITY);             // byte 0: tag = 65
+        data.push(TAG_UPDATE_ASSET_AUTHORITY); // byte 0: tag = 65
         data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // bytes 1-2
-        data.push(ASSET_AUTH_ADMIN);                      // byte 3: kind = 0
-        data.extend_from_slice(&[0u8; 32]);               // bytes 4-35: zero burn
+        data.push(ASSET_AUTH_ADMIN); // byte 3: kind = 0
+        data.extend_from_slice(&[0u8; 32]); // bytes 4-35: zero burn
 
         assert_eq!(data.len(), 36, "admin burn wire must be 36 bytes");
         assert_eq!(data[0], 65, "tag must be 65");
         assert_eq!(data[3], 0, "kind must be 0 (ASSET_AUTH_ADMIN)");
         assert_ne!(data[3], 1, "must not be kind=1 (ASSET_AUTH_INSURANCE)");
-        assert_ne!(data[3], 2, "must not be kind=2 (ASSET_AUTH_INSURANCE_OPERATOR)");
+        assert_ne!(
+            data[3], 2,
+            "must not be kind=2 (ASSET_AUTH_INSURANCE_OPERATOR)"
+        );
         // new_pubkey must be all zeros (the burn value)
-        assert_eq!(&data[4..36], &[0u8; 32], "new_pubkey must be all-zeros for admin burn");
+        assert_eq!(
+            &data[4..36],
+            &[0u8; 32],
+            "new_pubkey must be all-zeros for admin burn"
+        );
     }
 
     /// GUARD: all three kind constants in the secure-bind sequence are distinct
@@ -909,7 +934,10 @@ mod tag_tests {
     fn test_secure_bind_kind_constants_are_distinct() {
         assert_eq!(ASSET_AUTH_ADMIN, 0, "ASSET_AUTH_ADMIN must be 0");
         assert_eq!(ASSET_AUTH_INSURANCE, 1, "ASSET_AUTH_INSURANCE must be 1");
-        assert_eq!(ASSET_AUTH_INSURANCE_OPERATOR, 2, "ASSET_AUTH_INSURANCE_OPERATOR must be 2");
+        assert_eq!(
+            ASSET_AUTH_INSURANCE_OPERATOR, 2,
+            "ASSET_AUTH_INSURANCE_OPERATOR must be 2"
+        );
         // They must all differ (confusion between these is a security footgun)
         assert_ne!(ASSET_AUTH_ADMIN, ASSET_AUTH_INSURANCE);
         assert_ne!(ASSET_AUTH_ADMIN, ASSET_AUTH_INSURANCE_OPERATOR);
@@ -930,7 +958,7 @@ mod tag_tests {
     fn test_cpi_withdraw_insurance_asset_wire_shape() {
         let amount: u64 = 250_000;
         let mut data = Vec::with_capacity(19);
-        data.push(TAG_WITHDRAW_INSURANCE_ASSET);               // byte 0: tag = 57
+        data.push(TAG_WITHDRAW_INSURANCE_ASSET); // byte 0: tag = 57
         data.extend_from_slice(&ASSET_INDEX_ZERO.to_le_bytes()); // bytes 1-2: asset_index = 0
         data.extend_from_slice(&(amount as u128).to_le_bytes()); // bytes 3-18: amount u128 LE
 
@@ -944,7 +972,11 @@ mod tag_tests {
         assert_eq!(decoded, amount as u128, "amount round-trips as u128 LE");
 
         // Guard: must NOT be the 9-byte u64 wire (would be rejected by wrapper read_u128).
-        assert_ne!(data.len(), 9, "9-byte u64 wire would be rejected by wrapper");
+        assert_ne!(
+            data.len(),
+            9,
+            "9-byte u64 wire would be rejected by wrapper"
+        );
         // Guard: tag 57, not tag 9 (TopUpInsurance) — different directions.
         assert_ne!(data[0], TAG_TOP_UP_INSURANCE, "must be tag 57, not tag 9");
     }
@@ -957,7 +989,11 @@ mod tag_tests {
         let mut data = Vec::with_capacity(1);
         data.push(TAG_RESOLVE_MARKET);
 
-        assert_eq!(data.len(), 1, "tag-19 ResolveMarket wire must be exactly 1 byte");
+        assert_eq!(
+            data.len(),
+            1,
+            "tag-19 ResolveMarket wire must be exactly 1 byte"
+        );
         assert_eq!(data[0], 19, "tag must be 19 (ResolveMarket)");
 
         // Byte-for-byte parity with the deployed vault's cpi_resolve_market:
@@ -992,9 +1028,16 @@ mod tag_tests {
             (true, false), // 0: pool PDA (marketauth), signer via invoke_signed, read-only
             (false, true), // 1: market/slab, writable, not a signer
         ];
-        assert_eq!(shape.len(), 2, "ResolveMarket CPI must pass exactly 2 accounts");
+        assert_eq!(
+            shape.len(),
+            2,
+            "ResolveMarket CPI must pass exactly 2 accounts"
+        );
         assert!(shape[0].0, "account 0 (marketauth) must be a signer");
-        assert!(!shape[0].1, "account 0 (marketauth) is read-only, not writable");
+        assert!(
+            !shape[0].1,
+            "account 0 (marketauth) is read-only, not writable"
+        );
         assert!(shape[1].1, "account 1 (market) must be writable");
         assert!(!shape[1].0, "account 1 (market) is not a signer");
     }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1111,62 +1111,98 @@ mod tests {
     #[test]
     fn poc_byte_payload_instructions_should_reject_trailing_bytes() {
         let cases: &[(u8, Vec<u8>, &str)] = &[
-            (0, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&100u64.to_le_bytes());
-                payload.extend_from_slice(&5_000u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "InitPool"),
-            (1, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&42u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "Deposit"),
-            (2, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&42u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "Withdraw"),
-            (3, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&42u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "FlushToInsurance"),
-            (10, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&42u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "ReturnInsurance"),
-            (13, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&100u64.to_le_bytes());
-                payload.extend_from_slice(&5_000u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "InitTradingPool"),
-            (15, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&1_500u16.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "AdminSetTrancheConfig"),
-            (16, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&42u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "DepositJunior"),
-            (23, {
-                let mut payload = Vec::new();
-                payload.extend_from_slice(&42u64.to_le_bytes());
-                payload.push(99);
-                payload
-            }, "RecoverFlushedInsurance"),
+            (
+                0,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&100u64.to_le_bytes());
+                    payload.extend_from_slice(&5_000u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "InitPool",
+            ),
+            (
+                1,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&42u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "Deposit",
+            ),
+            (
+                2,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&42u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "Withdraw",
+            ),
+            (
+                3,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&42u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "FlushToInsurance",
+            ),
+            (
+                10,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&42u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "ReturnInsurance",
+            ),
+            (
+                13,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&100u64.to_le_bytes());
+                    payload.extend_from_slice(&5_000u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "InitTradingPool",
+            ),
+            (
+                15,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&1_500u16.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "AdminSetTrancheConfig",
+            ),
+            (
+                16,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&42u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "DepositJunior",
+            ),
+            (
+                23,
+                {
+                    let mut payload = Vec::new();
+                    payload.extend_from_slice(&42u64.to_le_bytes());
+                    payload.push(99);
+                    payload
+                },
+                "RecoverFlushedInsurance",
+            ),
         ];
 
         for (tag, payload, name) in cases {
@@ -1202,7 +1238,11 @@ mod tests {
         let amount: u64 = 123_456_789;
         let mut data = vec![23u8];
         data.extend_from_slice(&amount.to_le_bytes());
-        assert_eq!(data.len(), 9, "tag 23 payload must be 1 tag + 8 amount bytes");
+        assert_eq!(
+            data.len(),
+            9,
+            "tag 23 payload must be 1 tag + 8 amount bytes"
+        );
         match StakeInstruction::unpack(&data).unwrap() {
             StakeInstruction::RecoverFlushedInsurance { amount: got } => {
                 assert_eq!(got, amount, "amount round-trips correctly")

--- a/src/math.rs
+++ b/src/math.rs
@@ -328,11 +328,11 @@ pub fn distribute_fees(
         let q = (total_fee as u128) / total_weight;
         let r = (total_fee as u128) % total_weight;
         let part1 = q * junior_weight; // q ≤ 2^64, junior_weight ≤ 2^80 → fits u128
-        // part2 = floor(r * junior_weight / total_weight). r < total_weight ≤ ~2^81 and
-        // junior_weight ≤ ~2^80, so r * junior_weight (~2^161) overflows u128. The previous
-        // `unwrap_or(total_fee)` fallback on that overflow handed junior 100% of the fee
-        // (0% to the protected senior tranche) — see #120. Use an exact, overflow-safe
-        // 256-bit mul-div instead. The true result is < junior_weight ≤ ~2^80, so it fits.
+                                       // part2 = floor(r * junior_weight / total_weight). r < total_weight ≤ ~2^81 and
+                                       // junior_weight ≤ ~2^80, so r * junior_weight (~2^161) overflows u128. The previous
+                                       // `unwrap_or(total_fee)` fallback on that overflow handed junior 100% of the fee
+                                       // (0% to the protected senior tranche) — see #120. Use an exact, overflow-safe
+                                       // 256-bit mul-div instead. The true result is < junior_weight ≤ ~2^80, so it fits.
         let part2 = mul_div_floor(r, junior_weight, total_weight);
         part1.saturating_add(part2)
     };
@@ -377,7 +377,11 @@ fn mul_div_floor(a: u128, b: u128, d: u128) -> u128 {
     let mut i: u32 = 256;
     while i > 0 {
         i -= 1;
-        let bit = if i >= 128 { (hi >> (i - 128)) & 1 } else { (lo >> i) & 1 };
+        let bit = if i >= 128 {
+            (hi >> (i - 128)) & 1
+        } else {
+            (lo >> i) & 1
+        };
         let rem_top = rem >> 127; // bit shifted out of the 128-bit rem below
         rem = (rem << 1) | bit;
         // Compare the true remainder (rem_top:rem) against d; reduce if >=.
@@ -496,7 +500,10 @@ mod tests {
         // way (999 <= 1000 deposited), just slightly more conservative than before.
         let back = calc_collateral_for_withdraw(5_500, 11_000, 500).unwrap();
         assert_eq!(back, 999);
-        assert!(back <= 1_000, "N7 offset must never let a withdrawal profit");
+        assert!(
+            back <= 1_000,
+            "N7 offset must never let a withdrawal profit"
+        );
     }
 
     #[test]
@@ -733,9 +740,12 @@ mod tests {
         // Deposit then immediate withdraw on the senior sub-pool must not profit.
         // Senior sub-pool after a junior-absorbed loss: senior_total_lp=1000, senior_balance=1000.
         let lp = calc_senior_lp_for_deposit(1000, 1000, 1000).unwrap(); // 1000 LP
-        // After deposit, senior_total_lp=2000, senior_balance=2000.
+                                                                        // After deposit, senior_total_lp=2000, senior_balance=2000.
         let back = calc_senior_collateral_for_withdraw(2000, 2000, lp).unwrap();
-        assert!(back <= 1000, "senior round-trip must not profit (got {back})");
+        assert!(
+            back <= 1000,
+            "senior round-trip must not profit (got {back})"
+        );
     }
 
     #[test]
@@ -941,10 +951,13 @@ mod tests {
     fn test_fee_appreciation_increases_share_price() {
         let lp_before = calc_collateral_for_withdraw(1000, 1000, 100).unwrap();
         assert_eq!(lp_before, 100); // supply == value -> offset cancels exactly
-        // N7: 100*(1200+1)/(1000+1) = 119.98... -> floor 119 (was exact 120 pre-offset).
+                                    // N7: 100*(1200+1)/(1000+1) = 119.98... -> floor 119 (was exact 120 pre-offset).
         let lp_after = calc_collateral_for_withdraw(1000, 1200, 100).unwrap();
         assert_eq!(lp_after, 119);
-        assert!(lp_after > lp_before, "fee appreciation must still raise share price");
+        assert!(
+            lp_after > lp_before,
+            "fee appreciation must still raise share price"
+        );
     }
 
     // ── N7 (CONSOLIDATED-PLAN §2.2): virtual-offset mutation checks ─────────
@@ -1003,7 +1016,10 @@ mod tests {
              STRICTLY LESS than the pre-N7 baseline {pre_n7} — equality means the virtual \
              offset was removed"
         );
-        assert!(current > 0, "sanity: this deposit must still mint something");
+        assert!(
+            current > 0,
+            "sanity: this deposit must still mint something"
+        );
     }
 
     #[test]
@@ -1028,7 +1044,10 @@ mod tests {
         // from an unrelated formula change.
         let current = calc_lp_for_deposit(500_000, 500_000, 250_000).unwrap();
         let pre_n7 = pre_n7_calc_lp_for_deposit_baseline(500_000, 500_000, 250_000).unwrap();
-        assert_eq!(current, pre_n7, "supply==value must cancel the offset exactly");
+        assert_eq!(
+            current, pre_n7,
+            "supply==value must cancel the offset exactly"
+        );
     }
 }
 

--- a/tests/c1_admin_resolve_market_e2e.rs
+++ b/tests/c1_admin_resolve_market_e2e.rs
@@ -104,7 +104,11 @@ fn canonical_vault_ata(vault_authority: &Pubkey, mint: &Pubkey) -> Pubkey {
     let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
     let ata_program = Pubkey::from_str(ATA_PROGRAM).unwrap();
     Pubkey::find_program_address(
-        &[vault_authority.as_ref(), token_program.as_ref(), mint.as_ref()],
+        &[
+            vault_authority.as_ref(),
+            token_program.as_ref(),
+            mint.as_ref(),
+        ],
         &ata_program,
     )
     .0
@@ -421,12 +425,28 @@ fn common_svm_setup() -> Option<(LiteSVM, Pubkey, Pubkey, Pubkey, Keypair, Keypa
 /// wrapper decoder and `handle_resolve_market` expect.
 #[test]
 fn admin_resolve_market_succeeds_and_actually_flips_wrapper_mode() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
-    let (market, _mint, _wrapper_vault, pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
-    inject_pool(&mut svm, stake_id, wrapper_id, market, &admin.pubkey(), 0, 0, 0);
+    let (market, _mint, _wrapper_vault, pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
+    inject_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        &admin.pubkey(),
+        0,
+        0,
+        0,
+    );
 
     // First call: must succeed (nothing outstanding, admin signs, wire is correct).
     send(
@@ -452,7 +472,9 @@ fn admin_resolve_market_succeeds_and_actually_flips_wrapper_mode() {
         TransactionError::InstructionError(_, InstructionError::Custom(_)) => {
             // expected: the wrapper's mode guard (EngineLockActive) fires.
         }
-        other => panic!("expected a Custom program error from the wrapper's mode guard, got {other:?}"),
+        other => {
+            panic!("expected a Custom program error from the wrapper's mode guard, got {other:?}")
+        }
     }
 }
 
@@ -460,16 +482,32 @@ fn admin_resolve_market_succeeds_and_actually_flips_wrapper_mode() {
 /// proxy is admin-gated, not permissionless.
 #[test]
 fn admin_resolve_market_rejects_non_admin_signer() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
     let attacker = Keypair::new();
     svm.airdrop(&attacker.pubkey(), 20_000_000_000).unwrap();
 
-    let (market, _mint, _wrapper_vault, pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, _mint, _wrapper_vault, pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
     // pool.admin == admin.pubkey(), NOT attacker.
-    inject_pool(&mut svm, stake_id, wrapper_id, market, &admin.pubkey(), 0, 0, 0);
+    inject_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        &admin.pubkey(),
+        0,
+        0,
+        0,
+    );
 
     let err = send(
         &mut svm,
@@ -480,7 +518,10 @@ fn admin_resolve_market_rejects_non_admin_signer() {
     .expect_err("AdminResolveMarket must reject a non-admin signer");
     match err {
         TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
-            assert_eq!(code, 2, "expected StakeError::Unauthorized (2), got Custom({code})");
+            assert_eq!(
+                code, 2,
+                "expected StakeError::Unauthorized (2), got Custom({code})"
+            );
         }
         other => panic!("expected Custom(2) Unauthorized, got {other:?}"),
     }
@@ -492,13 +533,29 @@ fn admin_resolve_market_rejects_non_admin_signer() {
 /// remain resolvable-later (mode unchanged) after the rejection.
 #[test]
 fn admin_resolve_market_h1_blocked_by_outstanding_flushed_insurance() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
-    let (market, _mint, _wrapper_vault, pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, _mint, _wrapper_vault, pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
     // 600 tokens flushed, only 400 recovered from the wrapper -> 200 outstanding.
-    inject_pool(&mut svm, stake_id, wrapper_id, market, &admin.pubkey(), 600, 400, 400);
+    inject_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        &admin.pubkey(),
+        600,
+        400,
+        400,
+    );
 
     let err = send(
         &mut svm,
@@ -532,13 +589,29 @@ fn admin_resolve_market_h1_blocked_by_outstanding_flushed_insurance() {
 /// the fix.
 #[test]
 fn admin_resolve_market_h1_unblocked_after_recovery() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
-    let (market, _mint, _wrapper_vault, pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, _mint, _wrapper_vault, pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
     // Fully recovered from the wrapper: 600 flushed, 600 recovered -> 0 outstanding.
-    inject_pool(&mut svm, stake_id, wrapper_id, market, &admin.pubkey(), 600, 600, 600);
+    inject_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        &admin.pubkey(),
+        600,
+        600,
+        600,
+    );
 
     send(
         &mut svm,
@@ -560,16 +633,32 @@ fn admin_resolve_market_h1_unblocked_after_recovery() {
 /// instruction — proving the fix closes the exact hole the re-review found.
 #[test]
 fn admin_resolve_market_h1_blocked_when_only_total_returned_satisfied() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
-    let (market, _mint, _wrapper_vault, pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, _mint, _wrapper_vault, pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
     // total_returned == total_flushed (the OLD gate's condition is satisfied),
     // but total_recovered_from_wrapper == 0 — nothing was ever CPI'd out of
     // the wrapper. This is the exact state ReturnInsurance-only bookkeeping
     // (or the #161 phantom write-off) produces.
-    inject_pool(&mut svm, stake_id, wrapper_id, market, &admin.pubkey(), 600, 600, 0);
+    inject_pool(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        &admin.pubkey(),
+        600,
+        600,
+        0,
+    );
 
     let err = send(
         &mut svm,
@@ -802,24 +891,52 @@ fn read_pool_state(svm: &LiteSVM, pool_pda: &Pubkey) -> StakePool {
 /// resolution while flushed capital sits stranded in the wrapper.
 #[test]
 fn admin_resolve_market_h1_blocked_by_real_return_insurance_call() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
-    let (market, mint, wrapper_vault, _rotated_pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, mint, wrapper_vault, _rotated_pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
 
-    let ctx = inject_pool_with_vault(&mut svm, stake_id, wrapper_id, market, mint, &admin.pubkey(), FLUSH_AMOUNT);
+    let ctx = inject_pool_with_vault(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        mint,
+        &admin.pubkey(),
+        FLUSH_AMOUNT,
+    );
 
     // Bind + flush: real collateral moves stake_vault -> wrapper_vault, and
     // pool.total_flushed genuinely advances to FLUSH_AMOUNT.
-    send(&mut svm, &payer, &[&admin], bind_ix(&ctx, wrapper_id, market, &admin.pubkey()))
-        .expect("BindInsuranceAuthority");
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        bind_ix(&ctx, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("BindInsuranceAuthority");
     svm.expire_blockhash();
     send(
         &mut svm,
         &payer,
         &[&admin],
-        flush_ix(&ctx, wrapper_id, token_program, market, wrapper_vault, &admin.pubkey(), FLUSH_AMOUNT),
+        flush_ix(
+            &ctx,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            &admin.pubkey(),
+            FLUSH_AMOUNT,
+        ),
     )
     .expect("FlushToInsurance");
 
@@ -839,7 +956,14 @@ fn admin_resolve_market_h1_blocked_by_real_return_insurance_call() {
         &mut svm,
         &payer,
         &[&admin],
-        return_insurance_ix(ctx.pool_pda, admin_ata, ctx.stake_vault, token_program, &admin.pubkey(), FLUSH_AMOUNT),
+        return_insurance_ix(
+            ctx.pool_pda,
+            admin_ata,
+            ctx.stake_vault,
+            token_program,
+            &admin.pubkey(),
+            FLUSH_AMOUNT,
+        ),
     )
     .expect("ReturnInsurance must succeed — it's a real self-funded transfer, not the bug");
 
@@ -888,23 +1012,52 @@ fn admin_resolve_market_h1_blocked_by_real_return_insurance_call() {
 /// that real recovery has run does `AdminResolveMarket` succeed.
 #[test]
 fn admin_resolve_market_h1_unblocked_only_after_real_recover_flushed_insurance() {
-    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup() else {
+    let Some((mut svm, stake_id, wrapper_id, token_program, admin, payer)) = common_svm_setup()
+    else {
         return;
     };
-    let (market, mint, wrapper_vault, _rotated_pool_pda) =
-        setup_resolved_ready_market(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, mint, wrapper_vault, _rotated_pool_pda) = setup_resolved_ready_market(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
 
-    let ctx = inject_pool_with_vault(&mut svm, stake_id, wrapper_id, market, mint, &admin.pubkey(), FLUSH_AMOUNT);
-    let wrapper_vault_auth = Pubkey::find_program_address(&[b"vault", market.as_ref()], &wrapper_id).0;
+    let ctx = inject_pool_with_vault(
+        &mut svm,
+        stake_id,
+        wrapper_id,
+        market,
+        mint,
+        &admin.pubkey(),
+        FLUSH_AMOUNT,
+    );
+    let wrapper_vault_auth =
+        Pubkey::find_program_address(&[b"vault", market.as_ref()], &wrapper_id).0;
 
-    send(&mut svm, &payer, &[&admin], bind_ix(&ctx, wrapper_id, market, &admin.pubkey()))
-        .expect("BindInsuranceAuthority");
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        bind_ix(&ctx, wrapper_id, market, &admin.pubkey()),
+    )
+    .expect("BindInsuranceAuthority");
     svm.expire_blockhash();
     send(
         &mut svm,
         &payer,
         &[&admin],
-        flush_ix(&ctx, wrapper_id, token_program, market, wrapper_vault, &admin.pubkey(), FLUSH_AMOUNT),
+        flush_ix(
+            &ctx,
+            wrapper_id,
+            token_program,
+            market,
+            wrapper_vault,
+            &admin.pubkey(),
+            FLUSH_AMOUNT,
+        ),
     )
     .expect("FlushToInsurance");
 
@@ -919,7 +1072,10 @@ fn admin_resolve_market_h1_unblocked_only_after_real_recover_flushed_insurance()
     .expect_err("AdminResolveMarket must be blocked before any recovery");
     match blocked {
         TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
-            assert_eq!(code, 24, "expected InsuranceLossOutstanding pre-recovery, got {code}");
+            assert_eq!(
+                code, 24,
+                "expected InsuranceLossOutstanding pre-recovery, got {code}"
+            );
         }
         other => panic!("expected Custom(24), got {other:?}"),
     }

--- a/tests/cpi_tags.rs
+++ b/tests/cpi_tags.rs
@@ -80,7 +80,11 @@ fn test_cpi_tag32_update_authority_wire_33_bytes() {
         "tag-32 marketauth-rotation wire must be 1 (tag) + 32 (pubkey) = 33 bytes"
     );
     assert_eq!(data[0], 32, "byte 0 must be tag=32 (UpdateAuthority)");
-    assert_eq!(&data[1..33], &new_authority, "new_authority pubkey at bytes [1..33]");
+    assert_eq!(
+        &data[1..33],
+        &new_authority,
+        "new_authority pubkey at bytes [1..33]"
+    );
 
     // Byte-for-byte parity with the deployed vault's exact wire construction
     // (percolator-vault@eb3ebe8 src/cpi.rs cpi_update_authority):
@@ -104,12 +108,15 @@ fn test_cpi_tag32_update_authority_wire_33_bytes() {
 fn test_cpi_tag32_account_shape_is_three_accounts_both_signers() {
     // [is_signer, is_writable] per account, in order.
     let shape = [
-        (true, false),  // 0: current_authority (signer, read-only)
-        (true, false),  // 1: new_authority (signer, read-only)
-        (false, true),  // 2: market/slab (writable, not a signer)
+        (true, false), // 0: current_authority (signer, read-only)
+        (true, false), // 1: new_authority (signer, read-only)
+        (false, true), // 2: market/slab (writable, not a signer)
     ];
     assert_eq!(shape.len(), 3, "tag 32 CPI must pass exactly 3 accounts");
-    assert!(shape[0].0 && shape[1].0, "both authority slots must be signers");
+    assert!(
+        shape[0].0 && shape[1].0,
+        "both authority slots must be signers"
+    );
     assert!(shape[2].1, "the market account must be writable");
     assert!(!shape[2].0, "the market account is not a signer");
 }
@@ -149,7 +156,10 @@ fn test_cpi_tag65_update_asset_authority_wire_36_bytes() {
 
     // (1) Tag = 65
     assert_eq!(data[0], 65, "byte 0 must be tag=65 (UpdateAssetAuthority)");
-    assert_ne!(data[0], 32, "tag 32 is the OLD UpdateAuthority — must NOT ship");
+    assert_ne!(
+        data[0], 32,
+        "tag 32 is the OLD UpdateAuthority — must NOT ship"
+    );
 
     // (2) asset_index = 0 (u16 LE, bytes 1-2)
     assert_eq!(data[1], 0x00, "asset_index low byte must be 0x00");
@@ -159,7 +169,10 @@ fn test_cpi_tag65_update_asset_authority_wire_36_bytes() {
 
     // (3) kind = 1, NOT 2
     assert_eq!(data[3], 1, "byte 3 must be kind=1 (ASSET_AUTH_INSURANCE)");
-    assert_ne!(data[3], 2, "kind=2 is old AUTHORITY_INSURANCE — must NOT ship");
+    assert_ne!(
+        data[3], 2,
+        "kind=2 is old AUTHORITY_INSURANCE — must NOT ship"
+    );
 
     // pubkey round-trip
     assert_eq!(&data[4..36], &new_pubkey, "new_pubkey at bytes [4..36]");
@@ -176,7 +189,7 @@ fn test_old_v16_bind_wire_documents_the_break() {
     // The v16 wire
     let mut old_data: Vec<u8> = Vec::with_capacity(34);
     old_data.push(32u8); // old tag
-    old_data.push(2u8);  // old kind = AUTHORITY_INSURANCE (from v16 UpdateAuthority enum)
+    old_data.push(2u8); // old kind = AUTHORITY_INSURANCE (from v16 UpdateAuthority enum)
     old_data.extend_from_slice(&new_pubkey);
 
     // Document what was wrong:
@@ -185,10 +198,7 @@ fn test_old_v16_bind_wire_documents_the_break() {
     assert_eq!(old_data[1], 2, "old kind was 2 (AUTHORITY_INSURANCE)");
 
     // In v17, the correct wire has a different tag, kind, and 2 extra bytes
-    assert_ne!(
-        old_data[0], 65,
-        "old wire used tag 32; v17 requires tag 65"
-    );
+    assert_ne!(old_data[0], 65, "old wire used tag 32; v17 requires tag 65");
     assert_ne!(
         old_data.len(),
         36,
@@ -201,7 +211,7 @@ fn test_old_v16_bind_wire_documents_the_break() {
 /// vault_auth PDA, but the wire structure is byte-identical.
 #[test]
 fn test_bind_and_rotate_produce_same_wire_shape() {
-    let pda_pubkey = [0x11u8; 32];   // vault_auth PDA (bind target)
+    let pda_pubkey = [0x11u8; 32]; // vault_auth PDA (bind target)
     let rotate_target = [0x22u8; 32]; // rotation destination (rotate target)
 
     let mut bind_wire = Vec::with_capacity(36);
@@ -225,7 +235,8 @@ fn test_bind_and_rotate_produce_same_wire_shape() {
 
     // Only the pubkey differs
     assert_ne!(
-        &bind_wire[4..36], &rotate_wire[4..36],
+        &bind_wire[4..36],
+        &rotate_wire[4..36],
         "new_pubkey bytes differ between bind and rotate"
     );
 }
@@ -243,7 +254,11 @@ fn test_bind_and_rotate_produce_same_wire_shape() {
 fn test_cpi_tag19_resolve_market_wire_is_1_byte() {
     let data = vec![19u8]; // mirrors cpi::cpi_resolve_market's `vec![TAG_RESOLVE_MARKET]`
 
-    assert_eq!(data.len(), 1, "tag-19 ResolveMarket wire must be exactly 1 byte");
+    assert_eq!(
+        data.len(),
+        1,
+        "tag-19 ResolveMarket wire must be exactly 1 byte"
+    );
     assert_eq!(data[0], 19, "byte 0 must be tag=19 (ResolveMarket)");
 
     // Byte-for-byte parity with the deployed vault's cpi_resolve_market
@@ -268,7 +283,11 @@ fn test_cpi_tag19_account_shape_is_two_accounts() {
         (true, false), // 0: admin/marketauth (pool PDA), signer via invoke_signed, read-only
         (false, true), // 1: market/slab, writable, not a signer
     ];
-    assert_eq!(shape.len(), 2, "ResolveMarket CPI must pass exactly 2 accounts");
+    assert_eq!(
+        shape.len(),
+        2,
+        "ResolveMarket CPI must pass exactly 2 accounts"
+    );
     assert!(shape[0].0, "account 0 (marketauth) must be a signer");
     assert!(!shape[0].1, "account 0 (marketauth) is read-only");
     assert!(shape[1].1, "account 1 (market) must be writable");
@@ -294,6 +313,9 @@ fn test_cpi_tag19_wire_length_distinct_from_other_cpis() {
         update_asset_authority_len,
         withdraw_insurance_asset_len,
     ] {
-        assert_ne!(resolve_market_len, other, "tag-19 wire length must stay distinct");
+        assert_ne!(
+            resolve_market_len, other,
+            "tag-19 wire length must stay distinct"
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -57,7 +57,9 @@ fn test_full_senior_deposit_withdraw_cycle() {
 
     // Step 2: Deposit 5_000_000
     let deposit_amount = 5_000_000u64;
-    let lp = pool.calc_lp_for_deposit(deposit_amount).expect("calc_lp must succeed");
+    let lp = pool
+        .calc_lp_for_deposit(deposit_amount)
+        .expect("calc_lp must succeed");
     assert_eq!(lp, deposit_amount, "first depositor gets 1:1 LP");
     pool.total_deposited += deposit_amount;
     pool.total_lp_supply += lp;
@@ -68,7 +70,9 @@ fn test_full_senior_deposit_withdraw_cycle() {
     // (pool_mode=1 required for fees to count in pool_value)
     pool.pool_mode = 1;
     pool.total_fees_earned = 100_000;
-    let pool_value_with_fees = pool.total_pool_value().expect("pool value must be computable");
+    let pool_value_with_fees = pool
+        .total_pool_value()
+        .expect("pool value must be computable");
     assert_eq!(pool_value_with_fees, deposit_amount + 100_000);
 
     // Step 4: Withdraw all LP
@@ -77,12 +81,18 @@ fn test_full_senior_deposit_withdraw_cycle() {
     let collateral_back = pool
         .calc_collateral_for_withdraw(lp)
         .expect("calc_collateral must succeed");
-    assert_eq!(collateral_back, deposit_amount, "first depositor gets exact amount back");
+    assert_eq!(
+        collateral_back, deposit_amount,
+        "first depositor gets exact amount back"
+    );
 
     pool.total_withdrawn += collateral_back;
     pool.total_lp_supply -= lp;
 
-    assert_eq!(pool.total_lp_supply, 0, "LP supply must be zero after full withdrawal");
+    assert_eq!(
+        pool.total_lp_supply, 0,
+        "LP supply must be zero after full withdrawal"
+    );
     assert_eq!(
         pool.total_pool_value(),
         Some(0),
@@ -237,7 +247,10 @@ fn test_insurance_loss_exceeds_junior_spills_to_senior() {
 
     let eff_junior = pool.effective_junior_balance();
     // junior (2M) fully wiped, returns 0
-    assert_eq!(eff_junior, 0, "junior is fully wiped by a loss exceeding its balance");
+    assert_eq!(
+        eff_junior, 0,
+        "junior is fully wiped by a loss exceeding its balance"
+    );
 
     // pool_value = 15M - 5M = 10M, senior = 10M - 0 = 10M
     // But senior also lost 3M (the spill-over): senior = 10M - 0 = 10M
@@ -259,7 +272,10 @@ fn test_flush_to_insurance_cpi_tag_is_9() {
     data.push(9u8); // TAG_TOP_UP_INSURANCE
     data.extend_from_slice(&amount.to_le_bytes());
 
-    assert_eq!(data[0], 9, "FlushToInsurance must use CPI tag 9 (TopUpInsurance)");
+    assert_eq!(
+        data[0], 9,
+        "FlushToInsurance must use CPI tag 9 (TopUpInsurance)"
+    );
     assert_eq!(&data[1..9], &amount.to_le_bytes());
 }
 
@@ -318,7 +334,10 @@ fn test_set_discriminator_sets_version_and_magic() {
     let mut pool = StakePool::zeroed();
     pool.set_discriminator();
 
-    assert!(pool.validate_discriminator(), "discriminator must validate after set_discriminator");
+    assert!(
+        pool.validate_discriminator(),
+        "discriminator must validate after set_discriminator"
+    );
     assert_eq!(
         pool.version(),
         StakePool::CURRENT_VERSION,
@@ -346,7 +365,10 @@ fn test_zeroed_pool_fails_discriminator() {
 #[test]
 fn test_initialized_pool_passes_discriminator() {
     let pool = initialized_pool();
-    assert!(pool.validate_discriminator(), "Initialized pool must pass discriminator validation");
+    assert!(
+        pool.validate_discriminator(),
+        "Initialized pool must pass discriminator validation"
+    );
 }
 
 /// Pool with corrupted discriminator (one byte flipped) must fail.
@@ -587,10 +609,7 @@ fn test_flush_reduces_pool_value() {
 
     pool.total_flushed = 3_000_000; // 3M moved to insurance
     let value = pool.total_pool_value().unwrap();
-    assert_eq!(
-        value, 7_000_000,
-        "Flushed amount must reduce pool value"
-    );
+    assert_eq!(value, 7_000_000, "Flushed amount must reduce pool value");
 }
 
 /// Full flush + return roundtrip is conservative (value restored exactly).
@@ -620,7 +639,10 @@ fn test_partial_return_reflects_insurance_loss() {
 
     let value = pool.total_pool_value().unwrap();
     // 10M - 3M + 1M = 8M (2M permanently lost)
-    assert_eq!(value, 8_000_000, "Partial return must reflect the 2M insurance loss");
+    assert_eq!(
+        value, 8_000_000,
+        "Partial return must reflect the 2M insurance loss"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════
@@ -631,7 +653,10 @@ fn test_partial_return_reflects_insurance_loss() {
 #[test]
 fn test_market_resolved_blocks_deposits() {
     let mut pool = initialized_pool();
-    assert!(!pool.market_resolved(), "Pool must not be resolved initially");
+    assert!(
+        !pool.market_resolved(),
+        "Pool must not be resolved initially"
+    );
 
     pool.set_market_resolved(true);
     assert!(
@@ -700,7 +725,10 @@ fn test_all_standard_instruction_tags_decode() {
     data.extend_from_slice(&50u64.to_le_bytes()); // cooldown_slots
     data.extend_from_slice(&5_000_000u64.to_le_bytes()); // deposit_cap
     match StakeInstruction::unpack(&data).unwrap() {
-        StakeInstruction::InitPool { cooldown_slots, deposit_cap } => {
+        StakeInstruction::InitPool {
+            cooldown_slots,
+            deposit_cap,
+        } => {
             assert_eq!(cooldown_slots, 50);
             assert_eq!(deposit_cap, 5_000_000);
         }
@@ -787,7 +815,10 @@ fn test_invalid_instruction_tags_rejected() {
 /// Empty instruction data must return error.
 #[test]
 fn test_empty_instruction_data_rejected() {
-    assert!(StakeInstruction::unpack(&[]).is_err(), "Empty data must be rejected");
+    assert!(
+        StakeInstruction::unpack(&[]).is_err(),
+        "Empty data must be rejected"
+    );
 }
 
 /// Truncated instruction data must return error.
@@ -859,7 +890,10 @@ fn test_deposit_pda_per_user_deterministic() {
     let (dep_b, _) = derive_deposit_pda(&program_id, &pool, &user_b);
 
     assert_eq!(dep_a1, dep_a2, "Same user must get same deposit PDA");
-    assert_ne!(dep_a1, dep_b, "Different users must get different deposit PDAs");
+    assert_ne!(
+        dep_a1, dep_b,
+        "Different users must get different deposit PDAs"
+    );
 }
 
 // ════════════════════════════════════════════════════════════════
@@ -906,7 +940,11 @@ fn test_large_amounts_no_overflow() {
     pool.total_lp_supply = u64::MAX / 2;
 
     let lp = pool.calc_lp_for_deposit(u64::MAX / 4).unwrap();
-    assert_eq!(lp, u64::MAX / 4, "Large LP calculation must use u128 intermediate");
+    assert_eq!(
+        lp,
+        u64::MAX / 4,
+        "Large LP calculation must use u128 intermediate"
+    );
 }
 
 /// Regression: fully-wiped junior LP should be able to burn worthless LP and exit.

--- a/tests/kani.rs
+++ b/tests/kani.rs
@@ -27,9 +27,7 @@
 
 #[cfg(kani)]
 mod kani_proofs {
-    use percolator_stake::math::{
-        calc_collateral_for_withdraw, calc_lp_for_deposit, pool_value,
-    };
+    use percolator_stake::math::{calc_collateral_for_withdraw, calc_lp_for_deposit, pool_value};
 
     // ═══════════════════════════════════════════════════════════
     // 1. LP Conservation — No Inflation
@@ -180,7 +178,6 @@ mod kani_proofs {
         let withdrawn: u64 = kani::any();
         let _ = pool_value(deposited, withdrawn);
     }
-
 
     // ═══════════════════════════════════════════════════════════
     // 3. Fairness — Monotonicity
@@ -783,8 +780,7 @@ mod kani_proofs {
         let proposed_at: u64 = kani::any();
         let timelock: u64 = kani::any();
         let now: u64 = kani::any();
-        let res =
-            percolator_stake::processor::timelock_window_elapsed(proposed_at, timelock, now);
+        let res = percolator_stake::processor::timelock_window_elapsed(proposed_at, timelock, now);
         match proposed_at.checked_add(timelock) {
             None => assert!(res.is_err()),
             Some(earliest) => assert_eq!(res, Ok(now >= earliest)),

--- a/tests/mode0_accrue_fees_e2e.rs
+++ b/tests/mode0_accrue_fees_e2e.rs
@@ -173,7 +173,12 @@ fn build_live_market_v17(
     (market, mint)
 }
 
-fn preallocate_empty_spl_account(svm: &mut LiteSVM, key: Pubkey, token_program: Pubkey, size: usize) {
+fn preallocate_empty_spl_account(
+    svm: &mut LiteSVM,
+    key: Pubkey,
+    token_program: Pubkey,
+    size: usize,
+) {
     svm.set_account(
         key,
         Account {
@@ -210,7 +215,12 @@ struct InitPoolAccounts {
     token_program: Pubkey,
 }
 
-fn init_pool_ix(stake_id: Pubkey, a: &InitPoolAccounts, cooldown_slots: u64, deposit_cap: u64) -> Instruction {
+fn init_pool_ix(
+    stake_id: Pubkey,
+    a: &InitPoolAccounts,
+    cooldown_slots: u64,
+    deposit_cap: u64,
+) -> Instruction {
     Instruction {
         program_id: stake_id,
         accounts: vec![
@@ -335,13 +345,18 @@ fn deposit_ix(
 // ---- Stake AccrueFees (tag 12) — real instruction. Accounts per
 // instruction.rs:299-306 / processor.rs:2543-2551. ----
 
-fn accrue_fees_ix(stake_id: Pubkey, caller: &Pubkey, pool_pda: Pubkey, vault: Pubkey) -> Instruction {
+fn accrue_fees_ix(
+    stake_id: Pubkey,
+    caller: &Pubkey,
+    pool_pda: Pubkey,
+    vault: Pubkey,
+) -> Instruction {
     Instruction {
         program_id: stake_id,
         accounts: vec![
             AccountMeta::new_readonly(*caller, true), // 0. caller [signer, permissionless]
-            AccountMeta::new(pool_pda, false),         // 1. pool PDA [writable]
-            AccountMeta::new_readonly(vault, false),   // 2. vault [readonly, balance only]
+            AccountMeta::new(pool_pda, false),        // 1. pool PDA [writable]
+            AccountMeta::new_readonly(vault, false),  // 2. vault [readonly, balance only]
             AccountMeta::new_readonly(solana_sdk::sysvar::clock::id(), false), // 3. clock
         ],
         data: vec![12u8], // tag = AccrueFees
@@ -391,23 +406,50 @@ fn mode0_pool_accrues_fees_via_real_accrue_fees_instruction() {
 
     // ---- InitPool (real instruction; pool_mode = 0 is InitPool's hardcoded
     // default -- see processor.rs:672. This is the path EVERY real client uses. ----
-    let (_market, accts) = setup(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
-    send(&mut svm, &payer, &[&admin], init_pool_ix(stake_id, &accts, 5, 0))
-        .unwrap_or_else(|e| panic!("InitPool must succeed.\nLogs:\n{}", e.meta.logs.join("\n")));
+    let (_market, accts) = setup(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        init_pool_ix(stake_id, &accts, 5, 0),
+    )
+    .unwrap_or_else(|e| panic!("InitPool must succeed.\nLogs:\n{}", e.meta.logs.join("\n")));
 
     let pool_before_deposit = read_pool(&svm, &accts.pool_pda);
-    assert_eq!(pool_before_deposit.pool_mode, 0, "InitPool must produce a mode-0 pool");
-    assert_eq!(pool_before_deposit.total_fees_earned, 0, "genesis pool has no fees yet");
+    assert_eq!(
+        pool_before_deposit.pool_mode, 0,
+        "InitPool must produce a mode-0 pool"
+    );
+    assert_eq!(
+        pool_before_deposit.total_fees_earned, 0,
+        "genesis pool has no fees yet"
+    );
 
     // ---- Deposit (real instruction; genesis deposit, so LP = amount - MINIMUM_LIQUIDITY). ----
     let user_ata = Pubkey::new_unique();
-    set_token_account(&mut svm, user_ata, &accts.collateral_mint, &user.pubkey(), 10_000);
+    set_token_account(
+        &mut svm,
+        user_ata,
+        &accts.collateral_mint,
+        &user.pubkey(),
+        10_000,
+    );
     let user_lp_ata = Pubkey::new_unique();
     set_token_account(&mut svm, user_lp_ata, &accts.lp_mint, &user.pubkey(), 0);
     let (deposit_pda, _) = derive_deposit_pda(&stake_id, &accts.pool_pda, &user.pubkey());
 
     let deposit_amount: u64 = 2_000;
-    assert!(deposit_amount > MINIMUM_LIQUIDITY, "must clear the N7 dead-share floor");
+    assert!(
+        deposit_amount > MINIMUM_LIQUIDITY,
+        "must clear the N7 dead-share floor"
+    );
     let dep_ix = deposit_ix(
         stake_id,
         &user.pubkey(),
@@ -424,7 +466,10 @@ fn mode0_pool_accrues_fees_via_real_accrue_fees_instruction() {
         .unwrap_or_else(|e| panic!("Deposit must succeed.\nLogs:\n{}", e.meta.logs.join("\n")));
 
     let pool_before_accrue = read_pool(&svm, &accts.pool_pda);
-    assert_eq!(pool_before_accrue.pool_mode, 0, "pool_mode is immutable after InitPool");
+    assert_eq!(
+        pool_before_accrue.pool_mode, 0,
+        "pool_mode is immutable after InitPool"
+    );
     assert_eq!(
         token_amount(&svm, &accts.vault),
         deposit_amount,
@@ -433,7 +478,10 @@ fn mode0_pool_accrues_fees_via_real_accrue_fees_instruction() {
     let pool_value_before = pool_before_accrue
         .total_pool_value()
         .expect("pool value must be computable pre-accrual");
-    assert_eq!(pool_value_before, deposit_amount, "pre-accrual: tpv == the real deposit, no fees yet");
+    assert_eq!(
+        pool_value_before, deposit_amount,
+        "pre-accrual: tpv == the real deposit, no fees yet"
+    );
 
     // ---- The ONE authorized forgery (task-11-brief.md step 3 / task instructions'
     // "Explicit permission" section): set the vault's token balance directly to
@@ -464,7 +512,10 @@ fn mode0_pool_accrues_fees_via_real_accrue_fees_instruction() {
 
     // ---- Assertions on the REAL post-instruction state. ----
     let pool_after = read_pool(&svm, &accts.pool_pda);
-    assert_eq!(pool_after.pool_mode, 0, "AccrueFees must not mutate pool_mode");
+    assert_eq!(
+        pool_after.pool_mode, 0,
+        "AccrueFees must not mutate pool_mode"
+    );
     assert_eq!(
         pool_after.total_fees_earned, surplus,
         "total_fees_earned must grow by EXACTLY the vault surplus"

--- a/tests/mode0_pre_accrue_dilution_e2e.rs
+++ b/tests/mode0_pre_accrue_dilution_e2e.rs
@@ -207,7 +207,12 @@ fn build_live_market_v17(
     (market, mint)
 }
 
-fn preallocate_empty_spl_account(svm: &mut LiteSVM, key: Pubkey, token_program: Pubkey, size: usize) {
+fn preallocate_empty_spl_account(
+    svm: &mut LiteSVM,
+    key: Pubkey,
+    token_program: Pubkey,
+    size: usize,
+) {
     svm.set_account(
         key,
         Account {
@@ -243,7 +248,12 @@ struct InitPoolAccounts {
     token_program: Pubkey,
 }
 
-fn init_pool_ix(stake_id: Pubkey, a: &InitPoolAccounts, cooldown_slots: u64, deposit_cap: u64) -> Instruction {
+fn init_pool_ix(
+    stake_id: Pubkey,
+    a: &InitPoolAccounts,
+    cooldown_slots: u64,
+    deposit_cap: u64,
+) -> Instruction {
     Instruction {
         program_id: stake_id,
         accounts: vec![
@@ -361,13 +371,18 @@ fn deposit_ix(
 
 // ---- Stake AccrueFees (tag 12) -- copied verbatim from mode0_accrue_fees_e2e.rs. ----
 
-fn accrue_fees_ix(stake_id: Pubkey, caller: &Pubkey, pool_pda: Pubkey, vault: Pubkey) -> Instruction {
+fn accrue_fees_ix(
+    stake_id: Pubkey,
+    caller: &Pubkey,
+    pool_pda: Pubkey,
+    vault: Pubkey,
+) -> Instruction {
     Instruction {
         program_id: stake_id,
         accounts: vec![
             AccountMeta::new_readonly(*caller, true), // 0. caller [signer, permissionless]
-            AccountMeta::new(pool_pda, false),         // 1. pool PDA [writable]
-            AccountMeta::new_readonly(vault, false),   // 2. vault [readonly, balance only]
+            AccountMeta::new(pool_pda, false),        // 1. pool PDA [writable]
+            AccountMeta::new_readonly(vault, false),  // 2. vault [readonly, balance only]
             AccountMeta::new_readonly(solana_sdk::sysvar::clock::id(), false), // 3. clock
         ],
         data: vec![12u8], // tag = AccrueFees
@@ -439,20 +454,52 @@ fn mode0_deposit_priced_after_crystallization_not_before() {
 
     // ---- InitPool (real; pool_mode = 0, InitPool's hardcoded default -- the
     // path EVERY real client uses). ----
-    let (_market, accts) = setup(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
-    send(&mut svm, &payer, &[&admin], init_pool_ix(stake_id, &accts, 5, 0))
-        .unwrap_or_else(|e| panic!("InitPool must succeed.\nLogs:\n{}", e.meta.logs.join("\n")));
-    assert_eq!(read_pool(&svm, &accts.pool_pda).pool_mode, 0, "InitPool must produce a mode-0 pool");
+    let (_market, accts) = setup(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        init_pool_ix(stake_id, &accts, 5, 0),
+    )
+    .unwrap_or_else(|e| panic!("InitPool must succeed.\nLogs:\n{}", e.meta.logs.join("\n")));
+    assert_eq!(
+        read_pool(&svm, &accts.pool_pda).pool_mode,
+        0,
+        "InitPool must produce a mode-0 pool"
+    );
 
     // ---- Genesis deposit by an honest LP (real instruction). ----
     const GENESIS_DEPOSIT: u64 = 100_000;
-    assert!(GENESIS_DEPOSIT > MINIMUM_LIQUIDITY, "must clear the N7 dead-share floor");
+    assert!(
+        GENESIS_DEPOSIT > MINIMUM_LIQUIDITY,
+        "must clear the N7 dead-share floor"
+    );
 
     let genesis_ata = Pubkey::new_unique();
-    set_token_account(&mut svm, genesis_ata, &accts.collateral_mint, &genesis_lp.pubkey(), GENESIS_DEPOSIT);
+    set_token_account(
+        &mut svm,
+        genesis_ata,
+        &accts.collateral_mint,
+        &genesis_lp.pubkey(),
+        GENESIS_DEPOSIT,
+    );
     let genesis_lp_ata = Pubkey::new_unique();
-    set_token_account(&mut svm, genesis_lp_ata, &accts.lp_mint, &genesis_lp.pubkey(), 0);
-    let (genesis_deposit_pda, _) = derive_deposit_pda(&stake_id, &accts.pool_pda, &genesis_lp.pubkey());
+    set_token_account(
+        &mut svm,
+        genesis_lp_ata,
+        &accts.lp_mint,
+        &genesis_lp.pubkey(),
+        0,
+    );
+    let (genesis_deposit_pda, _) =
+        derive_deposit_pda(&stake_id, &accts.pool_pda, &genesis_lp.pubkey());
 
     let genesis_dep_ix = deposit_ix(
         stake_id,
@@ -466,8 +513,12 @@ fn mode0_deposit_priced_after_crystallization_not_before() {
         genesis_deposit_pda,
         GENESIS_DEPOSIT,
     );
-    send(&mut svm, &payer, &[&genesis_lp], genesis_dep_ix)
-        .unwrap_or_else(|e| panic!("Genesis deposit must succeed.\nLogs:\n{}", e.meta.logs.join("\n")));
+    send(&mut svm, &payer, &[&genesis_lp], genesis_dep_ix).unwrap_or_else(|e| {
+        panic!(
+            "Genesis deposit must succeed.\nLogs:\n{}",
+            e.meta.logs.join("\n")
+        )
+    });
 
     let mint_amount_genesis = token_amount(&svm, &genesis_lp_ata);
     assert_eq!(
@@ -478,7 +529,10 @@ fn mode0_deposit_priced_after_crystallization_not_before() {
 
     let pool_before_surplus = read_pool(&svm, &accts.pool_pda);
     let total_lp_supply_before = pool_before_surplus.total_lp_supply;
-    assert_eq!(total_lp_supply_before, GENESIS_DEPOSIT, "sanity: full genesis lp_to_mint incl. dead share");
+    assert_eq!(
+        total_lp_supply_before, GENESIS_DEPOSIT,
+        "sanity: full genesis lp_to_mint incl. dead share"
+    );
     assert_eq!(
         token_amount(&svm, &accts.vault),
         GENESIS_DEPOSIT,
@@ -521,10 +575,23 @@ fn mode0_deposit_priced_after_crystallization_not_before() {
     // permissionless AccrueFees in the same transaction". ----
     const ATTACKER_DEPOSIT: u64 = GENESIS_DEPOSIT;
     let attacker_ata = Pubkey::new_unique();
-    set_token_account(&mut svm, attacker_ata, &accts.collateral_mint, &attacker.pubkey(), ATTACKER_DEPOSIT);
+    set_token_account(
+        &mut svm,
+        attacker_ata,
+        &accts.collateral_mint,
+        &attacker.pubkey(),
+        ATTACKER_DEPOSIT,
+    );
     let attacker_lp_ata = Pubkey::new_unique();
-    set_token_account(&mut svm, attacker_lp_ata, &accts.lp_mint, &attacker.pubkey(), 0);
-    let (attacker_deposit_pda, _) = derive_deposit_pda(&stake_id, &accts.pool_pda, &attacker.pubkey());
+    set_token_account(
+        &mut svm,
+        attacker_lp_ata,
+        &accts.lp_mint,
+        &attacker.pubkey(),
+        0,
+    );
+    let (attacker_deposit_pda, _) =
+        derive_deposit_pda(&stake_id, &accts.pool_pda, &attacker.pubkey());
 
     let attacker_dep_ix = deposit_ix(
         stake_id,
@@ -538,16 +605,22 @@ fn mode0_deposit_priced_after_crystallization_not_before() {
         attacker_deposit_pda,
         ATTACKER_DEPOSIT,
     );
-    let attacker_accrue_ix = accrue_fees_ix(stake_id, &attacker.pubkey(), accts.pool_pda, accts.vault);
+    let attacker_accrue_ix =
+        accrue_fees_ix(stake_id, &attacker.pubkey(), accts.pool_pda, accts.vault);
 
-    send_batch(&mut svm, &payer, &[&attacker], vec![attacker_dep_ix, attacker_accrue_ix])
-        .unwrap_or_else(|e| {
-            panic!(
-                "Attacker's deposit+AccrueFees batch must succeed (both are real, valid \
+    send_batch(
+        &mut svm,
+        &payer,
+        &[&attacker],
+        vec![attacker_dep_ix, attacker_accrue_ix],
+    )
+    .unwrap_or_else(|e| {
+        panic!(
+            "Attacker's deposit+AccrueFees batch must succeed (both are real, valid \
                  instructions on a mode-0 pool post-Task-11).\nLogs:\n{}",
-                e.meta.logs.join("\n")
-            )
-        });
+            e.meta.logs.join("\n")
+        )
+    });
 
     // ---- Assertions on REAL post-transaction state (nothing hand-set). ----
     let actual_attacker_lp = token_amount(&svm, &attacker_lp_ata);
@@ -559,7 +632,10 @@ fn mode0_deposit_priced_after_crystallization_not_before() {
     eprintln!(
         "expected_lp_post_accrual={} actual_attacker_lp={} claim_before_correct={} \
          actual_genesis_claim_after={}",
-        expected_lp_post_accrual, actual_attacker_lp, claim_before_correct, actual_genesis_claim_after
+        expected_lp_post_accrual,
+        actual_attacker_lp,
+        claim_before_correct,
+        actual_genesis_claim_after
     );
 
     assert_eq!(

--- a/tests/n6_marketauth_rotation_e2e.rs
+++ b/tests/n6_marketauth_rotation_e2e.rs
@@ -177,7 +177,12 @@ fn build_live_market_v17(
 /// instruction would produce before InitPool's `initialize_mint`/`initialize_account`
 /// CPIs run. InitPool does NOT create these accounts itself (only `pool_pda` gets
 /// `create_or_adopt_pda`), so the caller must pre-allocate them.
-fn preallocate_empty_spl_account(svm: &mut LiteSVM, key: Pubkey, token_program: Pubkey, size: usize) {
+fn preallocate_empty_spl_account(
+    svm: &mut LiteSVM,
+    key: Pubkey,
+    token_program: Pubkey,
+    size: usize,
+) {
     svm.set_account(
         key,
         Account {
@@ -211,7 +216,12 @@ struct InitPoolAccounts {
     token_program: Pubkey,
 }
 
-fn init_pool_ix(stake_id: Pubkey, a: &InitPoolAccounts, cooldown_slots: u64, deposit_cap: u64) -> Instruction {
+fn init_pool_ix(
+    stake_id: Pubkey,
+    a: &InitPoolAccounts,
+    cooldown_slots: u64,
+    deposit_cap: u64,
+) -> Instruction {
     Instruction {
         program_id: stake_id,
         accounts: vec![
@@ -242,7 +252,14 @@ fn read_32_at(svm: &LiteSVM, market: &Pubkey, off: usize) -> [u8; 32] {
 
 /// Common setup: live market (marketauth=admin) + pre-allocated (but not yet
 /// InitPool'd) lp_mint/vault/pool_pda accounts, ready for an InitPool call.
-fn setup(svm: &mut LiteSVM, wrapper_id: Pubkey, stake_id: Pubkey, token_program: Pubkey, admin: &Keypair, payer: &Keypair) -> (Pubkey, InitPoolAccounts) {
+fn setup(
+    svm: &mut LiteSVM,
+    wrapper_id: Pubkey,
+    stake_id: Pubkey,
+    token_program: Pubkey,
+    admin: &Keypair,
+    payer: &Keypair,
+) -> (Pubkey, InitPoolAccounts) {
     let (market, mint) = build_live_market_v17(svm, wrapper_id, token_program, admin, payer);
 
     let (pool_pda, _) = derive_pool_pda(&stake_id, &market);
@@ -298,7 +315,14 @@ fn initpool_rotates_marketauth_to_pool_pda() {
     svm.airdrop(&payer.pubkey(), 200_000_000_000).unwrap();
     svm.airdrop(&admin.pubkey(), 20_000_000_000).unwrap();
 
-    let (market, accts) = setup(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, accts) = setup(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
 
     // PRE-STATE: locate cfg.marketauth by searching for admin's pubkey in the raw
     // market bytes (InitMarket bootstraps marketauth to the init signer).
@@ -313,7 +337,13 @@ fn initpool_rotates_marketauth_to_pool_pda() {
     );
 
     // Run the real InitPool instruction.
-    send(&mut svm, &payer, &[&admin], init_pool_ix(stake_id, &accts, 5, 0)).unwrap_or_else(|e| {
+    send(
+        &mut svm,
+        &payer,
+        &[&admin],
+        init_pool_ix(stake_id, &accts, 5, 0),
+    )
+    .unwrap_or_else(|e| {
         panic!("InitPool must succeed when admin == current marketauth.\nError: {e:?}")
     });
 
@@ -332,7 +362,10 @@ fn initpool_rotates_marketauth_to_pool_pda() {
 
     // Pool PDA account was actually created and initialized.
     let pool_acct = svm.get_account(&accts.pool_pda).unwrap();
-    assert_eq!(pool_acct.owner, stake_id, "pool_pda must be owned by the stake program");
+    assert_eq!(
+        pool_acct.owner, stake_id,
+        "pool_pda must be owned by the stake program"
+    );
 
     // BEHAVIORAL proof the handoff is real: the OLD admin key can no longer call
     // wrapper UpdateAuthority (tag 32) directly — it would need to co-sign as
@@ -353,8 +386,9 @@ fn initpool_rotates_marketauth_to_pool_pda() {
         },
     };
     svm.expire_blockhash();
-    let err = send(&mut svm, &payer, &[&admin], re_rotate_attempt)
-        .expect_err("admin must NOT be able to re-rotate marketauth after InitPool moved it to the pool PDA");
+    let err = send(&mut svm, &payer, &[&admin], re_rotate_attempt).expect_err(
+        "admin must NOT be able to re-rotate marketauth after InitPool moved it to the pool PDA",
+    );
     match err {
         TransactionError::InstructionError(_, InstructionError::Custom(_)) => {
             // expect_live_authority(&cfg.marketauth, admin.key) fails: Unauthorized.
@@ -392,13 +426,23 @@ fn initpool_reverts_atomically_if_caller_is_not_marketauth() {
 
     // Market's marketauth is `admin`; attacker (not admin) attempts InitPool,
     // signing as the (wrong) admin account of a pool derived from the SAME slab.
-    let (market, mut accts) = setup(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (market, mut accts) = setup(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
     // Attacker pays and signs as "admin" of the pool — but is not the wrapper's
     // current marketauth, so the CPI must reject them.
     accts.admin = attacker.pubkey();
 
     let pool_pda_before = svm.get_account(&accts.pool_pda);
-    assert!(pool_pda_before.is_none(), "PRE-STATE: pool_pda must not exist yet");
+    assert!(
+        pool_pda_before.is_none(),
+        "PRE-STATE: pool_pda must not exist yet"
+    );
 
     let err = send(
         &mut svm,
@@ -453,7 +497,14 @@ fn initpool_requires_writable_slab() {
     svm.airdrop(&payer.pubkey(), 200_000_000_000).unwrap();
     svm.airdrop(&admin.pubkey(), 20_000_000_000).unwrap();
 
-    let (_market, accts) = setup(&mut svm, wrapper_id, stake_id, token_program, &admin, &payer);
+    let (_market, accts) = setup(
+        &mut svm,
+        wrapper_id,
+        stake_id,
+        token_program,
+        &admin,
+        &payer,
+    );
 
     // Build the InitPool ix by hand with slab marked READ-ONLY (index 1).
     let mut ix = init_pool_ix(stake_id, &accts, 5, 0);

--- a/tests/n7_share_inflation_defense.rs
+++ b/tests/n7_share_inflation_defense.rs
@@ -66,8 +66,13 @@ fn accrue(pool: &mut StakePool, vault_balance: u64) {
 /// Returns (real_lp_minted_to_depositor, total_lp_supply_after).
 fn deposit_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
     let total_lp_supply_before = pool.total_lp_supply;
-    let lp_to_mint = pool.calc_lp_for_deposit(amount).expect("calc_lp_for_deposit");
-    assert!(lp_to_mint > 0, "S-4 guard: must never mint 0 LP for a nonzero deposit");
+    let lp_to_mint = pool
+        .calc_lp_for_deposit(amount)
+        .expect("calc_lp_for_deposit");
+    assert!(
+        lp_to_mint > 0,
+        "S-4 guard: must never mint 0 LP for a nonzero deposit"
+    );
 
     let mint_amount = if total_lp_supply_before == 0 {
         lp_to_mint
@@ -76,7 +81,10 @@ fn deposit_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
     } else {
         lp_to_mint
     };
-    assert!(mint_amount > 0, "N7 guard: genesis deposit must mint > 0 real LP");
+    assert!(
+        mint_amount > 0,
+        "N7 guard: genesis deposit must mint > 0 real LP"
+    );
 
     pool.total_deposited += amount;
     pool.total_lp_supply += lp_to_mint; // full amount, including any dead-share portion
@@ -130,11 +138,13 @@ fn donation_then_accrue_attack_now_costs_the_attacker_real_value() {
     let attacker_genesis_deposit = MINIMUM_LIQUIDITY + 1_000; // 2,000
     let attacker_lp = deposit_fixed(&mut pool, &mut vault, attacker_genesis_deposit);
     assert_eq!(
-        attacker_lp,
-        1_000,
+        attacker_lp, 1_000,
         "attacker's REAL LP is genesis_deposit - MINIMUM_LIQUIDITY, not the full deposit"
     );
-    assert_eq!(pool.total_lp_supply, attacker_genesis_deposit, "tracked supply includes the dead shares");
+    assert_eq!(
+        pool.total_lp_supply, attacker_genesis_deposit,
+        "tracked supply includes the dead shares"
+    );
 
     // Attacker donates a large amount directly to the vault (bypassing Deposit).
     let donation = 1_000_000u64;
@@ -142,13 +152,14 @@ fn donation_then_accrue_attack_now_costs_the_attacker_real_value() {
 
     // Attacker cranks the permissionless AccrueFees, booking the donation as fees.
     accrue(&mut pool, vault);
-    assert_eq!(pool.total_fees_earned, donation, "the donation is booked as fees, as the bug describes");
+    assert_eq!(
+        pool.total_fees_earned, donation,
+        "the donation is booked as fees, as the bug describes"
+    );
 
     // Attacker immediately tries to recover 100% of their genesis position PLUS
     // the donation by withdrawing all their (real, minted) LP.
-    let attacker_withdraw_all = pool
-        .calc_collateral_for_withdraw(attacker_lp)
-        .unwrap();
+    let attacker_withdraw_all = pool.calc_collateral_for_withdraw(attacker_lp).unwrap();
     let attacker_total_recovered = attacker_withdraw_all; // they only ever put in genesis_deposit + donation
 
     // PRE-N7 baseline: attacker's LP would have been the FULL genesis deposit
@@ -237,5 +248,8 @@ fn dead_share_floor_applies_only_once_at_genesis() {
     // floor were (incorrectly) applied per-deposit, this would underflow/panic
     // or mint 0. It must mint normally (pro-rata), proving genesis-only scoping.
     let second_lp = deposit_fixed(&mut pool, &mut vault, 10);
-    assert!(second_lp > 0, "non-genesis deposits below MINIMUM_LIQUIDITY must still mint normally");
+    assert!(
+        second_lp > 0,
+        "non-genesis deposits below MINIMUM_LIQUIDITY must still mint normally"
+    );
 }

--- a/tests/poc_hwm_floor_100pct_freeze.rs
+++ b/tests/poc_hwm_floor_100pct_freeze.rs
@@ -56,7 +56,11 @@ fn floor_100pct_blocks_every_positive_withdrawal_on_a_healthy_pool() {
     // Sanity: at 100% the floor equals the full mark.
     let hwm = pool.refresh_hwm(5, 1_000_000);
     assert_eq!(hwm, 1_000_000);
-    assert_eq!(hwm_floor(hwm, 10_000), Some(1_000_000), "floor == 100% of the mark");
+    assert_eq!(
+        hwm_floor(hwm, 10_000),
+        Some(1_000_000),
+        "floor == 100% of the mark"
+    );
 
     // No loss has occurred — the pool is fully solvent (TVL == 1,000,000) — yet EVERY
     // positive withdrawal is rejected, from a dust 1-unit exit up to a full redemption.
@@ -76,18 +80,27 @@ fn epoch_rollover_does_not_lift_the_freeze() {
     let mut pool = pool_with_floor(10_000);
 
     // Epoch 5: frozen.
-    assert!(!withdrawal_allowed(&mut pool, 5, 1), "frozen in the peak epoch");
+    assert!(
+        !withdrawal_allowed(&mut pool, 5, 1),
+        "frozen in the peak epoch"
+    );
 
     // Epoch 6 (rollover): refresh_hwm re-anchors mark to current TVL = 1,000,000.
     let hwm_new_epoch = pool.refresh_hwm(6, 1_000_000);
-    assert_eq!(hwm_new_epoch, 1_000_000, "mark re-anchors to current TVL on a new epoch");
+    assert_eq!(
+        hwm_new_epoch, 1_000_000,
+        "mark re-anchors to current TVL on a new epoch"
+    );
     assert!(
         !withdrawal_allowed(&mut pool, 6, 1),
         "STILL frozen one epoch later — the freeze is permanent until the admin lowers the floor"
     );
 
     // And many epochs later — same result.
-    assert!(!withdrawal_allowed(&mut pool, 9_999, 1), "still frozen thousands of epochs later");
+    assert!(
+        !withdrawal_allowed(&mut pool, 9_999, 1),
+        "still frozen thousands of epochs later"
+    );
 }
 
 #[test]
@@ -96,9 +109,18 @@ fn boundary_9999_allows_a_sliver_so_10000_is_the_discontinuity() {
     // the feature still functions as a *rate limiter*. Bumping the cap by a single bp to
     // 10000 removes the last unit of headroom and converts it into a *kill switch*.
     let mut pool99 = pool_with_floor(9_999);
-    assert!(withdrawal_allowed(&mut pool99, 5, 100), "9999 bps allows a 100-unit withdrawal");
-    assert!(!withdrawal_allowed(&mut pool99, 5, 101), "9999 bps blocks beyond the 0.01% headroom");
+    assert!(
+        withdrawal_allowed(&mut pool99, 5, 100),
+        "9999 bps allows a 100-unit withdrawal"
+    );
+    assert!(
+        !withdrawal_allowed(&mut pool99, 5, 101),
+        "9999 bps blocks beyond the 0.01% headroom"
+    );
 
     let mut pool100 = pool_with_floor(10_000);
-    assert!(!withdrawal_allowed(&mut pool100, 5, 1), "10000 bps blocks even a single unit");
+    assert!(
+        !withdrawal_allowed(&mut pool100, 5, 1),
+        "10000 bps blocks even a single unit"
+    );
 }

--- a/tests/poc_hwm_flush_freeze.rs
+++ b/tests/poc_hwm_flush_freeze.rs
@@ -46,7 +46,10 @@ fn hwm_freeze_after_loss_blocks_all_withdrawals() {
     // A withdraw calls refresh_hwm(5, 400_000): same epoch, 400k < mark, so the mark is
     // NOT lowered (it only raises). Floor stays 50% of the stale 1,000,000 peak = 500,000.
     let mark = pool.refresh_hwm(5, 400_000);
-    assert_eq!(mark, 1_000_000, "mark stays pegged to the pre-loss peak (the bug)");
+    assert_eq!(
+        mark, 1_000_000,
+        "mark stays pegged to the pre-loss peak (the bug)"
+    );
 
     // Current TVL (400,000) is already below the 500,000 floor, so EVERY withdrawal —
     // even a zero-size one (post_tvl == current TVL) — is blocked.
@@ -73,9 +76,18 @@ fn rebaselining_hwm_on_flush_unfreezes_withdrawals() {
     assert_eq!(mark, 400_000, "mark tracks the legitimate loss");
 
     // Floor = 50% of 400,000 = 200,000. Withdrawals down to the loss-adjusted floor resume.
-    assert!(hwm_withdrawal_allowed(400_000, mark, 5000), "withdrawals resume after re-baseline");
-    assert!(hwm_withdrawal_allowed(200_000, mark, 5000), "allowed down to the loss-adjusted floor");
-    assert!(!hwm_withdrawal_allowed(199_999, mark, 5000), "floor still enforced — anti-drain intact");
+    assert!(
+        hwm_withdrawal_allowed(400_000, mark, 5000),
+        "withdrawals resume after re-baseline"
+    );
+    assert!(
+        hwm_withdrawal_allowed(200_000, mark, 5000),
+        "allowed down to the loss-adjusted floor"
+    );
+    assert!(
+        !hwm_withdrawal_allowed(199_999, mark, 5000),
+        "floor still enforced — anti-drain intact"
+    );
 }
 
 /// The crux that picks "lower the mark by the flushed amount" over "reset the mark to
@@ -95,20 +107,35 @@ fn lower_by_amount_does_not_forgive_prior_drain() {
     // Withdrawals bring TVL to 800,000; the mark does NOT move (refresh only raises).
     pool.total_withdrawn = 200_000;
     let mark_after_withdraw = pool.refresh_hwm(5, 800_000);
-    assert_eq!(mark_after_withdraw, 1_000_000, "withdrawals never lower the mark");
+    assert_eq!(
+        mark_after_withdraw, 1_000_000,
+        "withdrawals never lower the mark"
+    );
 
     // Flush 600,000 → TVL 200,000. The handler lowers the mark by the flushed amount.
     pool.total_flushed = 600_000;
     assert_eq!(pool.total_pool_value().unwrap(), 200_000);
     pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(600_000)); // -> 400,000
     let mark = pool.refresh_hwm(5, 200_000);
-    assert_eq!(mark, 400_000, "lower by the LOSS only — not down to post-flush TVL");
+    assert_eq!(
+        mark, 400_000,
+        "lower by the LOSS only — not down to post-flush TVL"
+    );
 
     // Floor = 200,000. Post-flush TVL is already at the floor → no further drain allowed.
-    assert!(hwm_withdrawal_allowed(200_000, mark, 5000), "exactly at the loss-adjusted floor");
-    assert!(!hwm_withdrawal_allowed(199_999, mark, 5000), "prior drain remembered — no new headroom");
+    assert!(
+        hwm_withdrawal_allowed(200_000, mark, 5000),
+        "exactly at the loss-adjusted floor"
+    );
+    assert!(
+        !hwm_withdrawal_allowed(199_999, mark, 5000),
+        "prior drain remembered — no new headroom"
+    );
     // reset-to-TVL would have set mark=200,000, floor=100,000, wrongly allowing TVL→100,000.
-    assert!(!hwm_withdrawal_allowed(100_000, mark, 5000), "reset-to-TVL would have allowed this — rejected");
+    assert!(
+        !hwm_withdrawal_allowed(100_000, mark, 5000),
+        "reset-to-TVL would have allowed this — rejected"
+    );
 }
 
 /// Multiple flushes in an epoch compose: mark = peak − Σ flushed (saturating).
@@ -119,7 +146,11 @@ fn multiple_flushes_compose() {
     pool.refresh_hwm(5, 1_000_000);
     pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(300_000));
     pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(300_000));
-    assert_eq!(pool.epoch_high_water_tvl(), 400_000, "two 300k flushes == one 600k flush");
+    assert_eq!(
+        pool.epoch_high_water_tvl(),
+        400_000,
+        "two 300k flushes == one 600k flush"
+    );
 }
 
 /// A flush whose amount exceeds the (stale/zero) mark saturates to 0 — floor 0, no freeze.
@@ -128,6 +159,13 @@ fn flush_exceeding_mark_saturates_to_zero() {
     let mut pool = hwm_pool();
     pool.set_epoch_high_water_tvl(100_000);
     pool.set_epoch_high_water_tvl(pool.epoch_high_water_tvl().saturating_sub(200_000));
-    assert_eq!(pool.epoch_high_water_tvl(), 0, "saturates, no underflow/panic");
-    assert!(hwm_withdrawal_allowed(0, 0, 5000), "floor 0 → no restriction");
+    assert_eq!(
+        pool.epoch_high_water_tvl(),
+        0,
+        "saturates, no underflow/panic"
+    );
+    assert!(
+        hwm_withdrawal_allowed(0, 0, 5000),
+        "floor 0 → no restriction"
+    );
 }

--- a/tests/poc_issue198_flush_available_underflow.rs
+++ b/tests/poc_issue198_flush_available_underflow.rs
@@ -89,8 +89,14 @@ fn flush_available_underflows_in_a_reachable_state_with_tokens_present() {
     assert_eq!(physical_vault(&p), 20);
 
     // Underflow precondition: D - W < F  <=>  total_pool_value() < total_returned.
-    assert!(p.total_deposited - p.total_withdrawn < p.total_flushed, "D - W < F");
-    assert!(tpv < p.total_returned, "equivalently, total_pool_value < total_returned");
+    assert!(
+        p.total_deposited - p.total_withdrawn < p.total_flushed,
+        "D - W < F"
+    );
+    assert!(
+        tpv < p.total_returned,
+        "equivalently, total_pool_value < total_returned"
+    );
 
     // BUG: the old inline calc underflows at `(D-W) - F` = (70 - 100) -> None,
     // so the old process_flush_to_insurance returned StakeError::Overflow.
@@ -124,7 +130,11 @@ fn fix_does_not_overcount_flushable_balance_with_realized_junior_loss() {
 
     // The naive reorder would report 150 (= physical vault + realized_junior_loss),
     // letting the admin be admitted to flush 50 tokens that are NOT in the vault.
-    assert_eq!(reorder_available(&p), Some(150), "reorder over-counts by realized_junior_loss");
+    assert_eq!(
+        reorder_available(&p),
+        Some(150),
+        "reorder over-counts by realized_junior_loss"
+    );
 
     // The implemented fix reports exactly the real balance (100) -> no over-count.
     assert_eq!(fixed_available(&p), Some(100));
@@ -158,5 +168,9 @@ fn fix_still_blocks_flush_when_vault_truly_empty() {
     p.total_returned = 100;
     assert_eq!(p.total_pool_value().unwrap(), 0);
     assert_eq!(physical_vault(&p), 0);
-    assert_eq!(fixed_available(&p), Some(0), "fix reports 0 -> any flush still blocked");
+    assert_eq!(
+        fixed_available(&p),
+        Some(0),
+        "fix reports 0 -> any flush still blocked"
+    );
 }

--- a/tests/poc_jit_fee_snipe.rs
+++ b/tests/poc_jit_fee_snipe.rs
@@ -41,7 +41,9 @@ fn accrue(pool: &mut StakePool, vault: u64) {
 
 /// Models the CURRENT `process_deposit`: price against total_pool_value() (no pre-accrue).
 fn deposit_current(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
-    let lp = pool.calc_lp_for_deposit(amount).expect("calc_lp_for_deposit");
+    let lp = pool
+        .calc_lp_for_deposit(amount)
+        .expect("calc_lp_for_deposit");
     pool.total_deposited += amount;
     pool.total_lp_supply += lp;
     *vault += amount;
@@ -51,7 +53,9 @@ fn deposit_current(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
 /// Models a FIXED `process_deposit`: crystallize pending fees BEFORE pricing.
 fn deposit_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
     accrue(pool, *vault); // <-- the fix: fold pending surplus into share price first
-    let lp = pool.calc_lp_for_deposit(amount).expect("calc_lp_for_deposit");
+    let lp = pool
+        .calc_lp_for_deposit(amount)
+        .expect("calc_lp_for_deposit");
     pool.total_deposited += amount;
     pool.total_lp_supply += lp;
     *vault += amount;
@@ -59,7 +63,9 @@ fn deposit_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
 }
 
 fn withdraw(pool: &mut StakePool, vault: &mut u64, lp: u64) -> u64 {
-    let coll = pool.calc_collateral_for_withdraw(lp).expect("calc_collateral_for_withdraw");
+    let coll = pool
+        .calc_collateral_for_withdraw(lp)
+        .expect("calc_collateral_for_withdraw");
     pool.total_withdrawn += coll;
     pool.total_lp_supply -= lp;
     *vault -= coll;

--- a/tests/poc_junior_jit_fee_snipe.rs
+++ b/tests/poc_junior_jit_fee_snipe.rs
@@ -65,8 +65,12 @@ fn accrue(pool: &mut StakePool, vault: u64) {
 
 /// CURRENT `process_deposit_junior`: price against `effective_junior_balance()` with NO pre-accrue.
 fn deposit_junior_current(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
-    let lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), pool.effective_junior_balance(), amount)
-        .expect("calc_junior_lp_for_deposit");
+    let lp = calc_junior_lp_for_deposit(
+        pool.junior_total_lp(),
+        pool.effective_junior_balance(),
+        amount,
+    )
+    .expect("calc_junior_lp_for_deposit");
     pool.total_deposited += amount;
     pool.total_lp_supply += lp;
     pool.set_junior_total_lp(pool.junior_total_lp() + lp);
@@ -78,8 +82,12 @@ fn deposit_junior_current(pool: &mut StakePool, vault: &mut u64, amount: u64) ->
 /// FIXED `process_deposit_junior`: crystallize pending fees (pre-accrue) BEFORE pricing.
 fn deposit_junior_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u64 {
     accrue(pool, *vault); // <-- the fix: mirror the #136 pre-accrue from process_deposit
-    let lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), pool.effective_junior_balance(), amount)
-        .expect("calc_junior_lp_for_deposit");
+    let lp = calc_junior_lp_for_deposit(
+        pool.junior_total_lp(),
+        pool.effective_junior_balance(),
+        amount,
+    )
+    .expect("calc_junior_lp_for_deposit");
     pool.total_deposited += amount;
     pool.total_lp_supply += lp;
     pool.set_junior_total_lp(pool.junior_total_lp() + lp);
@@ -89,9 +97,12 @@ fn deposit_junior_fixed(pool: &mut StakePool, vault: &mut u64, amount: u64) -> u
 }
 
 fn withdraw_junior(pool: &mut StakePool, vault: &mut u64, lp: u64) -> u64 {
-    let coll =
-        calc_junior_collateral_for_withdraw(pool.junior_total_lp(), pool.effective_junior_balance(), lp)
-            .expect("calc_junior_collateral_for_withdraw");
+    let coll = calc_junior_collateral_for_withdraw(
+        pool.junior_total_lp(),
+        pool.effective_junior_balance(),
+        lp,
+    )
+    .expect("calc_junior_collateral_for_withdraw");
     pool.total_withdrawn += coll;
     pool.total_lp_supply -= lp;
     pool.set_junior_total_lp(pool.junior_total_lp() - lp);
@@ -128,7 +139,10 @@ fn junior_jit_fee_snipe_is_profitable_with_current_pricing() {
     // VIRTUAL_ASSETS=1 offset (math.rs) rounds this withdrawal pool-favoring by 1
     // unit versus the pre-N7 exact value (was 1,400,000) — dust retained by the
     // pool, not a change in the JIT-snipe vulnerability this PoC documents.
-    assert_eq!(eve_back, 1_399_999, "Eve captures ~+400,000 of fees she did not earn (minus 1 unit of N7 offset dust)");
+    assert_eq!(
+        eve_back, 1_399_999,
+        "Eve captures ~+400,000 of fees she did not earn (minus 1 unit of N7 offset dust)"
+    );
 }
 
 #[test]

--- a/tests/poc_junior_preexisting_loss.rs
+++ b/tests/poc_junior_preexisting_loss.rs
@@ -55,7 +55,8 @@ fn first_junior_inherits_preexisting_loss() {
     // so effective_junior_balance() == 0 and she mints 1:1 — it looks like a fair entry.
     let eff_at_deposit = pool.effective_junior_balance();
     assert_eq!(eff_at_deposit, 0);
-    let jane_lp = calc_junior_lp_for_deposit(pool.junior_total_lp(), eff_at_deposit, 1_000_000).unwrap();
+    let jane_lp =
+        calc_junior_lp_for_deposit(pool.junior_total_lp(), eff_at_deposit, 1_000_000).unwrap();
     assert_eq!(jane_lp, 1_000_000);
     pool.set_junior_balance(1_000_000);
     pool.set_junior_total_lp(jane_lp);
@@ -71,9 +72,14 @@ fn first_junior_inherits_preexisting_loss() {
     );
 
     // Jane withdraws her 1,000,000 LP and recovers only 400,000 — an instant 600,000 loss.
-    let jane_back = calc_junior_collateral_for_withdraw(pool.junior_total_lp(), eff_after, jane_lp).unwrap();
+    let jane_back =
+        calc_junior_collateral_for_withdraw(pool.junior_total_lp(), eff_after, jane_lp).unwrap();
     assert_eq!(jane_back, 400_000);
-    assert_eq!(1_000_000 - jane_back, 600_000, "Jane lost the full pre-existing loss");
+    assert_eq!(
+        1_000_000 - jane_back,
+        600_000,
+        "Jane lost the full pre-existing loss"
+    );
 
     // Greg (now senior) recovers his FULL 3,000,000 — his loss evaporated onto Jane.
     let greg_back = calc_senior_collateral_for_withdraw(
@@ -82,7 +88,10 @@ fn first_junior_inherits_preexisting_loss() {
         3_000_000,
     )
     .unwrap();
-    assert_eq!(greg_back, 3_000_000, "incumbent made whole at the new junior's expense");
+    assert_eq!(
+        greg_back, 3_000_000,
+        "incumbent made whole at the new junior's expense"
+    );
 
     // Conservation holds globally (3,000,000 + 400,000 == 3,400,000 == vault), which is
     // exactly why no runtime check catches it — but 600,000 was transferred from the
@@ -110,13 +119,22 @@ fn junior_deposit_gate_fires_while_loss_outstanding_and_lifts_on_return() {
 
     // Outstanding loss → gate fires (handler rejects DepositJunior).
     pool.total_flushed = 600_000;
-    assert!(pool.total_flushed > pool.total_returned, "gate must fire while loss outstanding");
+    assert!(
+        pool.total_flushed > pool.total_returned,
+        "gate must fire while loss outstanding"
+    );
 
     // Partial return → still outstanding → gate still fires.
     pool.total_returned = 200_000;
-    assert!(pool.total_flushed > pool.total_returned, "gate must stay closed on partial return");
+    assert!(
+        pool.total_flushed > pool.total_returned,
+        "gate must stay closed on partial return"
+    );
 
     // Fully returned → gate lifts → junior deposits resume.
     pool.total_returned = 600_000;
-    assert!(!(pool.total_flushed > pool.total_returned), "gate must lift once fully returned");
+    assert!(
+        !(pool.total_flushed > pool.total_returned),
+        "gate must lift once fully returned"
+    );
 }

--- a/tests/poc_senior_bootstrap_orphan.rs
+++ b/tests/poc_senior_bootstrap_orphan.rs
@@ -62,8 +62,16 @@ fn orphan_state_is_well_formed() {
     let pool = orphan_pool();
     assert_eq!(pool.total_lp_supply, 0, "all LP exited");
     assert_eq!(pool.senior_total_lp(), 0, "no senior LP");
-    assert_eq!(pool.effective_junior_balance(), 0, "no junior; net_loss == 0");
-    assert_eq!(pool.total_pool_value().unwrap(), 500_000, "orphaned value present");
+    assert_eq!(
+        pool.effective_junior_balance(),
+        0,
+        "no junior; net_loss == 0"
+    );
+    assert_eq!(
+        pool.total_pool_value().unwrap(),
+        500_000,
+        "orphaned value present"
+    );
     assert_eq!(
         pool.senior_balance().unwrap(),
         500_000,
@@ -122,7 +130,11 @@ fn c9_guard_rejects_senior_deposit_into_orphan() {
     );
     // It is the STATE that is blocked, not a size threshold — any amount is rejected.
     assert_eq!(
-        calc_senior_lp_for_deposit(pool.senior_total_lp(), pool.senior_balance().unwrap(), 1_000_000),
+        calc_senior_lp_for_deposit(
+            pool.senior_total_lp(),
+            pool.senior_balance().unwrap(),
+            1_000_000
+        ),
         None,
         "FIX: a large deposit into an orphan is rejected too"
     );
@@ -137,8 +149,12 @@ fn first_senior_deposit_into_empty_pool_mints_1_to_1() {
     assert_eq!(pool.senior_total_lp(), 0);
     assert_eq!(pool.senior_balance().unwrap(), 0);
 
-    let lp = calc_senior_lp_for_deposit(pool.senior_total_lp(), pool.senior_balance().unwrap(), 750_000)
-        .expect("FIX: true first senior into an empty pool must succeed");
+    let lp = calc_senior_lp_for_deposit(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        750_000,
+    )
+    .expect("FIX: true first senior into an empty pool must succeed");
     assert_eq!(lp, 750_000, "true first senior mints 1:1");
 }
 
@@ -160,8 +176,12 @@ fn first_senior_after_junior_only_mints_1_to_1() {
         "junior-first leaves senior_balance == 0 (not an orphan)"
     );
 
-    let lp = calc_senior_lp_for_deposit(pool.senior_total_lp(), pool.senior_balance().unwrap(), 500_000)
-        .expect("FIX: first senior after junior-only must succeed");
+    let lp = calc_senior_lp_for_deposit(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        500_000,
+    )
+    .expect("FIX: first senior after junior-only must succeed");
     assert_eq!(lp, 500_000, "first senior mints 1:1");
 }
 
@@ -188,7 +208,11 @@ fn junior_only_with_partial_loss_first_senior_not_bricked() {
     pool.total_lp_supply = 800_000; // all junior
 
     assert_eq!(pool.senior_total_lp(), 0);
-    assert_eq!(pool.effective_junior_balance(), 600_000, "junior absorbs all net_loss");
+    assert_eq!(
+        pool.effective_junior_balance(),
+        600_000,
+        "junior absorbs all net_loss"
+    );
     assert_eq!(pool.total_pool_value().unwrap(), 600_000);
     assert_eq!(
         pool.senior_balance().unwrap(),
@@ -196,7 +220,14 @@ fn junior_only_with_partial_loss_first_senior_not_bricked() {
         "junior-only (gross_senior == 0) keeps senior_balance == 0 through loss + recovery"
     );
 
-    let lp = calc_senior_lp_for_deposit(pool.senior_total_lp(), pool.senior_balance().unwrap(), 400_000)
-        .expect("FIX: first senior into a junior-only-post-loss pool must succeed 1:1");
-    assert_eq!(lp, 400_000, "first senior mints 1:1 (not bricked by a phantom senior_balance)");
+    let lp = calc_senior_lp_for_deposit(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        400_000,
+    )
+    .expect("FIX: first senior into a junior-only-post-loss pool must succeed 1:1");
+    assert_eq!(
+        lp, 400_000,
+        "first senior mints 1:1 (not bricked by a phantom senior_balance)"
+    );
 }

--- a/tests/poc_senior_deposit_loss_snipe.rs
+++ b/tests/poc_senior_deposit_loss_snipe.rs
@@ -54,7 +54,11 @@ fn senior_deposit_during_loss_snipes_recovery() {
     pool.total_flushed = 600_000;
     assert_eq!(pool.effective_junior_balance(), 0);
     assert_eq!(pool.total_pool_value().unwrap(), 400_000);
-    assert_eq!(pool.senior_balance().unwrap(), 400_000, "senior depressed during the loss");
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        400_000,
+        "senior depressed during the loss"
+    );
     assert!(senior_marked_down(&pool));
 
     // Eve deposits 400k senior at the depressed price (UNGATED today).
@@ -64,9 +68,12 @@ fn senior_deposit_during_loss_snipes_recovery() {
     // vulnerability this PoC documents (N7 is orthogonal defense-in-depth; the
     // actual fix for THIS bug is the senior recovery-snipe gate, exercised by the
     // other tests in this file).
-    let eve_lp =
-        calc_senior_lp_for_deposit(pool.senior_total_lp(), pool.senior_balance().unwrap(), 400_000)
-            .unwrap();
+    let eve_lp = calc_senior_lp_for_deposit(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        400_000,
+    )
+    .unwrap();
     assert_eq!(eve_lp, 899_998, "400k * (900k+1) / (400k+1), N7 offset");
     pool.total_deposited += 400_000;
     pool.total_lp_supply += eve_lp;
@@ -80,20 +87,40 @@ fn senior_deposit_during_loss_snipes_recovery() {
 
     // Eve withdraws her senior LP. N7 offset again shaves 1 unit off the exact
     // pre-N7 value (900k*1.3M/1.8M = 650,000); still a clean transfer from Greg.
-    let eve_out =
-        calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), eve_lp)
-            .unwrap();
-    assert_eq!(eve_out, 649_999, "N7-offset value; pre-N7 was 900k * 1.3M / 1.8M = 650,000");
-    assert_eq!(eve_out - 400_000, 249_999, "Eve nets ~+250k on a 400k deposit she never put at risk");
+    let eve_out = calc_senior_collateral_for_withdraw(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        eve_lp,
+    )
+    .unwrap();
+    assert_eq!(
+        eve_out, 649_999,
+        "N7-offset value; pre-N7 was 900k * 1.3M / 1.8M = 650,000"
+    );
+    assert_eq!(
+        eve_out - 400_000,
+        249_999,
+        "Eve nets ~+250k on a 400k deposit she never put at risk"
+    );
     pool.total_withdrawn += eve_out;
     pool.total_lp_supply -= eve_lp;
 
     // Greg (incumbent senior) withdraws his 900k senior LP.
-    let greg_out =
-        calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), 900_000)
-            .unwrap();
-    assert_eq!(greg_out, 650_001, "deposited 900k, recovers only ~650k (N7-offset value)");
-    assert_eq!(900_000 - greg_out, eve_out - 400_000, "Greg's -~250k == Eve's +~250k (clean transfer)");
+    let greg_out = calc_senior_collateral_for_withdraw(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        900_000,
+    )
+    .unwrap();
+    assert_eq!(
+        greg_out, 650_001,
+        "deposited 900k, recovers only ~650k (N7-offset value)"
+    );
+    assert_eq!(
+        900_000 - greg_out,
+        eve_out - 400_000,
+        "Greg's -~250k == Eve's +~250k (clean transfer)"
+    );
     // Without Eve, after the return senior_balance would be 900k over 900k LP -> Greg whole.
 }
 
@@ -109,7 +136,10 @@ fn gate_blocks_snipe_only_while_senior_marked_down() {
     p.set_junior_balance(100_000);
     p.set_junior_total_lp(100_000);
     p.total_flushed = 600_000; // > junior 100k
-    assert!(senior_marked_down(&p), "loss spilled past junior -> senior deposits paused");
+    assert!(
+        senior_marked_down(&p),
+        "loss spilled past junior -> senior deposits paused"
+    );
 
     // (b) Loss <= junior: senior fully protected (unchanged) -> senior deposits stay OPEN.
     let mut p2 = tranche_pool();
@@ -118,12 +148,22 @@ fn gate_blocks_snipe_only_while_senior_marked_down() {
     p2.set_junior_balance(100_000);
     p2.set_junior_total_lp(100_000);
     p2.total_flushed = 80_000; // < junior 100k: junior absorbs, senior NOT marked down
-    assert_eq!(p2.senior_balance().unwrap(), 900_000, "senior unchanged when loss <= junior");
-    assert!(!senior_marked_down(&p2), "no snipe possible -> senior deposits remain allowed");
+    assert_eq!(
+        p2.senior_balance().unwrap(),
+        900_000,
+        "senior unchanged when loss <= junior"
+    );
+    assert!(
+        !senior_marked_down(&p2),
+        "no snipe possible -> senior deposits remain allowed"
+    );
 
     // (c) After the insurance is returned, the gate lifts.
     p.total_returned = 600_000;
-    assert!(!senior_marked_down(&p), "gate lifts once the loss is recovered");
+    assert!(
+        !senior_marked_down(&p),
+        "gate lifts once the loss is recovered"
+    );
 }
 
 /// The crux that picks the PRECISE gate over both the simple-symmetric gate and a
@@ -144,12 +184,17 @@ fn precise_gate_no_false_fire_on_junior_partial_exit() {
     // Flush 300k — junior-ABSORBED (300k <= 400k): senior NOT marked down.
     pool.total_flushed = 300_000;
     assert_eq!(pool.effective_junior_balance(), 100_000);
-    assert_eq!(pool.senior_balance().unwrap(), 900_000, "senior untouched by a junior-absorbed loss");
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        900_000,
+        "senior untouched by a junior-absorbed loss"
+    );
     assert!(!senior_marked_down(&pool));
 
     // A junior burns 390k of 400k LP. Valued against effective_junior (100k):
     // withdrawal_amount = 390k * 100k / 400k = 97_500. Raw junior_balance drops by that.
-    let wd = calc_junior_collateral_for_withdraw(400_000, pool.effective_junior_balance(), 390_000).unwrap();
+    let wd = calc_junior_collateral_for_withdraw(400_000, pool.effective_junior_balance(), 390_000)
+        .unwrap();
     assert_eq!(wd, 97_500);
     pool.total_withdrawn += wd;
     pool.set_junior_balance(pool.junior_balance() - wd); // 400_000 - 97_500 = 302_500
@@ -158,6 +203,13 @@ fn precise_gate_no_false_fire_on_junior_partial_exit() {
 
     // net_loss (300k) is still <= junior_balance (302_500): gate stays OPEN, and senior is
     // STILL undepressed — so a senior deposit here is fair and must be allowed.
-    assert!(!senior_marked_down(&pool), "precise gate does NOT false-fire on junior partial exit");
-    assert_eq!(pool.senior_balance().unwrap(), 900_000, "senior still whole after junior's partial exit");
+    assert!(
+        !senior_marked_down(&pool),
+        "precise gate does NOT false-fire on junior partial exit"
+    );
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        900_000,
+        "senior still whole after junior's partial exit"
+    );
 }

--- a/tests/poc_senior_deposit_mispricing.rs
+++ b/tests/poc_senior_deposit_mispricing.rs
@@ -39,7 +39,9 @@ fn initialized_pool() -> StakePool {
 
 /// Old (buggy) senior deposit pricing: GLOBAL pool ratio.
 fn senior_deposit_global(pool: &mut StakePool, amount: u64) -> u64 {
-    let lp = pool.calc_lp_for_deposit(amount).expect("calc_lp_for_deposit");
+    let lp = pool
+        .calc_lp_for_deposit(amount)
+        .expect("calc_lp_for_deposit");
     pool.total_deposited += amount;
     pool.total_lp_supply += lp;
     lp
@@ -64,8 +66,12 @@ fn senior_deposit_fixed(pool: &mut StakePool, amount: u64) -> u64 {
 
 /// Senior withdraw — same as `process_withdraw`'s senior branch.
 fn senior_withdraw(pool: &mut StakePool, lp: u64) -> u64 {
-    let coll = calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), lp)
-        .expect("calc_senior_collateral_for_withdraw");
+    let coll = calc_senior_collateral_for_withdraw(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        lp,
+    )
+    .expect("calc_senior_collateral_for_withdraw");
     pool.total_withdrawn += coll;
     pool.total_lp_supply -= lp;
     coll
@@ -106,8 +112,12 @@ fn senior_subpool_pricing_prevents_extraction() {
     // Regression guard: the FIXED senior sub-pool pricing yields NO profit and
     // leaves the incumbent senior whole.
     let (mut pool, alice_lp) = setup();
-    let alice_before =
-        calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), alice_lp).unwrap();
+    let alice_before = calc_senior_collateral_for_withdraw(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        alice_lp,
+    )
+    .unwrap();
 
     let eve_dep = 1_000_000u64;
     let eve_lp = senior_deposit_fixed(&mut pool, eve_dep);
@@ -117,8 +127,12 @@ fn senior_subpool_pricing_prevents_extraction() {
         "FIX: sub-pool-priced senior deposit must not profit (got {eve_back} for {eve_dep})"
     );
 
-    let alice_after =
-        calc_senior_collateral_for_withdraw(pool.senior_total_lp(), pool.senior_balance().unwrap(), alice_lp).unwrap();
+    let alice_after = calc_senior_collateral_for_withdraw(
+        pool.senior_total_lp(),
+        pool.senior_balance().unwrap(),
+        alice_lp,
+    )
+    .unwrap();
     assert!(
         alice_after >= alice_before,
         "FIX: incumbent senior must not be diluted ({alice_before} -> {alice_after})"

--- a/tests/proptest_extended.rs
+++ b/tests/proptest_extended.rs
@@ -32,16 +32,26 @@ fn calc_lp_for_deposit(supply: u64, pool_value: u64, deposit: u64) -> Option<u64
         let lp = (deposit as u128)
             .checked_mul(supply as u128)?
             .checked_div(pool_value as u128)?;
-        if lp > u64::MAX as u128 { None } else { Some(lp as u64) }
+        if lp > u64::MAX as u128 {
+            None
+        } else {
+            Some(lp as u64)
+        }
     }
 }
 
 fn calc_collateral_for_withdraw(supply: u64, pool_value: u64, lp: u64) -> Option<u64> {
-    if supply == 0 { return None; }
+    if supply == 0 {
+        return None;
+    }
     let col = (lp as u128)
         .checked_mul(pool_value as u128)?
         .checked_div(supply as u128)?;
-    if col > u64::MAX as u128 { None } else { Some(col as u64) }
+    if col > u64::MAX as u128 {
+        None
+    } else {
+        Some(col as u64)
+    }
 }
 
 /// Mirror of math::distribute_fees
@@ -51,15 +61,21 @@ fn distribute_fees(
     junior_fee_mult_bps: u16,
     total_fee: u64,
 ) -> (u64, u64) {
-    if total_fee == 0 { return (0, 0); }
+    if total_fee == 0 {
+        return (0, 0);
+    }
     let total_balance = junior_balance as u128 + senior_balance as u128;
-    if total_balance == 0 { return (0, 0); }
+    if total_balance == 0 {
+        return (0, 0);
+    }
 
     let junior_weight = (junior_balance as u128) * (junior_fee_mult_bps as u128);
     let senior_weight = (senior_balance as u128) * 10_000u128;
     let total_weight = junior_weight + senior_weight;
 
-    if total_weight == 0 { return (0, 0); }
+    if total_weight == 0 {
+        return (0, 0);
+    }
 
     let junior_fee_u128 = if let Some(product) = (total_fee as u128).checked_mul(junior_weight) {
         product / total_weight
@@ -67,7 +83,8 @@ fn distribute_fees(
         let q = (total_fee as u128) / total_weight;
         let r = (total_fee as u128) % total_weight;
         let part1 = q * junior_weight;
-        let part2 = r.checked_mul(junior_weight)
+        let part2 = r
+            .checked_mul(junior_weight)
             .map(|p| p / total_weight)
             .unwrap_or(total_fee as u128);
         part1.saturating_add(part2)
@@ -708,11 +725,17 @@ fn test_loss_exceeds_total_is_capped() {
 #[test]
 fn test_cpi_insurance_policy_tag_is_not_30() {
     let data = build_set_insurance_withdraw_policy([0u8; 32], 0, 0, 0);
-    assert_eq!(data[0], 22, "CRIT: SetInsuranceWithdrawPolicy must be 22, not 30");
+    assert_eq!(
+        data[0], 22,
+        "CRIT: SetInsuranceWithdrawPolicy must be 22, not 30"
+    );
 }
 
 #[test]
 fn test_cpi_withdraw_limited_tag_is_not_31() {
     let data = build_withdraw_insurance_limited(1000);
-    assert_eq!(data[0], 23, "CRIT: WithdrawInsuranceLimited must be 23, not 31");
+    assert_eq!(
+        data[0], 23,
+        "CRIT: WithdrawInsuranceLimited must be 23, not 31"
+    );
 }

--- a/tests/proptest_math.rs
+++ b/tests/proptest_math.rs
@@ -330,7 +330,13 @@ fn test_three_depositors_sequential_conservation() {
 // ═══════════════════════════════════════════════════════════════
 
 /// Build a mode-0 (insurance LP) tranche pool with the given ledger fields.
-fn tranche_pool(deposited: u64, withdrawn: u64, flushed: u64, returned: u64, junior_balance: u64) -> StakePool {
+fn tranche_pool(
+    deposited: u64,
+    withdrawn: u64,
+    flushed: u64,
+    returned: u64,
+    junior_balance: u64,
+) -> StakePool {
     use bytemuck::Zeroable;
     let mut pool = StakePool::zeroed();
     pool.is_initialized = 1;

--- a/tests/regression_166_pda_squat.rs
+++ b/tests/regression_166_pda_squat.rs
@@ -87,7 +87,7 @@ fn mint_data_with_authority(mint_authority: &Pubkey) -> Vec<u8> {
     // [36..44] supply = 0 (already zero)
     d[44] = 6; // decimals
     d[45] = 1; // is_initialized = true
-    // freeze_authority = None (bytes 46..82 already zero)
+               // freeze_authority = None (bytes 46..82 already zero)
     d
 }
 
@@ -120,7 +120,7 @@ fn token_data(mint: &Pubkey, owner: &Pubkey, amount: u64) -> Vec<u8> {
     d[64..72].copy_from_slice(&amount.to_le_bytes());
     // delegate = None (bytes 72..108 already zero)
     d[108] = 1; // state = Initialized
-    // is_native = None, delegated_amount = 0, close_authority = None (zero)
+                // is_native = None, delegated_amount = 0, close_authority = None (zero)
     d
 }
 
@@ -290,15 +290,15 @@ fn deposit_ix(
     Instruction {
         program_id: stake_id,
         accounts: vec![
-            AccountMeta::new(*user, true),                       // 0. user [signer, writable]
-            AccountMeta::new(pool_pda, false),                   // 1. pool_pda [writable]
-            AccountMeta::new(user_ata, false),                   // 2. user_ata [writable]
-            AccountMeta::new(vault, false),                      // 3. vault [writable]
-            AccountMeta::new(lp_mint, false),                    // 4. lp_mint [writable]
-            AccountMeta::new(user_lp_ata, false),                // 5. user_lp_ata [writable]
-            AccountMeta::new_readonly(vault_auth, false),        // 6. vault_auth
-            AccountMeta::new(deposit_pda, false),                // 7. deposit_pda [writable]
-            AccountMeta::new_readonly(token_program, false),     // 8. token_program
+            AccountMeta::new(*user, true),        // 0. user [signer, writable]
+            AccountMeta::new(pool_pda, false),    // 1. pool_pda [writable]
+            AccountMeta::new(user_ata, false),    // 2. user_ata [writable]
+            AccountMeta::new(vault, false),       // 3. vault [writable]
+            AccountMeta::new(lp_mint, false),     // 4. lp_mint [writable]
+            AccountMeta::new(user_lp_ata, false), // 5. user_lp_ata [writable]
+            AccountMeta::new_readonly(vault_auth, false), // 6. vault_auth
+            AccountMeta::new(deposit_pda, false), // 7. deposit_pda [writable]
+            AccountMeta::new_readonly(token_program, false), // 8. token_program
             AccountMeta::new_readonly(solana_sdk::sysvar::clock::id(), false), // 9. clock
             AccountMeta::new_readonly(system_program::id(), false), // 10. system_program
         ],
@@ -388,7 +388,7 @@ fn deposit_pda_squat_adoption() {
         Account {
             lamports: squat_lamports,
             owner: system_program::id(), // System-owned: griefer can only transfer, not allocate/assign
-            data: vec![],               // empty data: griefer cannot allocate data
+            data: vec![],                // empty data: griefer cannot allocate data
             executable: false,
             rent_epoch: 0,
         },

--- a/tests/task13_cpi_proxies_e2e.rs
+++ b/tests/task13_cpi_proxies_e2e.rs
@@ -802,7 +802,9 @@ fn tag88_maintenance_fee_direct_dies_after_initpool_and_proxy_writes_full_u128()
         &[&e.admin],
         direct_update_maintenance_fee_ix(e.wrapper_id, e.admin.pubkey(), market, BIG),
     )
-    .expect_err("AFTER StakeInitPool the direct tag-88 call must fail (marketauth is the pool PDA)");
+    .expect_err(
+        "AFTER StakeInitPool the direct tag-88 call must fail (marketauth is the pool PDA)",
+    );
     eprintln!("tag88 direct-call-after-InitPool rejected with: {err:?}");
     assert_eq!(
         read_u128_at(&e.svm, &market, OFF_MAINTENANCE_FEE_PER_SLOT),

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -955,16 +955,30 @@ fn test_154_deposit_cap_enforced_on_principal_not_fees() {
     pool.total_lp_supply = 800_000;
     pool.total_fees_earned = 300_000; // tpv = 1_100_000 (> cap); principal = 800_000 (< cap)
 
-    assert_eq!(pool.principal_tvl(), Some(800_000), "principal excludes accrued fees");
-    assert_eq!(pool.total_pool_value(), Some(1_100_000), "tpv includes accrued fees");
+    assert_eq!(
+        pool.principal_tvl(),
+        Some(800_000),
+        "principal excludes accrued fees"
+    );
+    assert_eq!(
+        pool.total_pool_value(),
+        Some(1_100_000),
+        "tpv includes accrued fees"
+    );
 
     // A 150K deposit keeps principal at 950K (<= 1M cap) → admitted under the fixed (principal) basis.
     let deposit = 150_000u64;
     let principal_after = pool.principal_tvl().unwrap() + deposit;
-    assert!(principal_after <= pool.deposit_cap, "#154: principal-basis cap admits the deposit");
+    assert!(
+        principal_after <= pool.deposit_cap,
+        "#154: principal-basis cap admits the deposit"
+    );
     // The old tpv-basis would have (wrongly) rejected it: 1.1M + 150K = 1.25M > cap.
     let tpv_after = pool.total_pool_value().unwrap() + deposit;
-    assert!(tpv_after > pool.deposit_cap, "old fee-inclusive basis would have rejected it");
+    assert!(
+        tpv_after > pool.deposit_cap,
+        "old fee-inclusive basis would have rejected it"
+    );
 
     // 2026-07-19: mode-0 insurance pools now accrue fees too, so principal_tvl()
     // (which never has a fee term, for either mode) diverges from total_pool_value()
@@ -974,7 +988,11 @@ fn test_154_deposit_cap_enforced_on_principal_not_fees() {
     m0.pool_mode = 0;
     m0.total_deposited = 500_000;
     m0.total_fees_earned = 99_999; // now counted in tpv, still excluded from principal_tvl
-    assert_eq!(m0.principal_tvl(), Some(500_000), "mode-0: principal_tvl excludes fees");
+    assert_eq!(
+        m0.principal_tvl(),
+        Some(500_000),
+        "mode-0: principal_tvl excludes fees"
+    );
     assert_eq!(
         m0.total_pool_value(),
         Some(599_999),
@@ -995,12 +1013,20 @@ fn test_161_last_junior_exit_does_not_windfall_recovery_to_senior() {
     pool.total_lp_supply = 200_000;
     pool.set_junior_balance(100_000);
     pool.set_junior_total_lp(100_000);
-    assert_eq!(pool.senior_balance().unwrap(), 100_000, "senior 100k pre-loss");
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        100_000,
+        "senior 100k pre-loss"
+    );
 
     // Flush 50k, junior-absorbed: senior protected, junior marked down to 50k.
     pool.total_flushed = 50_000;
     assert_eq!(pool.effective_junior_balance(), 50_000);
-    assert_eq!(pool.senior_balance().unwrap(), 100_000, "senior protected by junior first-loss");
+    assert_eq!(
+        pool.senior_balance().unwrap(),
+        100_000,
+        "senior protected by junior first-loss"
+    );
 
     // Last junior exits at eff_jb. Mirror process_withdraw's full-exit updates + the #161 booking.
     let junior_payout = pool.effective_junior_balance(); // 50k
@@ -1012,7 +1038,10 @@ fn test_161_last_junior_exit_does_not_windfall_recovery_to_senior() {
         .junior_balance()
         .saturating_sub(pool.effective_junior_balance())
         .min(net_loss);
-    assert_eq!(forfeited, 50_000, "junior forfeits the 50k loss it absorbed");
+    assert_eq!(
+        forfeited, 50_000,
+        "junior forfeits the 50k loss it absorbed"
+    );
     pool.total_returned += forfeited;
     pool.set_realized_junior_loss(pool.realized_junior_loss() + forfeited);
     pool.set_junior_total_lp(0);
@@ -1021,7 +1050,11 @@ fn test_161_last_junior_exit_does_not_windfall_recovery_to_senior() {
 
     // Senior is NOT windfalled — stays at its 100k principal.
     assert_eq!(pool.effective_junior_balance(), 0);
-    assert_eq!(pool.total_pool_value().unwrap(), 100_000, "tpv excludes the dead forfeited loss");
+    assert_eq!(
+        pool.total_pool_value().unwrap(),
+        100_000,
+        "tpv excludes the dead forfeited loss"
+    );
     assert_eq!(
         pool.senior_balance().unwrap(),
         100_000,
@@ -1131,7 +1164,11 @@ fn test_169_mode0_unaffected_and_rl_still_subtracted() {
         Some(700),
         "#161 RL still subtracted under the i128 rewrite"
     );
-    assert_eq!(pool.principal_tvl(), Some(700), "principal_tvl also subtracts RL");
+    assert_eq!(
+        pool.principal_tvl(),
+        Some(700),
+        "principal_tvl also subtracts RL"
+    );
 }
 
 #[test]
@@ -1142,6 +1179,10 @@ fn test_169_mode1_fees_included_in_value_but_not_principal() {
     pool.pool_mode = 1;
     pool.total_deposited = 1_000;
     pool.total_fees_earned = 250;
-    assert_eq!(pool.total_pool_value(), Some(1_250), "value includes fees in mode 1");
+    assert_eq!(
+        pool.total_pool_value(),
+        Some(1_250),
+        "value includes fees in mode 1"
+    );
     assert_eq!(pool.principal_tvl(), Some(1_000), "cap basis excludes fees");
 }

--- a/tests/v16_stake_insurance_e2e.rs
+++ b/tests/v16_stake_insurance_e2e.rs
@@ -170,8 +170,7 @@ impl Env {
         let wrapper_id = Pubkey::from_str(WRAPPER_MAINNET).unwrap();
         let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
         svm.add_program_from_file(stake_id, stake_so()).unwrap();
-        svm.add_program_from_file(wrapper_id, wrapper_so())
-            .unwrap();
+        svm.add_program_from_file(wrapper_id, wrapper_so()).unwrap();
 
         let payer = Keypair::new();
         let admin = Keypair::new();
@@ -344,8 +343,7 @@ fn smoke_both_programs_load() {
     let stake_id = Pubkey::from_str(STAKE_ID).unwrap();
     let wrapper_id = Pubkey::from_str(WRAPPER_MAINNET).unwrap();
     svm.add_program_from_file(stake_id, stake_path).unwrap();
-    svm.add_program_from_file(wrapper_id, wrapper_path)
-        .unwrap();
+    svm.add_program_from_file(wrapper_id, wrapper_path).unwrap();
     assert!(svm.get_account(&stake_id).unwrap().executable);
     assert!(svm.get_account(&wrapper_id).unwrap().executable);
 }
@@ -852,8 +850,7 @@ fn no_lockout_rotate_then_rebind_from_new_program() {
     let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
     svm.add_program_from_file(stake_id, stake_so()).unwrap();
     svm.add_program_from_file(stake_id_2, stake_so()).unwrap();
-    svm.add_program_from_file(wrapper_id, wrapper_so())
-        .unwrap();
+    svm.add_program_from_file(wrapper_id, wrapper_so()).unwrap();
 
     let admin = Keypair::new();
     let payer = Keypair::new();

--- a/tests/v17_stake_insurance_e2e.rs
+++ b/tests/v17_stake_insurance_e2e.rs
@@ -94,7 +94,11 @@ fn canonical_vault_ata(vault_authority: &Pubkey, mint: &Pubkey) -> Pubkey {
     let token_program = Pubkey::from_str(TOKEN_PROGRAM).unwrap();
     let ata_program = Pubkey::from_str(ATA_PROGRAM).unwrap();
     Pubkey::find_program_address(
-        &[vault_authority.as_ref(), token_program.as_ref(), mint.as_ref()],
+        &[
+            vault_authority.as_ref(),
+            token_program.as_ref(),
+            mint.as_ref(),
+        ],
         &ata_program,
     )
     .0
@@ -206,9 +210,8 @@ fn send(
     // (~153 CU). Every transaction to the wrapper MUST request a 128KB heap frame; this
     // mirrors the production transaction shape. See issue #176 (v17 deploy blocker: no
     // TS client currently requests this frame).
-    let cb_heap = solana_sdk::compute_budget::ComputeBudgetInstruction::request_heap_frame(
-        128 * 1024,
-    );
+    let cb_heap =
+        solana_sdk::compute_budget::ComputeBudgetInstruction::request_heap_frame(128 * 1024);
     let cb_cu =
         solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
     let tx = Transaction::new_signed_with_payer(
@@ -418,12 +421,12 @@ fn withdraw_insurance_asset_ix(args: WithdrawInsuranceArgs) -> Instruction {
     Instruction {
         program_id: args.wrapper_id,
         accounts: vec![
-            AccountMeta::new(args.operator, true),          // operator (signer)
-            AccountMeta::new(args.market, false),            // market (writable)
-            AccountMeta::new(args.dest_token, false),        // dest_token (writable)
-            AccountMeta::new(args.wrapper_vault, false),     // vault_token (writable)
+            AccountMeta::new(args.operator, true),    // operator (signer)
+            AccountMeta::new(args.market, false),     // market (writable)
+            AccountMeta::new(args.dest_token, false), // dest_token (writable)
+            AccountMeta::new(args.wrapper_vault, false), // vault_token (writable)
             AccountMeta::new_readonly(args.wrapper_vault_auth, false), // vault_authority
-            AccountMeta::new_readonly(args.token_program, false),      // token_program
+            AccountMeta::new_readonly(args.token_program, false), // token_program
         ],
         data: encode_withdraw_insurance_asset(0, args.amount),
     }
@@ -502,15 +505,15 @@ fn recover_flushed_insurance_ix(
     Instruction {
         program_id: ctx.stake_id,
         accounts: vec![
-            AccountMeta::new_readonly(*caller, false),            // 0: caller (permissionless)
-            AccountMeta::new(ctx.pool_pda, false),                // 1: pool PDA (writable)
-            AccountMeta::new(ctx.stake_vault, false),             // 2: pool vault (dest; writable)
-            AccountMeta::new_readonly(ctx.vault_auth, false),     // 3: vault_auth PDA
-            AccountMeta::new(market, false),                      // 4: wrapper market (writable)
-            AccountMeta::new(wrapper_vault, false),               // 5: wrapper vault (source; writable)
+            AccountMeta::new_readonly(*caller, false), // 0: caller (permissionless)
+            AccountMeta::new(ctx.pool_pda, false),     // 1: pool PDA (writable)
+            AccountMeta::new(ctx.stake_vault, false),  // 2: pool vault (dest; writable)
+            AccountMeta::new_readonly(ctx.vault_auth, false), // 3: vault_auth PDA
+            AccountMeta::new(market, false),           // 4: wrapper market (writable)
+            AccountMeta::new(wrapper_vault, false),    // 5: wrapper vault (source; writable)
             AccountMeta::new_readonly(wrapper_vault_auth, false), // 6: wrapper vault auth
-            AccountMeta::new_readonly(token_program, false),      // 7: token program
-            AccountMeta::new_readonly(wrapper_id, false),         // 8: percolator program
+            AccountMeta::new_readonly(token_program, false), // 7: token program
+            AccountMeta::new_readonly(wrapper_id, false), // 8: percolator program
         ],
         data,
     }
@@ -638,7 +641,11 @@ fn flush_applies_insurance_after_bind_v17() {
         }
         other => panic!("expected Custom(8) Unauthorized, got {other:?}"),
     }
-    assert_eq!(token_amount(&svm, &pool.stake_vault), FLUSH_AMOUNT, "no tokens moved");
+    assert_eq!(
+        token_amount(&svm, &pool.stake_vault),
+        FLUSH_AMOUNT,
+        "no tokens moved"
+    );
     assert_eq!(token_amount(&svm, &wrapper_vault), 0, "no tokens moved");
 
     // Expire blockhash before the GREEN path so the flush tx hash differs from the RED attempt.
@@ -829,7 +836,11 @@ fn no_admin_drain_before_and_after_bind() {
         other => panic!("unexpected error variant from drain attempt: {other:?}"),
     }
     // No tokens moved (balance was zero anyway).
-    assert_eq!(token_amount(&svm, &admin_dest_red), 0, "no drain — balance was zero");
+    assert_eq!(
+        token_amount(&svm, &admin_dest_red),
+        0,
+        "no drain — balance was zero"
+    );
 
     // ── GREEN: full secure bind sequence — admin drain BLOCKED (no pre-rotation) ─
     // Secure bind sequence:
@@ -1239,7 +1250,11 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
         ),
     )
     .expect("flush A");
-    assert_eq!(token_amount(&svm, &wrapper_vault), 40_000, "flush A applied");
+    assert_eq!(
+        token_amount(&svm, &wrapper_vault),
+        40_000,
+        "flush A applied"
+    );
 
     // Step 2a: ROTATE insurance_authority off PDA_A to the admin wallet (tag 20)
     // before the final asset_admin burn.
@@ -1267,7 +1282,13 @@ fn no_lockout_rotate_then_rebind_from_new_program_v17() {
         &mut svm,
         &payer,
         &[&admin],
-        rotate_operator_stake_ix(&pool_a, wrapper_id, market, &admin.pubkey(), &admin.pubkey()),
+        rotate_operator_stake_ix(
+            &pool_a,
+            wrapper_id,
+            market,
+            &admin.pubkey(),
+            &admin.pubkey(),
+        ),
     )
     .expect("rotate insurance_operator: PDA_A → admin wallet");
 
@@ -1512,18 +1533,17 @@ fn recover_flushed_insurance_after_burn() {
     // Step 4: RecoverFlushedInsurance — PDA-signed, permissionless caller (use payer).
     // Reads pool.total_returned before to verify accounting increment.
     let pool_account_before = svm.get_account(&pool.pool_pda).unwrap();
-    let pool_state_before =
-        bytemuck::try_from_bytes::<percolator_stake::state::StakePool>(
-            &pool_account_before.data[..percolator_stake::state::STAKE_POOL_SIZE],
-        )
-        .unwrap();
+    let pool_state_before = bytemuck::try_from_bytes::<percolator_stake::state::StakePool>(
+        &pool_account_before.data[..percolator_stake::state::STAKE_POOL_SIZE],
+    )
+    .unwrap();
     let total_returned_before = pool_state_before.total_returned;
 
     svm.expire_blockhash();
     send(
         &mut svm,
         &payer,
-        &[],                   // permissionless — payer signs only as fee payer
+        &[], // permissionless — payer signs only as fee payer
         recover_flushed_insurance_ix(
             &pool,
             wrapper_id,
@@ -1531,7 +1551,7 @@ fn recover_flushed_insurance_after_burn() {
             market,
             wrapper_vault,
             wrapper_vault_auth,
-            &payer.pubkey(),   // caller (permissionless, not admin)
+            &payer.pubkey(), // caller (permissionless, not admin)
             FLUSH_AMOUNT,
         ),
     )
@@ -1551,16 +1571,13 @@ fn recover_flushed_insurance_after_burn() {
 
     // Assert: pool.total_returned incremented by FLUSH_AMOUNT.
     let pool_account_after = svm.get_account(&pool.pool_pda).unwrap();
-    let pool_state_after =
-        bytemuck::try_from_bytes::<percolator_stake::state::StakePool>(
-            &pool_account_after.data[..percolator_stake::state::STAKE_POOL_SIZE],
-        )
-        .unwrap();
+    let pool_state_after = bytemuck::try_from_bytes::<percolator_stake::state::StakePool>(
+        &pool_account_after.data[..percolator_stake::state::STAKE_POOL_SIZE],
+    )
+    .unwrap();
     assert_eq!(
         pool_state_after.total_returned,
-        total_returned_before
-            .checked_add(FLUSH_AMOUNT)
-            .unwrap(),
+        total_returned_before.checked_add(FLUSH_AMOUNT).unwrap(),
         "total_returned incremented by FLUSH_AMOUNT (conservation)"
     );
 }
@@ -1636,15 +1653,15 @@ fn recover_flushed_insurance_wrong_dest_rejected() {
         let ix = Instruction {
             program_id: stake_id,
             accounts: vec![
-                AccountMeta::new_readonly(payer.pubkey(), false),    // 0: caller
-                AccountMeta::new(pool.pool_pda, false),              // 1: pool PDA
-                AccountMeta::new(attacker_dest, false),              // 2: WRONG dest (not pool.vault)
-                AccountMeta::new_readonly(pool.vault_auth, false),   // 3: vault_auth PDA
-                AccountMeta::new(market, false),                     // 4: market
-                AccountMeta::new(wrapper_vault, false),              // 5: wrapper vault
-                AccountMeta::new_readonly(wrapper_vault_auth, false),// 6: wrapper vault auth
-                AccountMeta::new_readonly(token_program, false),     // 7: token program
-                AccountMeta::new_readonly(wrapper_id, false),        // 8: percolator program
+                AccountMeta::new_readonly(payer.pubkey(), false), // 0: caller
+                AccountMeta::new(pool.pool_pda, false),           // 1: pool PDA
+                AccountMeta::new(attacker_dest, false),           // 2: WRONG dest (not pool.vault)
+                AccountMeta::new_readonly(pool.vault_auth, false), // 3: vault_auth PDA
+                AccountMeta::new(market, false),                  // 4: market
+                AccountMeta::new(wrapper_vault, false),           // 5: wrapper vault
+                AccountMeta::new_readonly(wrapper_vault_auth, false), // 6: wrapper vault auth
+                AccountMeta::new_readonly(token_program, false),  // 7: token program
+                AccountMeta::new_readonly(wrapper_id, false),     // 8: percolator program
             ],
             data,
         };
@@ -1665,7 +1682,11 @@ fn recover_flushed_insurance_wrong_dest_rejected() {
         other => panic!("expected Custom(InvalidPda=10), got {other:?}"),
     }
     // No tokens moved.
-    assert_eq!(token_amount(&svm, &attacker_dest), 0, "no drain to attacker_dest");
+    assert_eq!(
+        token_amount(&svm, &attacker_dest),
+        0,
+        "no drain to attacker_dest"
+    );
     assert_eq!(
         token_amount(&svm, &wrapper_vault),
         FLUSH_AMOUNT,


### PR DESCRIPTION
## Why CI never caught any of this

The triggers were `master` — **a branch that does not exist in this repository** — so CI has never run on a single push or PR here. Three defects reached the deployed devnet program under that blind spot.

## Changes

1. **`master` → `main`** on both triggers. This alone is why nothing ran.
2. **Build the BPF artifacts the e2e suites actually load.** `cargo test` does not produce them: the suites run the real programs under LiteSVM from `percolator-stake/target/deploy/percolator_stake.so` and the sibling `percolator-prog/target/deploy/percolator_prog.so`, both gitignored. Adds the Solana CLI, checks out `percolator-prog`, and builds both.
3. **An explicit artifact guard.** `common_svm_setup()` returns `None` and the test passes *vacuously* when either `.so` is missing — 23 tests across 7 suites behave that way.
4. **`cargo fmt --all`** in a separate commit, so the fmt gate can pass. 29 files had drifted.

## On the vacuous-skip hazard

Measured, not assumed:

| state | result |
|---|---|
| both `.so` present | 431 pass / 0 fail |
| stake `.so` missing | 417 pass / **14 fail** |
| wrapper `.so` missing | 421 pass / **10 fail** |

So today a missing artifact goes **red, not falsely green** — other suites `.unwrap()` and hard-fail. But that masking is incidental: it is one "let's fix these noisy failures" change away from becoming a silent 23-test hole. The guard asserts both artifacts up front rather than relying on it.

## Verification

- 431 pass / 0 fail after formatting, unchanged from before
- lib clippy `-D warnings` clean; `cargo fmt --check` now passes
- The fmt commit is verified behaviour-preserving at the artifact level: rebuilding the `.so` before/after gives identical size differing in **9 bytes of 253968 (0.0035%)**, at regular 24-byte intervals, each off by 3-5 — the panic-location line-number table shifting. The pre-fmt build still reproduces the deployed hash `1bf05bbb...`.

Clippy stays library-only: `--all-targets` reports pre-existing lints in the test suites, a separate cleanup rather than a gate to add mid-flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration to run on the `main` branch.
  * Expanded automated checks to build program artifacts, verify outputs, and run tests with an extended timeout.

* **Style**
  * Applied consistent Rust formatting across implementation code and test suites without changing behavior.

* **Tests**
  * Preserved existing unit, integration, end-to-end, regression, and proof-test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->