### PR TITLE
fix(security): promote #242 cooldown timelock out of _reserved (v4, 392->408) [BLOCKED on wrapper]

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -157,6 +157,27 @@ pub struct StakePool {
     /// cutover: pools are being re-seeded, so no on-chain migration path is
     /// needed — SDK decoders must add this field for version-3 pools.
     pub total_recovered_from_wrapper: u64,
+
+    /// #242 timelock (v4): the `cooldown_slots` INCREASE awaiting commit.
+    /// Meaningful only while `cooldown_proposed_at_slot != 0`.
+    ///
+    /// Real struct field (offset 392), NOT carved from `_reserved`. The original
+    /// #242 packing put this at `_reserved[10..18]`, whose comment claimed
+    /// `[10..32]` was "previously-free" — but PERC-313 HWM already owns that
+    /// entire range (`hwm_enabled` at [10], `hwm_floor_bps` at [11..13],
+    /// `epoch_high_water_tvl` at [16..24], `hwm_last_epoch` at [24..32]). The two
+    /// features therefore aliased each other on the DEPLOYED v3 program: proposing
+    /// a cooldown flipped `hwm_enabled` off and rewrote `hwm_floor_bps`, and an HWM
+    /// refresh rewrote the proposal slot — the latter reading as a long-elapsed
+    /// timelock, i.e. a bypass of the very delay that protects stakers from the
+    /// admin. See `tests/poc_cooldown_timelock_hwm_overlap.rs`.
+    pub pending_cooldown_slots: u64,
+
+    /// #242 timelock (v4): the slot at which the pending cooldown increase was
+    /// proposed. `0` = no active proposal (the sentinel; a live slot is never 0).
+    /// Real struct field (offset 400) — see [`StakePool::pending_cooldown_slots`]
+    /// for why these are no longer packed into `_reserved`.
+    pub cooldown_proposed_at_slot: u64,
 }
 
 /// Size of StakePool in bytes
@@ -201,7 +222,19 @@ const _: () = {
     assert!(offset_of!(StakePool, _reserved) == 320);
     assert!(offset_of!(StakePool, _reserved) + 8 == 328);
     // Total size — the wrapper's `STAKE_POOL_LEN` minimum-length gate.
-    assert!(STAKE_POOL_SIZE == 392);
+    //
+    // v4 grows this 392 -> 408 by APPENDING the two #242 timelock fields after
+    // `total_recovered_from_wrapper` (384). Every offset the wrapper reads is
+    // <= 328 and therefore unmoved, and its gate is `data.len() < STAKE_POOL_LEN`
+    // — a minimum — so a 408-byte account still passes it.
+    //
+    // BUT the wrapper also checks the version byte EXACTLY
+    // (`percolator-prog/src/v16_program.rs`: `STAKE_POOL_VERSION: u8 = 3`,
+    // `data[STAKE_POOL_OFF_VERSION] != STAKE_POOL_VERSION` -> InvalidInstruction).
+    // Shipping v4 therefore REQUIRES a coordinated wrapper bump to
+    // STAKE_POOL_VERSION = 4 / STAKE_POOL_LEN = 408 and a wrapper redeploy, or
+    // tag-87 stops paying the insurance fee leg to every stake pool.
+    assert!(STAKE_POOL_SIZE == 408);
 };
 
 /// Per-depositor state — tracks cooldown and LP amount per user.
@@ -424,34 +457,31 @@ impl StakePool {
         self._reserved[59] = if burned { 1 } else { 0 };
     }
 
-    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Stored at
-    /// `_reserved[10..18]` (LE u64), in the previously-free `[10..32]` region — no
-    /// struct-size change, no version bump. Meaningful only while
+    /// #242 timelock: the `cooldown_slots` INCREASE awaiting commit. Backed by the
+    /// dedicated [`StakePool::pending_cooldown_slots`] field (v4); it previously
+    /// aliased the PERC-313 HWM bytes at `_reserved[10..18]`. Meaningful only while
     /// `cooldown_proposed_at_slot() != 0`.
     pub fn pending_cooldown_slots(&self) -> u64 {
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&self._reserved[10..18]);
-        u64::from_le_bytes(bytes)
+        self.pending_cooldown_slots
     }
 
     /// Set the pending cooldown-increase value. See [`pending_cooldown_slots`].
     pub fn set_pending_cooldown_slots(&mut self, val: u64) {
-        self._reserved[10..18].copy_from_slice(&val.to_le_bytes());
+        self.pending_cooldown_slots = val;
     }
 
     /// #242 timelock: the slot at which the pending cooldown increase was proposed.
-    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Stored
-    /// at `_reserved[18..26]` (LE u64).
+    /// `0` = no active proposal (the sentinel; a live mainnet slot is never 0). Backed
+    /// by the dedicated [`StakePool::cooldown_proposed_at_slot`] field (v4); it
+    /// previously aliased the PERC-313 HWM bytes at `_reserved[18..26]`.
     pub fn cooldown_proposed_at_slot(&self) -> u64 {
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&self._reserved[18..26]);
-        u64::from_le_bytes(bytes)
+        self.cooldown_proposed_at_slot
     }
 
     /// Set the cooldown-increase proposal slot (`0` clears the proposal). See
     /// [`cooldown_proposed_at_slot`].
     pub fn set_cooldown_proposed_at_slot(&mut self, val: u64) {
-        self._reserved[18..26].copy_from_slice(&val.to_le_bytes());
+        self.cooldown_proposed_at_slot = val;
     }
 
     /// Loss-adjusted junior tranche balance.
@@ -542,7 +572,16 @@ impl StakePool {
     /// v3 (size 384 -> 392): added `total_recovered_from_wrapper` (H-1 re-review
     /// fix) — the resolve-gate counter that tracks ONLY wrapper-CPI-recovered
     /// flushed insurance, distinct from `total_returned`.
-    pub const CURRENT_VERSION: u8 = 3;
+    /// v4 (size 392 -> 408): promoted the #242 cooldown-timelock values to the
+    /// dedicated `pending_cooldown_slots` / `cooldown_proposed_at_slot` fields,
+    /// removing their aliasing of the PERC-313 HWM bytes in `_reserved[10..26]`.
+    ///
+    /// This MUST be 4, not a second flavour of 3: v3 is live on devnet at 392
+    /// bytes, and `validate_pool_version` compares for exact equality, so reusing
+    /// 3 for a 408-byte layout would let a v3 account pass the version check and
+    /// then fail the length check in `pool_from_data`. Fresh-start cutover: live
+    /// v3 pools are re-seeded, so no on-chain migration path is provided.
+    pub const CURRENT_VERSION: u8 = 4;
 
     /// Set discriminator in first 8 bytes of _reserved and version in byte 8.
     /// Call on init.
@@ -764,11 +803,10 @@ mod tests {
     fn test_stake_pool_size() {
         // Ensure struct is packed correctly (no surprise padding)
         assert_eq!(STAKE_POOL_SIZE, std::mem::size_of::<StakePool>());
-        // v3 size: prior 384 + total_recovered_from_wrapper[8] = 392.
-        // 1+1+1+1+4 + 5*32 + 7*8 + 32(percolator_program) + 24(PERC-272 u64s)
-        //   + 1(pool_mode) + 7(mode_pad) + 32(pending_admin) + 64(_reserved)
-        //   + 8(total_recovered_from_wrapper) = 392
-        assert_eq!(STAKE_POOL_SIZE, 392);
+        // v4 size: v3's 392 + pending_cooldown_slots[8] + cooldown_proposed_at_slot[8]
+        //   = 408. Both APPENDED after total_recovered_from_wrapper (384), so no
+        //   existing offset moves.
+        assert_eq!(STAKE_POOL_SIZE, 408);
     }
 
     #[test]

--- a/tests/poc_cooldown_timelock_hwm_overlap.rs
+++ b/tests/poc_cooldown_timelock_hwm_overlap.rs
@@ -1,0 +1,127 @@
+//! Regression for #250/#258 — the #242 cooldown-increase timelock fields
+//! (`pending_cooldown_slots`, `cooldown_proposed_at_slot`) used to be packed into
+//! `StakePool::_reserved[10..26]`, which the PERC-313 high-water-mark feature already
+//! owned in full (`hwm_enabled` at [10], `hwm_floor_bps` at [11..13],
+//! `epoch_high_water_tvl` at [16..24], `hwm_last_epoch` at [24..32]). Every write to
+//! one feature silently corrupted the other's stored state.
+//!
+//! The fix promotes both cooldown-timelock fields to real `StakePool` struct fields
+//! (CURRENT_VERSION 2 -> 3, STAKE_POOL_SIZE 384 -> 400), so they can no longer alias
+//! any `_reserved` byte. These tests mirror the exact corruption sequences from the
+//! original bug reports and assert the corruption no longer happens.
+
+use bytemuck::Zeroable;
+use percolator_stake::state::StakePool;
+
+#[test]
+fn cooldown_timelock_and_hwm_no_longer_share_storage() {
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    // Start with HWM enabled and a normal 50% floor.
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(5_000);
+    pool.set_epoch_high_water_tvl(1_000_000);
+    pool.set_hwm_last_epoch(10);
+
+    assert!(pool.hwm_enabled());
+    assert_eq!(pool.hwm_floor_bps(), 5_000);
+    assert_eq!(pool.epoch_high_water_tvl(), 1_000_000);
+    assert_eq!(pool.hwm_last_epoch(), 10);
+
+    // Proposing a cooldown increase used to write _reserved[10..18] and
+    // _reserved[18..26], which aliased every HWM field except the high bytes of
+    // hwm_last_epoch. With real fields, this must leave HWM state untouched.
+    pool.set_pending_cooldown_slots(43_200_000);
+    pool.set_cooldown_proposed_at_slot(123_456_789);
+
+    assert!(
+        pool.hwm_enabled(),
+        "cooldown proposal must not disturb hwm_enabled"
+    );
+    assert_eq!(
+        pool.hwm_floor_bps(),
+        5_000,
+        "cooldown proposal must not disturb hwm_floor_bps"
+    );
+    assert_eq!(
+        pool.epoch_high_water_tvl(),
+        1_000_000,
+        "cooldown proposal must not disturb epoch_high_water_tvl"
+    );
+    assert_eq!(
+        pool.hwm_last_epoch(),
+        10,
+        "cooldown proposal must not disturb hwm_last_epoch"
+    );
+
+    // Now the reverse direction: a later HWM refresh must not corrupt the active
+    // cooldown proposal.
+    let pending_before = pool.pending_cooldown_slots();
+    let proposed_at_before = pool.cooldown_proposed_at_slot();
+
+    pool.refresh_hwm(11, 2_000_000);
+
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        pending_before,
+        "refresh_hwm must not change pending_cooldown_slots"
+    );
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        proposed_at_before,
+        "refresh_hwm must not change cooldown_proposed_at_slot"
+    );
+}
+
+#[test]
+fn enabling_hwm_does_not_mutate_a_pending_cooldown_value() {
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    pool.set_pending_cooldown_slots(10_000_000);
+    pool.set_cooldown_proposed_at_slot(500_000);
+
+    let pending_before = pool.pending_cooldown_slots();
+    let proposed_at_before = pool.cooldown_proposed_at_slot();
+
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(9_000);
+
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        pending_before,
+        "set_hwm_enabled/set_hwm_floor_bps must not overwrite pending_cooldown_slots"
+    );
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        proposed_at_before,
+        "set_hwm_enabled/set_hwm_floor_bps must not overwrite cooldown_proposed_at_slot"
+    );
+}
+
+#[test]
+fn hwm_activity_does_not_fabricate_a_phantom_cooldown_proposal() {
+    // #250 Direction C: with the old _reserved packing, enabling HWM with a nonzero
+    // epoch_high_water_tvl made cooldown_proposed_at_slot() read as nonzero — a
+    // "phantom" proposal nobody made. With real fields, an untouched cooldown
+    // timelock must report no pending proposal regardless of HWM activity.
+    let mut pool = StakePool::zeroed();
+    pool.set_discriminator();
+
+    pool.set_hwm_enabled(true);
+    pool.set_hwm_floor_bps(5_000);
+    pool.refresh_hwm(1, 2_000_000_000);
+    pool.refresh_hwm(2, 5_000_000_000);
+
+    assert_eq!(
+        pool.cooldown_proposed_at_slot(),
+        0,
+        "HWM activity must never fabricate a pending cooldown proposal"
+    );
+    assert_eq!(
+        pool.pending_cooldown_slots(),
+        0,
+        "HWM activity must never fabricate a pending cooldown value"
+    );
+}

--- a/tests/regression_reserved_collision.rs
+++ b/tests/regression_reserved_collision.rs
@@ -1,0 +1,122 @@
+//! Regression: the #242 cooldown-timelock fields must never again share storage with
+//! the PERC-313 HWM fields.
+//!
+//! On the DEPLOYED v3 program (474079f) they aliased:
+//!
+//!   pending_cooldown_slots     _reserved[10..18]   hwm_enabled           _reserved[10]
+//!   cooldown_proposed_at_slot  _reserved[18..26]   hwm_floor_bps         _reserved[11..13]
+//!                                                  epoch_high_water_tvl  _reserved[16..24]
+//!                                                  hwm_last_epoch        _reserved[24..32]
+//!
+//! Both sides were live: propose/commit/cancel cooldown are dispatched instructions and
+//! `processor.rs` writes the HWM TVL on withdraw. Measured on v3, these three tests
+//! recorded `hwm_enabled` true->false, `hwm_floor_bps` 9000->843, `epoch_high_water_tvl`
+//! 1e9->2.6e13, and `cooldown_proposed_at_slot` 400_000_000->15_258 (a ~400M-slot
+//! timelock bypass). Each assertion below is the inverse of the measured v3 behaviour.
+
+use percolator_stake::state::StakePool;
+
+fn pool() -> StakePool {
+    let mut p: StakePool = bytemuck::Zeroable::zeroed();
+    p.set_discriminator();
+    p
+}
+
+/// v3: a cooldown proposal silently DISABLED the HWM withdrawal floor.
+#[test]
+fn proposing_cooldown_leaves_hwm_floor_intact() {
+    let mut p = pool();
+    p.set_hwm_enabled(true);
+    p.set_hwm_floor_bps(9_000); // 90% floor
+
+    p.set_pending_cooldown_slots(216_000); // ~1 day
+
+    assert!(
+        p.hwm_enabled(),
+        "cooldown proposal must not disable the HWM floor"
+    );
+    assert_eq!(
+        p.hwm_floor_bps(),
+        9_000,
+        "cooldown proposal must not rewrite hwm_floor_bps"
+    );
+}
+
+/// v3: an HWM refresh CLOBBERED the proposal slot, so the timelock read as long-elapsed.
+#[test]
+fn hwm_refresh_preserves_cooldown_timelock() {
+    let mut p = pool();
+    let proposed_at: u64 = 400_000_000;
+    p.set_pending_cooldown_slots(216_000);
+    p.set_cooldown_proposed_at_slot(proposed_at);
+
+    // Any withdraw that refreshes the epoch HWM.
+    p.set_epoch_high_water_tvl(1_000_000_000);
+    p.set_hwm_last_epoch(0);
+
+    assert_eq!(
+        p.cooldown_proposed_at_slot(),
+        proposed_at,
+        "HWM refresh must not move the proposal slot — that is a timelock bypass"
+    );
+    assert_eq!(
+        p.pending_cooldown_slots(),
+        216_000,
+        "HWM refresh must not move the pending value"
+    );
+}
+
+/// v3: a cooldown proposal corrupted the HWM TVL that gates withdrawals.
+#[test]
+fn cooldown_proposal_preserves_hwm_tvl() {
+    let mut p = pool();
+    p.set_hwm_enabled(true);
+    p.set_epoch_high_water_tvl(1_000_000_000);
+    p.set_hwm_last_epoch(700);
+
+    p.set_cooldown_proposed_at_slot(400_000_000);
+
+    assert_eq!(
+        p.epoch_high_water_tvl(),
+        1_000_000_000,
+        "proposal must not corrupt HWM TVL"
+    );
+    assert_eq!(
+        p.hwm_last_epoch(),
+        700,
+        "proposal must not corrupt the HWM epoch"
+    );
+}
+
+/// The discriminator, version byte and every other `_reserved` tenant must survive
+/// both feature's writes — the collision was found because `_reserved` had no owner map.
+#[test]
+fn reserved_tenants_survive_both_features() {
+    let mut p = pool();
+    p.set_market_resolved(true);
+    p.set_tranche_enabled(true);
+    p.set_realized_junior_loss(12_345);
+    p.set_asset_admin_burned(true);
+    p.set_hwm_enabled(true);
+    p.set_hwm_floor_bps(9_000);
+    p.set_epoch_high_water_tvl(1_000_000_000);
+    p.set_hwm_last_epoch(700);
+
+    p.set_pending_cooldown_slots(u64::MAX);
+    p.set_cooldown_proposed_at_slot(u64::MAX);
+
+    assert!(p.validate_discriminator(), "discriminator must survive");
+    assert_eq!(
+        p.version(),
+        StakePool::CURRENT_VERSION,
+        "version byte must survive"
+    );
+    assert!(p.market_resolved());
+    assert!(p.tranche_enabled());
+    assert_eq!(p.realized_junior_loss(), 12_345);
+    assert!(p.asset_admin_burned());
+    assert!(p.hwm_enabled());
+    assert_eq!(p.hwm_floor_bps(), 9_000);
+    assert_eq!(p.epoch_high_water_tvl(), 1_000_000_000);
+    assert_eq!(p.hwm_last_epoch(), 700);
+}

--- a/tests/struct_layout.rs
+++ b/tests/struct_layout.rs
@@ -6,15 +6,41 @@
 use percolator_stake::state::{StakeDeposit, StakePool, STAKE_DEPOSIT_SIZE, STAKE_POOL_SIZE};
 
 #[test]
-fn test_stake_pool_size_is_392() {
-    // v3 layout: prior 384 + total_recovered_from_wrapper[8] (H-1 re-review fix:
-    // resolve-gate counter tracking ONLY wrapper-CPI-recovered flushed insurance,
-    // distinct from total_returned) = 392.
+fn test_stake_pool_size_is_408() {
+    // v4 layout: v3's 392 + pending_cooldown_slots[8] + cooldown_proposed_at_slot[8]
+    // = 408. The two #242 timelock values were promoted out of `_reserved[10..26]`,
+    // where they aliased the PERC-313 HWM fields on the deployed v3 program.
     // If this changes, existing on-chain data becomes unreadable.
     // NEVER change this without a version bump + (if not fresh-start) a migration.
-    // Pools are being re-seeded fresh for v3, so no migration path is needed.
-    assert_eq!(STAKE_POOL_SIZE, 392);
-    assert_eq!(std::mem::size_of::<StakePool>(), 392);
+    // Pools are being re-seeded fresh for v4, so no migration path is needed.
+    assert_eq!(STAKE_POOL_SIZE, 408);
+    assert_eq!(std::mem::size_of::<StakePool>(), 408);
+}
+
+/// The new fields must be APPENDED after `total_recovered_from_wrapper` (offset 384),
+/// not inserted. Cross-program readers (percolator-surfpool's `stake_nft.rs` mirror)
+/// bounds-check with `len >= 392` and read every field at a fixed offset <= 384, so
+/// appending keeps them working unchanged; inserting would silently corrupt them.
+#[test]
+fn test_v3_prefix_offsets_are_unchanged() {
+    let pool: StakePool = bytemuck::Zeroable::zeroed();
+    let base = &pool as *const _ as usize;
+    let off = |p: *const u64| p as usize - base;
+    assert_eq!(
+        off(&pool.total_recovered_from_wrapper),
+        384,
+        "v3 field must stay at 384"
+    );
+    assert_eq!(
+        off(&pool.pending_cooldown_slots),
+        392,
+        "must be appended, not inserted"
+    );
+    assert_eq!(
+        off(&pool.cooldown_proposed_at_slot),
+        400,
+        "must be appended, not inserted"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Supersedes **#273** and **#261**, rebased onto the deployed layout. Both targeted the stale 384-byte `main` and computed `STAKE_POOL_SIZE = 400 / v3`; against the real deployed base (392, v3, `total_recovered_from_wrapper` at offset 384) the correct numbers are **408 / v4**.

## The bug, live on the deployed program

The #242 cooldown-timelock values and the PERC-313 HWM fields **alias the same `_reserved` bytes**. The #242 accessor comment claimed `[10..32]` was "previously-free"; PERC-313 already owned all of it.

```
pending_cooldown_slots     _reserved[10..18]   hwm_enabled           _reserved[10]
cooldown_proposed_at_slot  _reserved[18..26]   hwm_floor_bps         _reserved[11..13]
                                               epoch_high_water_tvl  _reserved[16..24]
                                               hwm_last_epoch        _reserved[24..32]
```

Both sides are live and reachable — propose/commit/cancel cooldown are dispatched instructions, and the HWM TVL is written on the withdraw path. Measured on the deployed v3 build:

| action | effect |
|---|---|
| propose a cooldown | `hwm_enabled` **true → false**, `hwm_floor_bps` **9000 → 843** — silently disables the HWM withdrawal floor |
| HWM refresh | `cooldown_proposed_at_slot` **400,000,000 → 15,258** — `CommitCooldownIncrease` sees the timelock as elapsed by ~400M slots |
| propose a cooldown | `epoch_high_water_tvl` **1e9 → 2.6e13** (26,214x) |

The timelock exists to protect stakers *from* the admin, and it can be bypassed.

## Why the struct has to grow

`_reserved` has only **7 free bytes** (`[13..16]` and `[60..64]`), so two `u64`s cannot be relocated within it. Both fields are **appended** after `total_recovered_from_wrapper` (384), so every v3 offset is unmoved — `test_v3_prefix_offsets_are_unchanged` pins that, and cross-program readers that bounds-check `len >= 392` and read fields at offsets `<= 384` keep working.

## ⚠️ BLOCKED — requires a coordinated wrapper change

`percolator-prog` pins the stake version **exactly**:

```rust
pub const STAKE_POOL_VERSION: u8 = 3;
data[STAKE_POOL_OFF_VERSION] != STAKE_POOL_VERSION -> InvalidInstruction
```

Its own comment anticipates this: *"a future v4 must fail loudly here."* **Merging this alone stops tag-87 paying the insurance fee leg to every stake pool.** The wrapper needs `STAKE_POOL_VERSION = 4` and `STAKE_POOL_LEN = 408` — its length gate is a `<` minimum, so 408 already passes that half — plus a redeploy, shipped together with this.

This also bricks the 25 live devnet pools (20 empty, 5 with round test deposits), which is a deliberate re-seed, not a silent break.

## Verification

- **439 pass / 0 fail** (baseline 431); lib clippy clean; no new fmt breakage
- Carries #261's 3-test PoC plus a 4-test regression suite covering all three corruption directions and every other `_reserved` tenant

## Why this over #273 / #261

#261 was the better of the two — its field names match the existing accessors (#273 reverses the word order) and it ships a real PoC. Both are superseded here only because their size/version arithmetic was computed against the stale base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cooldown settings could overwrite or be overwritten by high-water-mark data.
  * Preserved cooldown timing, high-water-mark settings, version information, and related state when either feature is updated.

* **Tests**
  * Added regression coverage for cooldown and high-water-mark interactions.
  * Updated storage layout validation for the latest stake pool format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->