### PR TITLE
ci: point the engine checkout at main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,13 @@ jobs:
         with:
           repository: dcccrypto/percolator
           path: percolator
-          # The engine is the opposite case: its main (d448e1c9) has DIVERGED from
-          # what is deployed (3 behind / 15 ahead), and f53be74a on this branch is
-          # the engine revision that reproduces the deployed wrapper byte-for-byte.
-          # Keep this pinned until the engine's main carries the deployed lineage.
-          ref: feat/protocol-fee-taker-only
+          # Now tracks main. The engine's main HAD diverged from the deployed
+          # lineage (d448e1c9: 3 commits one way, 15 the other), which is why this
+          # was pinned to a feature branch. dcccrypto/percolator@b5ddba2e merged the
+          # deployed lineage back in, so f53be74a is an ancestor of main and main's
+          # src/ is byte-identical to it — the wrapper built from main still
+          # reproduces the deployed DhSkE7u exactly.
+          ref: main
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1


### PR DESCRIPTION
Follow-up to the engine reconciliation in `dcccrypto/percolator@b5ddba2e`.

## Why the engine was pinned to a feature branch

`dcccrypto/percolator@main` had **diverged** from the engine revision the deployed wrapper was built against — `d448e1c9`, 3 commits one way and 15 the other. Pinning `feat/protocol-fee-taker-only` was the only way to test against what is actually running.

## What changed upstream

`percolator@b5ddba2e` merged the deployed lineage into `main`:

- brings in the **14 substantive commits** main was missing — the E1–E6 upstream ports, the taker-only trade fee work with the insurance-surplus withdraw primitive and its `capital==0` evasion fix, and the bankruptcy-hlock auto-clear
- **keeps** main's 2 unique commits (the #117 asymmetric-A accrual proof and the LIEN-1 terminal-release proof) — both test-only, not compiled into the program
- the conflicted files (`src/v16.rs`, `tests/lp_burn_repro.rs`) were taken from the deployed side. Both branches carried the same *"stop settlement destroying an account's positive PnL"* fix applied twice; the **code is identical** on both sides, only the comment length differed. Taking the deployed side keeps the byte-identity property, since a longer comment would shift panic-location line numbers.

Result: `f53be74a` is now an ancestor of `main`, and main's `src/`, `Cargo.toml` and `Cargo.lock` are **identical** to it.

## Verification

| check | result |
|---|---|
| wrapper from `percolator-prog@main` + engine `main` | sha256 `f9056571a2dedfca…` — **byte-identical to deployed `DhSkE7u`** |
| engine suite on merged main | **161 pass / 0 fail** (was 133 before the merge) |
| stake suite against merged engine | **437 pass / 0 fail** |

## Effect here

Both sibling checkouts now track `main`, so CI stops depending on feature branches that can go stale underneath it — which is exactly what bit us with `percolator-prog`'s, where the pinned branch was 3 commits *behind* main and CI was silently building an older wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to use the deployed engine lineage.
  * Improved workflow comments to clarify the configuration used to reproduce the deployed wrapper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->