### PR TITLE
fix(#286): tag 28 signs as the pool PDA (marketauth), matching wrapper #455

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -3886,9 +3886,32 @@ fn process_admin_update_backing_fee_policy(
     Ok(())
 }
 
-// ── 28: AdminUpdateTradeFeePolicy -> wrapper tag 55 (insurance_authority) ──
+// ── 28: AdminUpdateTradeFeePolicy -> wrapper tag 55 (MARKETAUTH, pool PDA signs) ──
 //
-// Accounts: identical to tag 27 above.
+// GH#286: wrapper #455 ("gate UpdateTradeFeePolicy on marketauth, like every other
+// market-wide setter") changed tag 55 to require `cfg.marketauth`. This proxy signed
+// as `vault_auth`, which is the per-asset insurance authority — so after #455 every
+// call returned Unauthorized (Custom(8)), and percolator-stake's CI went red without
+// anyone touching this repo.
+//
+// #455 is right: the trade fee is a market-wide policy, so it belongs behind
+// marketauth. `InitPool` irreversibly rotates `cfg.marketauth` to THIS pool's PDA,
+// so the pool PDA is the marketauth and is the correct signer. That makes tag 28 a
+// GROUP A proxy (marketauth-gated, pool PDA signs) rather than Group B, joining
+// tags 25 and 26.
+//
+// THE ACCOUNT LAYOUT IS DELIBERATELY UNCHANGED — still five accounts, with
+// `vault_auth` at index 2. Dropping it would be an ABI break on a deployed program
+// for no functional gain, and every existing caller and test already passes it. It
+// is still PDA-validated below, so a caller cannot substitute an arbitrary account
+// there; it simply no longer signs.
+//
+// Accounts:
+//   0. `[signer]`   Admin (must equal pool.admin)
+//   1. `[]`         Pool PDA — the marketauth; SIGNS the CPI via invoke_signed
+//   2. `[]`         Vault authority PDA — validated, no longer signs (see above)
+//   3. `[writable]` Slab / market account (wrapper-owned)
+//   4. `[]`         Percolator program
 fn process_admin_update_trade_fee_policy(
     program_id: &Pubkey,
     accounts: &[AccountInfo],
@@ -3901,25 +3924,30 @@ fn process_admin_update_trade_fee_policy(
     let slab = next_account_info(accounts_iter)?;
     let percolator_program = next_account_info(accounts_iter)?;
 
-    let vault_auth_bump = validate_group_b_proxy(
-        program_id,
-        admin,
-        pool_pda,
-        vault_auth,
-        slab,
-        percolator_program,
-    )?;
+    // Group A checks (admin is pool.admin, pool initialised, slab matches) and the
+    // POOL bump, which is what signs now.
+    let pool_bump = validate_group_a_proxy(program_id, admin, pool_pda, slab, percolator_program)?;
 
-    let vault_auth_seeds: &[&[u8]] = &[b"vault_auth", pool_pda.key.as_ref(), &[vault_auth_bump]];
+    // Keep validating account 2 even though it no longer signs: the layout still
+    // carries it, and an unvalidated account slot is an invitation.
+    let (expected_vault_auth, _vault_auth_bump) =
+        state::derive_vault_authority(program_id, pool_pda.key);
+    if *vault_auth.key != expected_vault_auth {
+        return Err(StakeError::InvalidPda.into());
+    }
+
+    let pool_seeds: &[&[u8]] = &[b"stake_pool", slab.key.as_ref(), &[pool_bump]];
     cpi::cpi_update_trade_fee_policy(
         percolator_program,
-        vault_auth,
+        pool_pda,
         slab,
         trade_fee_base_bps,
-        vault_auth_seeds,
+        pool_seeds,
     )?;
 
-    msg!("AdminUpdateTradeFeePolicy: wrapper trade fee policy updated via vault_auth PDA CPI");
+    msg!(
+        "AdminUpdateTradeFeePolicy: wrapper trade fee policy updated via pool PDA CPI (marketauth)"
+    );
     Ok(())
 }
 

--- a/tests/task13_cpi_proxies_e2e.rs
+++ b/tests/task13_cpi_proxies_e2e.rs
@@ -28,9 +28,15 @@
 //! before the rotation stop working after it, and only the proxy recovers them.
 //!
 //! GROUP A (marketauth-gated, POOL PDA signs): stake 25 -> wrapper 86,
-//! stake 26 -> wrapper 88.
+//! stake 26 -> wrapper 88, and — since GH#286 — stake 28 -> wrapper 55.
 //! GROUP B (insurance_authority-gated, VAULT_AUTH PDA signs): stake 27 ->
-//! wrapper 51, stake 28 -> wrapper 55.
+//! wrapper 51.
+//!
+//! Tag 28 MOVED from Group B to Group A. Wrapper #455 re-gated tag 55 on
+//! marketauth ("like every other market-wide setter"), and `InitPool` rotates
+//! marketauth to the pool PDA — so the pool PDA is now the correct signer and
+//! vault_auth is refused. See the note on `tag55_*` for why that test is
+//! ignored until the wrapper carrying #455 is deployed.
 //!
 //! Wrapper tag 51 is the setter for `backing_trade_fee_bps`. On a staked market
 //! nobody could set it, which is the mechanical root of the standing
@@ -973,8 +979,40 @@ fn tag51_backing_fee_direct_dies_after_bind_and_proxy_restores_it() {
     );
 }
 
-/// Group B, wrapper tag 55, via stake tag 28.
+/// Group A (was Group B), wrapper tag 55, via stake tag 28.
+///
+/// GH#286: IGNORED until percolator-prog is deployed at a commit containing #455.
+///
+/// This is not flakiness and not a weakened assertion — it is a genuine
+/// coordinated-deploy window, and the two sides are mutually exclusive:
+///
+///   wrapper 15eb8b0c (DEPLOYED, pre-#455)  tag 55 gates on the per-asset
+///                                          insurance authority -> vault_auth signs
+///   wrapper main      (post-#455)           tag 55 gates on marketauth
+///                                          -> the pool PDA signs
+///
+/// `cpi_update_trade_fee_policy` passes ONE authority account, so the proxy can
+/// present exactly one signer. There is no value that satisfies both wrappers.
+/// The proxy now signs as the pool PDA, which is correct for the wrapper we are
+/// shipping and wrong for the one currently on chain.
+///
+/// MEASURED, both ways, with fresh `cargo build-sbf -- --features devnet` builds:
+///   wrapper origin/main + engine main        8 passed, 0 failed
+///   wrapper 15eb8b0c   + engine f53be74a     7 passed, 1 failed (this test)
+///
+/// stake CI pins the wrapper to WRAPPER_DEPLOYED, so leaving this active would
+/// make the trunk red for a reason nobody can fix without a deploy — which is
+/// exactly the "permanently red gate nobody reads" failure this repo hit twice
+/// this week. Ignoring it with the removal condition stated in-source is the
+/// honest form.
+///
+/// TO REMOVE: when `ci/deployed-refs.env` in percolator-prog advances
+/// WRAPPER_DEPLOYED past #455 (0cc58c7c), the #287 drift guard fails and forces
+/// this file's pin to be bumped. Delete this attribute in the same commit.
 #[test]
+#[ignore = "GH#286: needs a wrapper deployed at/after #455; the deployed wrapper \
+            gates tag 55 on the per-asset authority, the new one on marketauth, \
+            and the proxy can only present one signer"]
 fn tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it() {
     let Some(mut e) = env() else { return };
 


### PR DESCRIPTION
Decision **A** on #286 — change stake to sign as the pool PDA, keeping #455's tightening.

## What was wrong

Wrapper #455 re-gated tag 55 `UpdateTradeFeePolicy` on `cfg.marketauth`, *"like every other market-wide setter"*. This proxy signed as `vault_auth` — the **per-asset insurance authority** — so after #455 every call returned `Unauthorized` (Custom(8)), and this repo's CI went red without anyone touching it.

#455 is right: the trade fee is market-wide policy and belongs behind marketauth. `InitPool` irreversibly rotates `cfg.marketauth` to this pool's PDA, so **the pool PDA is the marketauth** and is the correct signer. Tag 28 moves from Group B to Group A, joining tags 25 and 26.

**The account layout is unchanged** — still five accounts with `vault_auth` at index 2. Dropping it would be an ABI break on a deployed program for no functional gain, and every existing caller and test already passes it. It's still PDA-validated, so a caller can't substitute an arbitrary account there; it just no longer signs.

## This is a coordinated deploy, and the two sides are mutually exclusive

`cpi_update_trade_fee_policy` passes **one** authority account, so the proxy presents exactly one signer. No value satisfies both wrappers:

| wrapper | tag 55 gates on | signer needed |
|---|---|---|
| `15eb8b0c` — **deployed**, pre-#455 | per-asset insurance authority | `vault_auth` |
| `main` — post-#455 | `marketauth` | **pool PDA** |

I checked whether the proxy could sign as *both* — `invoke_signed` accepts multiple seed sets — and it can't help: the wrapper reads a single authority account and compares it to the one authority it gates on.

**Measured both ways**, with fresh `cargo build-sbf -- --features devnet` builds:

```
wrapper origin/main + engine main       8 passed, 0 failed
wrapper 15eb8b0c    + engine f53be74a   7 passed, 1 failed   (tag55 only)
```

So this fix is correct for the wrapper we're shipping and **wrong for the one currently on chain**. It must not be deployed before the wrapper carrying #455.

## Why `tag55_*` is ignored rather than left failing

This repo's CI pins the wrapper to `WRAPPER_DEPLOYED`, so leaving the test active makes the trunk red for something **nobody can fix without a deploy** — the "permanently red gate nobody reads" failure this repo hit twice this week.

The removal condition is written into the source, not left to memory: when percolator-prog advances `WRAPPER_DEPLOYED` past #455, the #287 drift guard fails and forces this file's pin to be bumped. Delete the attribute in that same commit.

## Verified

Full stake suite: **444 passed, 0 failed, 4 ignored** · `cargo fmt --check` clean.

**#286 stays open** until the coordinated deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated trade fee policy updates to authenticate with the pool authority required by the latest wrapper behavior.
  * Preserved existing account validation while ensuring the correct authority signs the operation.

* **Tests**
  * Updated trade fee policy proxy test documentation and metadata to reflect the revised authorization behavior.
  * Temporarily skipped an end-to-end test during the coordinated deployment transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->