### PR TITLE
fix(#252,#254,#255,#271): RecoverFlushedInsurance fail-fast, timelock error hints, dead-field docs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -122,6 +122,9 @@ pub fn error_hint(code: u32) -> &'static str {
         22 => "Zero shares minted — deposit amount too small to mint any LP at the current share price; increase the amount",
         23 => "No pending admin — there is no admin transfer to accept (propose one first, or it was cancelled)",
         24 => "Insurance loss outstanding — total_flushed > total_returned. Junior tranche deposits are paused, and AdminResolveMarket/SetMarketResolved are blocked until RecoverFlushedInsurance fully returns the flushed insurance (resolving first would strand it — recovery requires LIVE mode)",
+        25 => "Cooldown increase requires a timelock — raising the cooldown is not immediate; propose it first, then apply it once the timelock has elapsed (#242)",
+        26 => "Timelock not elapsed — the proposed cooldown increase is not yet applicable; wait for the timelock window to pass (#242)",
+        27 => "No pending cooldown proposal — there is no proposed cooldown increase to apply; propose one first, or it was cancelled (#242)",
         28 => "Deposit below minimum liquidity — the pool's first-ever deposit must exceed MINIMUM_LIQUIDITY so a permanent dead-share floor can be locked (N7 anti-inflation hardening); deposit a larger amount",
         _ => "Unknown error — check the error code and pool state",
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -2581,9 +2581,14 @@ fn accrue_fees_inner(pool: &mut state::StakePool, current_balance: u64) -> Progr
 /// Accrue trading fees from the percolator engine to the LP vault.
 /// Permissionless: reads vault token account balance and updates pool state.
 ///
-/// Fee delta = current_vault_balance - last_vault_snapshot - net_deposits_since_last
-/// To keep it simple and trustless: we track the vault token account balance directly.
-/// Any increase in vault balance beyond deposits is fee revenue.
+/// #255: this previously documented a snapshot-delta formula
+/// (`current_vault_balance - last_vault_snapshot - net_deposits_since_last`) that is
+/// NOT what this function implements. The accrual baseline is `total_pool_value()`,
+/// not `last_vault_snapshot`. `last_vault_snapshot` is still WRITTEN below, but no
+/// accounting path reads it; it is retained only because removing it would change
+/// `STAKE_POOL_LEN` and break the v4/408 layout. Treat it as reserved, not as state.
+///
+/// Actual behaviour: fee revenue is whatever the vault holds above `total_pool_value()`.
 fn process_accrue_fees(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     let accounts_iter = &mut accounts.iter();
     let caller = next_account_info(accounts_iter)?; // signer, permissionless
@@ -3385,6 +3390,17 @@ fn process_recover_flushed_insurance(
         return Err(StakeError::InvalidAccount.into());
     }
     validate_pool_version(pool)?;
+
+    // #254 / #271: fail fast if the wrapper market handed in is not THIS pool's
+    // slab. `process_flush_to_insurance` already checks the analogous
+    // `pool.slab != slab.key` (:1550); this path passed `market` straight through
+    // to the tag-57 WithdrawInsuranceAsset CPI without it. Exploitation is blocked
+    // by the wrapper (tag 57 checks the stake-pool owner), so this is
+    // defence-in-depth — but relying on the callee for a caller-side invariant is
+    // exactly the coupling the rest of this file avoids.
+    if pool.slab != market.key.to_bytes() {
+        return Err(StakeError::InvalidPda.into());
+    }
 
     // Insurance LP pools only (pool_mode == 0). Mirror FlushToInsurance and ReturnInsurance.
     if pool.pool_mode != 0 {

--- a/src/state.rs
+++ b/src/state.rs
@@ -105,8 +105,10 @@ pub struct StakePool {
     /// Reserved for future slot-based rate limiting if needed.
     pub last_fee_accrual_slot: u64,
 
-    /// Snapshot of engine vault balance at last fee accrual
-    /// (used to compute fee delta = new_vault - old_vault - deposits + withdrawals)
+    /// DEAD (#255). Written by `process_accrue_fees`, read by NO accounting path.
+    /// The delta formula this comment used to describe was never implemented — the
+    /// accrual baseline is `total_pool_value()`. Kept solely to preserve the v4/408
+    /// layout (`STAKE_POOL_LEN`); do not build new logic on it.
     pub last_vault_snapshot: u64,
 
     /// Pool mode: 0 = insurance LP (legacy), 1 = trading LP vault (PERC-272)


### PR DESCRIPTION
Fixes #252. Fixes #254. Fixes #255. Addresses the first half of #271.

## #254 / #271 — `RecoverFlushedInsurance` fail-fast on `market != pool.slab`
`process_recover_flushed_insurance` passed the wrapper `market` account straight into the tag-57 `WithdrawInsuranceAsset` CPI with **no stake-side check**, unlike its sibling `process_flush_to_insurance`, which checks the analogous `pool.slab != slab.key` at `:1550`.

Exploitation was already blocked by the wrapper (tag 57 checks the stake-pool owner), so this is defence-in-depth. But relying on the callee to enforce a caller-side invariant is exactly the coupling the rest of this file avoids. Uses the same `StakeError::InvalidPda` as the sibling.

#254 is a strict subset of #271 — this closes the shared half. #271's second item (release overflow-checks) is a build-profile decision and is **not** included here.

## #252 — `error_hint` arms for the #242 timelock codes
Codes 25/26/27 (`CooldownIncreaseRequiresTimelock`, `TimelockNotElapsed`, `NoPendingCooldownProposal`) fell through to `"Unknown error"` although the variants are fully defined — the match jumped 24 → 28. SDK/UX only, no on-chain behaviour.

## #255 — `last_vault_snapshot` documented as dead
Written at `:699` and `:2689`, read by **no** accounting path. The `AccrueFees` docstring described a snapshot-delta formula that was never implemented — the real baseline is `total_pool_value()`.

**Not removed.** Deleting the field would change `STAKE_POOL_LEN` and break the **v4/408** layout deployed at `d0c6ecb`. Marked dead at the declaration; docstring corrected to describe actual behaviour.

## Test status — one pre-existing failure, not from this change
`task13_cpi_proxies_e2e::tag69_restart_asset_oracle_is_not_proxyable_after_asset_admin_burn` fails **identically on unmodified `d0c6ecb`**. Verified by reverting this branch's changes and re-running.

Root cause identified: its PRE-BURN CONTROL asserts

> the asset_admin bypass must let admin rotate an authority it does not itself hold

which is precisely the hole **#437/#439 deliberately closed** when the bypass was inverted from an allow-list of KINDS to an allow-list of STATES ("permitted only for a state in which there IS NO HOLDER TO DEFEND"). The wrapper's own `v16_wrapper_update_asset_authority_rejects_after_resolve_...` sits in its known-failing 21 for the same reason.

I left it as-is rather than rewriting a parked security assertion to match current behaviour — that would mask the very thing the test exists to catch. It needs a deliberate test update, tracked separately.

Suite: **444 passed, 1 failed** (that one).

⚠️ On-chain program source — **not deployed**. Needs explicit human go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer guidance for cooldown operations that require a timelock, have not yet elapsed, or lack a pending proposal.
  * Added validation to prevent insurance recovery from using an incorrect market account.
* **Documentation**
  * Clarified fee accrual behavior and documented the retained status of a legacy vault snapshot field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->