### PR TITLE
fix(#286): pin stake CI to the deployed wrapper+engine, and correct a stale proxy test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,34 +31,64 @@ jobs:
       # `percolator-prog/target/deploy/percolator_prog.so`. Both are gitignored
       # build artifacts, so they must be built here or those suites do not
       # exercise the on-chain code at all.
+      # #286: this used to be `ref: main` for BOTH siblings, and that is what made
+      # this trunk go red on 2026-09-02 without anyone changing percolator-stake.
+      # The wrapper is, from this repo's point of view, a SEPARATE DEPLOYED PROGRAM
+      # that keeps running its deployed build after we merge to its main — so these
+      # suites must test the bytes that are actually on chain, exactly as
+      # percolator-prog's own ci.yml pins ITS siblings and for the same stated
+      # reason. Tracking main meant an unreleased wrapper change landed here
+      # instantly, as a silent red trunk rather than a deliberate decision.
+      #
+      # Pinned to WRAPPER_DEPLOYED from percolator-prog/ci/deployed-refs.env, which
+      # is the canonical record of what is on chain. The guard step below re-reads
+      # that file from prog's CURRENT main and fails if this pin has fallen behind,
+      # so a deploy cannot quietly leave these suites testing stale bytes.
+      #
+      # Verified byte-for-byte: percolator-prog@19d5d932 built with
+      # `cargo build-sbf -- --features devnet` reproduces
+      # DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj exactly (sha256
+      # f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802 over the
+      # 1243192 content bytes; on-chain is that plus 7040 bytes of zero padding).
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: dcccrypto/percolator-prog
           path: percolator-prog
-          # main IS the deployed devnet wrapper. Verified byte-for-byte:
-          # percolator-prog@19d5d932 built with `cargo build-sbf -- --features devnet`
-          # reproduces DhSkE7uTb8HBUYYWF1xkxMYBGtLYJEoDq1tfBD7SnHcj exactly
-          # (sha256 f9056571a2dedfca2ac40235d6d7e85d30bcf10d24c161074d268be1d6cdc802
-          # over the 1243192 content bytes; on-chain is that plus 7040 bytes of
-          # zero padding). NOT feat/protocol-fee-taker-only — that remote branch is
-          # stale, 3 commits BEHIND main, so pinning it tested an older wrapper.
+          ref: 15eb8b0c599e35a1c224bfa74f92b810c78fefb7
+          token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
+
+      # A second, shallow checkout of prog's CURRENT main, used ONLY to read
+      # ci/deployed-refs.env for the drift guard below. Not built, not tested.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: dcccrypto/percolator-prog
+          path: percolator-prog-refs
           ref: main
+          fetch-depth: 1
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       # percolator-prog has a path dependency on the engine
       # (`percolator = { path = "../percolator" }`), so the wrapper cannot build
       # without it checked out as a sibling.
+      # #286: also pinned, and for a subtler reason than the wrapper. The engine is
+      # a PATH DEPENDENCY compiled INTO the wrapper, so "wrapper 15eb8b0c" is only
+      # a complete description of the deployed bytes together with the engine
+      # commit it was built against. Leaving this on main while pinning the wrapper
+      # would still let engine merges change what these suites run.
+      #
+      # That is not hypothetical: the #286 bisect showed engine-main alone passed
+      # and wrapper-main alone passed, but the two TOGETHER failed. An unpinned
+      # engine reintroduces exactly that interaction.
+      #
+      # f53be74a is the deployed lineage and is an ancestor of main
+      # (dcccrypto/percolator@b5ddba2e merged it back), so this is a subset of main
+      # rather than a fork, and the wrapper built from it reproduces the deployed
+      # DhSkE7u.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: dcccrypto/percolator
           path: percolator
-          # Now tracks main. The engine's main HAD diverged from the deployed
-          # lineage (d448e1c9: 3 commits one way, 15 the other), which is why this
-          # was pinned to a feature branch. dcccrypto/percolator@b5ddba2e merged the
-          # deployed lineage back in, so f53be74a is an ancestor of main and main's
-          # src/ is byte-identical to it — the wrapper built from main still
-          # reproduces the deployed DhSkE7u exactly.
-          ref: main
+          ref: f53be74a
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1
@@ -86,6 +116,42 @@ jobs:
         run: |
           sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
           echo "$HOME/.local/share/solana/install/active_release/bin" >> "$GITHUB_PATH"
+
+      # #286 DRIFT GUARD. Pinning is only safe if the pin is noticed when it goes
+      # stale. percolator-prog/ci/deployed-refs.env is the canonical record of what
+      # is on chain, so compare our pin against prog's CURRENT main copy of it.
+      #
+      #   pin == WRAPPER_DEPLOYED  -> these suites are testing the deployed bytes.
+      #   pin != WRAPPER_DEPLOYED  -> a deploy happened and this pin was not moved.
+      #                               FAIL, loudly, with the value to move it to.
+      #
+      # This is the half that was missing before. The old `ref: main` never went
+      # stale, it just silently tested something else; a bare pin would never go
+      # red, it would just silently test something old. Neither is a signal.
+      - name: Assert the wrapper pin still matches WRAPPER_DEPLOYED
+        run: |
+          refs=percolator-prog-refs/ci/deployed-refs.env
+          if [ ! -f "$refs" ]; then
+            echo "::error::$refs missing — cannot verify the wrapper pin is current"
+            exit 1
+          fi
+          want=$(grep -E '^WRAPPER_DEPLOYED=' "$refs" | cut -d= -f2)
+          have=$(git -C percolator-prog rev-parse HEAD)
+          echo "pinned wrapper : $have"
+          echo "WRAPPER_DEPLOYED: $want"
+          if [ -z "$want" ]; then
+            echo "::error::WRAPPER_DEPLOYED not found in $refs"
+            exit 1
+          fi
+          if [ "$have" != "$want" ]; then
+            echo "::error::wrapper pin is STALE. percolator-prog/ci/deployed-refs.env"
+            echo "::error::now says WRAPPER_DEPLOYED=$want but this workflow pins $have."
+            echo "::error::A wrapper deploy has happened. Update the ref: in this file to"
+            echo "::error::$want and re-run, reviewing any newly failing proxy tests as a"
+            echo "::error::REAL wrapper/stake incompatibility (see issue #286)."
+            exit 1
+          fi
+          echo "wrapper pin is current"
 
       - name: Build stake BPF program
         working-directory: percolator-stake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
         with:
           repository: dcccrypto/percolator
           path: percolator
-          ref: f53be74a
+          # FULL 40-char SHA: actions/checkout resolves `ref` with `git fetch origin
+          # <ref>`, and an abbreviated SHA is not a valid fetch refspec. percolator-prog's
+          # ci.yml records that this exact mistake kept its CI from ever going green.
+          ref: f53be74aafcf5beda06890ffe3c4392637fe54bb
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1

--- a/tests/task13_cpi_proxies_e2e.rs
+++ b/tests/task13_cpi_proxies_e2e.rs
@@ -1331,12 +1331,33 @@ fn proxy_rejects_a_slab_that_is_not_the_pools_own_market() {
 ///     rejected, since vault_auth != asset_admin);
 ///   * post-burn, `asset_admin == [0;32]` — nothing can satisfy the gate.
 ///
-/// This test demonstrates the second half behaviourally. After the real
-/// InitPool + Bind + Burn sequence it shows that an `asset_admin`-gated wrapper
-/// instruction (tag 65, which shares exactly the same
-/// `expect_live_authority(asset_admin, ...)` gate as tag 69) is rejected for the
-/// admin — i.e. the authority is genuinely dead rather than merely moved. A
-/// proxy signing as `vault_auth` would hit the identical zero-authority check.
+/// This test demonstrates BOTH halves behaviourally, after the real
+/// InitPool + Bind + Burn sequence, using tag 65 — which shares exactly the same
+/// `expect_live_authority(asset_admin, ...)` gate as tag 69.
+///
+/// UPDATED for wrapper #416/#417 + #437/#439, both of which are in the DEPLOYED
+/// wrapper. `handle_update_asset_authority` used to let a live `asset_admin`
+/// rotate ANY of the asset's authorities, and this test's pre-burn step was a
+/// CONTROL that relied on exactly that bypass succeeding. The guard is now an
+/// allow-list of STATES rather than of kinds:
+///
+///     admin_bypass_permitted = admin_signed
+///         && (current_value == [0u8; 32] || <unsignable LP-registry PDA>)
+///
+/// so the bypass survives only where there is no holder to defend. The old
+/// control therefore asserts behaviour the wrapper deliberately removed, and it
+/// broke percolator-stake CI when that change reached `main`.
+///
+/// Rather than delete the control — which would leave both rejections
+/// indistinguishable from a malformed instruction — the test now:
+///   1. keeps a POSITIVE CONTROL, the current holder self-rotating, so the call
+///      path is proven live;
+///   2. asserts the pre-burn rejection EXPLICITLY, pinning the inversion; and
+///   3. keeps the post-burn rejection, which since #437/#439 is a second
+///      independent reason rather than the cause.
+///
+/// Net effect: this pins strictly more behaviour than before, and no longer
+/// depends on a bypass that no longer exists.
 ///
 /// Restoring tag 69 after a burn requires a WRAPPER change, which is out of
 /// scope for this task. If that ever lands, add the proxy and delete this test.
@@ -1363,12 +1384,16 @@ fn tag69_restart_asset_oracle_is_not_proxyable_after_asset_admin_burn() {
     );
     run_bind_insurance_authority(&mut e.svm, e.wrapper_id, e.stake_id, &e.admin, &e.payer, &s);
 
-    // PRE-BURN CONTROL: `BindInsuranceAuthority` has already moved
-    // insurance_operator to vault_auth, so admin is NOT the current holder of
-    // that authority. This call can only succeed via the asset_admin bypass
-    // (`admin_signed` in handle_update_asset_authority, which lets asset_admin
-    // rotate ANY of the asset's authorities). It succeeding is therefore direct
-    // evidence that asset_admin is live and equals admin.
+    // POSITIVE CONTROL: prove this instruction, these accounts and this signer
+    // actually work, by having the CURRENT HOLDER self-rotate. `oracle_authority`
+    // is still admin's after InitPool + bind, so this goes through
+    // `expect_live_authority` on the ordinary holder-consent path and never
+    // touches the asset_admin bypass.
+    //
+    // Without this the two rejections below would be indistinguishable from a
+    // malformed instruction that could never have succeeded — which is precisely
+    // how the old PRE-BURN CONTROL earned its keep, and why replacing it with
+    // nothing was not an option.
     send(
         &mut e.svm,
         &e.payer,
@@ -1376,19 +1401,52 @@ fn tag69_restart_asset_oracle_is_not_proxyable_after_asset_admin_burn() {
         direct_update_asset_authority_ix(
             e.wrapper_id,
             e.admin.pubkey(),
-            e.admin.pubkey(), // rotate insurance_operator back to admin
+            e.admin.pubkey(), // self-rotate oracle_authority: holder consents
             market,
-            2, // kind = insurance_operator
+            4, // kind = oracle_authority, still held by admin
         ),
     )
     .expect(
-        "PRE-BURN CONTROL: while asset_admin == admin, the asset_admin bypass must \
-         let admin rotate an authority it does not itself hold",
+        "POSITIVE CONTROL: the current holder must be able to self-rotate — if this \
+         fails the rejections below prove nothing about asset_admin",
     );
 
-    // `insurance_authority` (kind 1) is still vault_auth and admin does not hold
-    // it, so the post-burn attempt below targets THAT — it can only ever succeed
-    // through the same asset_admin bypass the control call just used.
+    // PRE-BURN: asset_admin is LIVE and equals admin, and it still cannot rotate an
+    // authority someone else holds.
+    //
+    // This assertion is the inverse of what this test asserted before wrapper
+    // #416/#417 and #437/#439. `handle_update_asset_authority` used to let
+    // asset_admin rotate ANY of the asset's authorities; the guard is now an
+    // allow-list of STATES rather than of kinds —
+    //
+    //     admin_bypass_permitted = admin_signed
+    //         && (current_value == [0u8; 32] || <unsignable LP-registry PDA>)
+    //
+    // — so the bypass survives only where there is NO HOLDER TO DEFEND. The
+    // wrapper's own note: "The insurance legs have already paid that price since
+    // #416/#417; this makes it uniform across all five kinds."
+    //
+    // `BindInsuranceAuthority` has moved insurance_operator to vault_auth, so it IS
+    // held, and admin is refused despite being asset_admin.
+    send(
+        &mut e.svm,
+        &e.payer,
+        &[&e.admin],
+        direct_update_asset_authority_ix(
+            e.wrapper_id,
+            e.admin.pubkey(),
+            e.admin.pubkey(),
+            market,
+            2, // kind = insurance_operator, held by vault_auth
+        ),
+    )
+    .expect_err(
+        "PRE-BURN: asset_admin must NOT be able to seize a HELD authority — this is \
+         the #416/#417 + #437/#439 inversion, and it is in the DEPLOYED wrapper",
+    );
+
+    // `insurance_authority` (kind 1) is also still vault_auth and admin does not
+    // hold it, so the post-burn attempt below targets THAT.
 
     // Burn asset_admin to [0;32] via the real stake instruction (tag 21).
     let burn_ix = Instruction {
@@ -1404,10 +1462,20 @@ fn tag69_restart_asset_oracle_is_not_proxyable_after_asset_admin_burn() {
     };
     send(&mut e.svm, &e.payer, &[&e.admin], burn_ix).expect("BurnAssetAdmin must succeed");
 
-    // POST-BURN: the same asset_admin-gated call is now rejected. asset_admin is
-    // [0;32] and `live_authority_matches` refuses a zero authority for EVERY
-    // signer — a vault_auth-signed CPI included. This is why no tag-69 proxy is
-    // shipped: there is no signer it could present that would pass.
+    // POST-BURN: still rejected, now for a SECOND independent reason. asset_admin
+    // is [0;32], so `admin_signed` is false outright, and `live_authority_matches`
+    // refuses a zero authority for every signer — a vault_auth-signed CPI included.
+    //
+    // Note honestly what this does and does not show. Since #437/#439 the burn is
+    // no longer what makes this call fail: the PRE-BURN assertion above proves it
+    // already failed while asset_admin was live. The burn removes the remaining
+    // path rather than the only one. That is why the pre-burn case is now asserted
+    // explicitly instead of being left as a control — otherwise this rejection
+    // would look like it was caused by the burn, and it is not.
+    //
+    // The conclusion the test exists for is unchanged and is now established by
+    // both halves together: there is no signer a tag-69 proxy could present that
+    // would pass, which is why none is shipped.
     let err = send(
         &mut e.svm,
         &e.payer,


### PR DESCRIPTION
Fixes the red trunk described in #286. `main` has failed CI since **2026-09-02** without anyone touching this repo.

## Root cause

This workflow checked out **both** `percolator-prog` and `percolator` at `ref: main`, so every wrapper and engine merge landed here instantly. An **unreleased** wrapper change turned this trunk red as a silent side effect.

Bisected by reproducing the 2026-08-17 green locally and varying one component at a time — every build using this workflow's own `cargo build-sbf -- --features devnet` (**the `--` matters**; without it the binary differs and the results are noise):

| engine | wrapper | stake | result |
|---|---|---|---|
| aug17 | aug17 | `d0c6ecb` | 8 pass |
| **today** | aug17 | `d0c6ecb` | 8 pass |
| aug17 | **today** | `d0c6ecb` | 8 pass |
| **today** | **today** | `d0c6ecb` | **2 FAIL** |
| **today** | **today** | `5beb91a` | **2 FAIL** |

Neither component alone reproduces it; both together do, and stake's own commit is irrelevant.

## Two causes, needing opposite treatment

**1. `tag55` → prog #455** ("gate UpdateTradeFeePolicy on marketauth"). Holding the engine at main: wrapper `8ce121ce` → 1 failure, `0cc58c7c` → 2. Stake's tag-28 proxy signs as `vault_auth`, which no longer satisfies that gate.

**This is a real incompatibility and is deliberately NOT fixed here.** #455 isn't deployed (`WRAPPER_DEPLOYED` is still `15eb8b0c`), so pinning makes it surface at the next wrapper deploy as a **deliberate decision** rather than as a permanent red trunk. **#286 stays open for it.**

**2. `tag69` → prog `d83e0a27` (#416/#417), which IS deployed.** `93d4d854` → pass, `d83e0a27` → fail, engine held constant, distinct `.so` sizes proving real rebuilds. That commit deliberately removed the `asset_admin` bypass, and the test's PRE-BURN CONTROL depended on that bypass **succeeding**. The test asserted behaviour the wrapper intentionally ended. Fixed in the test.

## Why the test change is not a weakening

The naive repair — flip the control to expect failure — makes the test **vacuous**. Since #437/#439 the bypass requires `current_value == 0`, so the post-burn call fails with or without the burn, and the test would pass while proving nothing.

Instead:

- a **positive control** is added (the current holder self-rotating `oracle_authority`) so the call path is proven live and the rejections can't be confused with a malformed instruction — which is what the old control was really for;
- the **pre-burn rejection is asserted explicitly**, pinning the #416/#417 + #437/#439 inversion;
- the post-burn rejection is kept, documented as a *second independent reason* rather than the cause.

Net: this pins strictly more behaviour than before.

## Pinning, with a guard

The wrapper is a separate deployed program from this repo's point of view, so these suites must run the bytes that are on chain — the same rule `percolator-prog`'s own `ci.yml` applies to its siblings, for the same stated reason.

The **engine is pinned too**: it's a path dependency compiled *into* the wrapper, so pinning only the wrapper would still let engine merges change what runs here — which the bisect shows is exactly the interaction that broke it.

A bare pin has the opposite failure mode: it never goes red, it just quietly tests something old. So a **drift guard** re-reads `WRAPPER_DEPLOYED` from prog's *current* main and fails, naming the value to move to, if this pin falls behind. Verified both ways — matching pin passes, stale pin fails.

## Verified

Full stake suite at the pinned stack: **445 passed, 0 failed**.

It read 434 with the wrapper `.so` missing — 11 e2e tests skip **vacuously** in that state. That's why the existing artifact assertion matters, and why the number moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D
