### PR TITLE
ci: test against the wrapper that is actually deployed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,14 @@ jobs:
           # this workflow's business.
           rustflags: ""
 
-      - name: Install Solana CLI (provides cargo-build-sbf)
+      # Pinned, not "stable": cargo-build-sbf bundles its own platform-tools
+      # rustc, so the CLI version determines the emitted bytes. v3.1.15
+      # (platform-tools v1.52) is what reproduces the deployed wrapper exactly;
+      # "stable" drifted and produced a 1206296-byte binary instead of 1243192
+      # from identical source.
+      - name: Install Solana CLI v3.1.15 (provides cargo-build-sbf)
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.15/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
 
       - name: Build stake BPF program
@@ -106,6 +111,13 @@ jobs:
           done
           [ "$missing" -eq 0 ] || exit 1
           ls -l "$stake_so" "$wrapper_so"
+          # The deployed devnet wrapper DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj
+          # is sha256 f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802
+          # over its 1243192 content bytes. Logged, not asserted: a legitimate
+          # wrapper redeploy should not break this repo's CI. If these differ, the
+          # e2e suites are exercising a wrapper that is not the one on devnet.
+          echo "wrapper sha256: $(sha256sum "$wrapper_so" | cut -d' ' -f1)"
+          echo "deployed      : f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802"
 
       - name: Test
         working-directory: percolator-stake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,17 @@ jobs:
           # this workflow's business.
           rustflags: ""
 
-      # Pinned, not "stable": cargo-build-sbf bundles its own platform-tools
-      # rustc, so the CLI version determines the emitted bytes. v3.1.15
-      # (platform-tools v1.52) is what reproduces the deployed wrapper exactly;
-      # "stable" drifted and produced a 1206296-byte binary instead of 1243192
-      # from identical source.
-      - name: Install Solana CLI v3.1.15 (provides cargo-build-sbf)
+      # NOTE on reproducibility: cargo-build-sbf bundles its own platform-tools
+      # rustc, so the CLI version determines the emitted bytes. "stable" here
+      # produces a 1206296-byte wrapper, while the DEPLOYED one is 1243192 (built
+      # with CLI 3.1.15 / platform-tools v1.52). Pinning would close that gap, but
+      # release.anza.xyz has no v3.1.15 installer (404; v3.1.14 is the nearest
+      # published one), so this stays on stable. What matters for these suites is
+      # already correct: same source ref (percolator-prog main) and same feature
+      # set (--features devnet). The sha is logged below so drift is visible.
+      - name: Install Solana CLI (provides cargo-build-sbf)
         run: |
-          sh -c "$(curl -sSfL https://release.anza.xyz/v3.1.15/install)"
+          sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
 
       - name: Build stake BPF program
@@ -113,9 +116,10 @@ jobs:
           ls -l "$stake_so" "$wrapper_so"
           # The deployed devnet wrapper DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj
           # is sha256 f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802
-          # over its 1243192 content bytes. Logged, not asserted: a legitimate
-          # wrapper redeploy should not break this repo's CI. If these differ, the
-          # e2e suites are exercising a wrapper that is not the one on devnet.
+          # over its 1243192 content bytes, from percolator-prog@main built with
+          # --features devnet under CLI 3.1.15. The CI build uses the same source
+          # and features but a newer platform-tools, so expect a DIFFERENT hash
+          # here — see the install step. Logged for visibility, not asserted.
           echo "wrapper sha256: $(sha256sum "$wrapper_so" | cut -d' ' -f1)"
           echo "deployed      : f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,14 @@ jobs:
         with:
           repository: dcccrypto/percolator-prog
           path: percolator-prog
-          # Pinned: the deployed devnet wrapper was built from this branch
-          # (19d5d932). TODO move to main once it lands there.
-          ref: feat/protocol-fee-taker-only
+          # main IS the deployed devnet wrapper. Verified byte-for-byte:
+          # percolator-prog@19d5d932 built with `cargo build-sbf -- --features devnet`
+          # reproduces DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj exactly
+          # (sha256 f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802
+          # over the 1243192 content bytes; on-chain is that plus 7040 bytes of
+          # zero padding). NOT feat/protocol-fee-taker-only — that remote branch is
+          # stale, 3 commits BEHIND main, so pinning it tested an older wrapper.
+          ref: main
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       # percolator-prog has a path dependency on the engine
@@ -47,9 +52,10 @@ jobs:
         with:
           repository: dcccrypto/percolator
           path: percolator
-          # Pinned for the same reason, and because dcccrypto/percolator@main
-          # does not currently compile under the wrapper's build settings
-          # ("error: variable does not need to be mutable", v16.rs:8871).
+          # The engine is the opposite case: its main (d448e1c9) has DIVERGED from
+          # what is deployed (3 behind / 15 ahead), and f53be74a on this branch is
+          # the engine revision that reproduces the deployed wrapper byte-for-byte.
+          # Keep this pinned until the engine's main carries the deployed lineage.
           ref: feat/protocol-fee-taker-only
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
@@ -77,7 +83,14 @@ jobs:
 
       - name: Build wrapper BPF program
         working-directory: percolator-prog
-        run: cargo build-sbf
+        # --features devnet is what the DEPLOYED wrapper was built with: it
+        # compiles the devnet percolator-stake program id into
+        # constants::STAKE_PROGRAM_ID, which tag 87
+        # (WithdrawInsuranceReserveToStake) pins its stake-pool owner check and
+        # PDA derivations to — precisely the path these e2e suites exercise.
+        # Without it the binary is 1237568 bytes instead of the deployed
+        # 1243192, i.e. a different program than the one on devnet.
+        run: cargo build-sbf -- --features devnet
 
       # Guard: `common_svm_setup()` in the e2e suites returns None and the test
       # passes VACUOUSLY when either .so is missing — 23 tests across 7 suites


### PR DESCRIPTION
Two corrections to the sibling checkouts added in #281, both found by verifying against devnet rather than assuming.

## 1. The wrapper pin was stale

`percolator-prog` was pinned to `feat/protocol-fee-taker-only`. That remote branch is **3 commits behind `main`** and an ancestor of it — so CI was building an *older* wrapper than the deployed one. `main` is the correct ref.

## 2. The wrapper was built without `--features devnet`

That produced **1237568 bytes** instead of the deployed **1243192**. The feature compiles the devnet `percolator-stake` program id into `constants::STAKE_PROGRAM_ID`, which tag 87 (`WithdrawInsuranceReserveToStake`) pins its stake-pool owner check and PDA derivations to — precisely the path these e2e suites exercise.

## Verification: `percolator-prog` `main` IS what is deployed

`percolator-prog@19d5d932` (= `main`) built with `cargo build-sbf -- --features devnet` reproduces `DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj` **byte-for-byte**:

| | |
|---|---|
| local build | 1243192 bytes |
| on-chain `Data Length` | 1250232 (= 1243192 + 7040 bytes zero padding) |
| sha256 over content bytes | `f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802` — **identical** |

## Known limitation: the CI-built wrapper is not byte-identical

`cargo-build-sbf` bundles its own platform-tools rustc, so the CLI version determines the emitted bytes. CI installs `stable`, which now ships newer platform-tools than the v1.52 (CLI 3.1.15) that built the deployed binary — so CI produces **1206296 bytes**, sha `9baa1a7f…`, from identical source.

I tried pinning to v3.1.15 and reverted it: `release.anza.xyz/v3.1.15/install` returns **404** (v3.1.14 is the nearest published installer), and the pin broke the toolchain install outright. Both hashes are now logged in every run so the gap is visible rather than silent.

What matters for these suites is correct either way: same source ref, same feature set.

## The engine pin stays, for the opposite reason

`dcccrypto/percolator@main` (`d448e1c9`) has **diverged** from the deployed lineage — 3 behind / 15 ahead — while `f53be74a` on `feat/protocol-fee-taker-only` is the engine revision that reproduces the deployed wrapper. It should move to `main` only once that branch carries the deployed lineage.

## Result

CI green, **437 pass / 0 fail**. Locally, the suite against the byte-identical deployed wrapper is also 437 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D