### PR TITLE
ci: check out the engine, pin siblings, and stop imposing -D warnings on them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
           path: percolator-prog
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
+      # percolator-prog has a path dependency on the engine
+      # (`percolator = { path = "../percolator" }`), so the wrapper cannot build
+      # without it checked out as a sibling.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: dcccrypto/percolator
+          path: percolator
+          token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
+
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
         with:
           toolchain: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           repository: dcccrypto/percolator-prog
           path: percolator-prog
+          # Pinned: the deployed devnet wrapper was built from this branch
+          # (19d5d932). TODO move to main once it lands there.
+          ref: feat/protocol-fee-taker-only
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       # percolator-prog has a path dependency on the engine
@@ -44,6 +47,10 @@ jobs:
         with:
           repository: dcccrypto/percolator
           path: percolator
+          # Pinned for the same reason, and because dcccrypto/percolator@main
+          # does not currently compile under the wrapper's build settings
+          # ("error: variable does not need to be mutable", v16.rs:8871).
+          ref: feat/protocol-fee-taker-only
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,15 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
         with:
           toolchain: stable
+          # This action defaults to rustflags: "-D warnings" and exports it as a
+          # GLOBAL env var, so it applies to every crate compiled here —
+          # including the sibling path dependencies. That made the engine fail to
+          # build on an `unused_mut` it has never been required to satisfy
+          # (percolator/src/v16.rs:9207), breaking the wrapper .so and this whole
+          # job. Deny-warnings for THIS crate is enforced by the Clippy job, which
+          # passes -D warnings explicitly; imposing it on other repos' code is not
+          # this workflow's business.
+          rustflags: ""
 
       - name: Install Solana CLI (provides cargo-build-sbf)
         run: |


### PR DESCRIPTION
Follow-up to #278, which turned CI on for the first time in this repository's history and immediately surfaced that the cross-repo e2e tests could not build.

Three things, in the order I found them:

**1. The engine repo was missing.** `percolator-prog` has a path dependency on `percolator`, so checking out the wrapper alone is not enough. The chain is **percolator-stake → percolator-prog → percolator**.

**2. Sibling refs pinned** to `feat/protocol-fee-taker-only` — what the deployed devnet wrapper was actually built from (`percolator-prog@19d5d932`, `percolator@f53be74a`). Testing the stake program against a wrapper build that does not match the deployed one would be misleading.

**3. The real blocker was this workflow, not the engine.** The wrapper build kept failing on:

```
error: variable does not need to be mutable
  --> percolator/src/v16.rs:9207
```

I was about to open a PR against `dcccrypto/percolator` to "fix" that. **The engine is not broken.** `actions-rust-lang/setup-rust-toolchain` defaults to `rustflags: "-D warnings"` and exports it as a **global env var**, so it applied to every crate compiled in this job — including sibling path dependencies that have never been required to satisfy it.

Reproduced locally:

| command | result |
|---|---|
| `cargo build-sbf` in percolator-prog | **0 errors** |
| same, under `RUSTFLAGS="-D warnings"` | exactly that failure |

Fixed by setting `rustflags: ""` on the Test job's toolchain step. Deny-warnings for *this* crate is still enforced by the Clippy job, which passes `-D warnings` explicitly.

## Result

All four jobs green, and the e2e tests genuinely execute:

- **CI: 437 passed / 0 failed** — identical to local
- **0 `SKIP: .so missing` messages**, so the 23 cross-repo e2e tests really ran rather than passing vacuously
- LiteSVM test names present in the log (`admin_resolve_market_h1_* ... ok`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D