### PR TITLE
harden(#271): enable release overflow-checks, and pin both guards with tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,20 @@ bytemuck = { version = "1.14", features = ["derive"] }
 # Pin blake3 to avoid edition2024 (SBF platform-tools has Rust 1.84)
 blake3 = ">=1.5.0, <1.8.0"
 
+# GH#271 item 2 — defence in depth ahead of external audit.
+#
+# Without this, integer overflow checks are OFF in the deployed SBF release binary
+# and a future unchecked add would silently WRAP rather than revert. Nothing relies
+# on wrapping today: every accounting path uses explicit checked_*/saturating_* or
+# i128 widening (total_pool_value, principal_tvl, the deposit/withdraw/flush/return
+# handlers, and the whole math module). This is here so that stays true by
+# construction rather than by review.
+#
+# CU cost is negligible for this program's arithmetic — it is a handful of
+# comparisons on paths that already do checked math.
+[profile.release]
+overflow-checks = true
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 

--- a/tests/hardening_271.rs
+++ b/tests/hardening_271.rs
@@ -1,0 +1,82 @@
+//! GH#271 — two pre-audit hardening items, and the guards that keep them true.
+//!
+//! Neither was an exploitable bug when filed; both are the kind of thing that stops
+//! being true quietly. These tests exist so removing either fails CI rather than
+//! waiting for an auditor to notice.
+
+use std::fs;
+use std::path::Path;
+
+fn manifest() -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+        .expect("Cargo.toml must be readable")
+}
+
+fn source() -> String {
+    fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/processor.rs"))
+        .expect("processor.rs must be readable")
+}
+
+/// Strip `#`-comments so a mention in prose cannot satisfy the assertion — the
+/// mistake that made an indexer migration test vacuous earlier this week.
+fn manifest_without_comments() -> String {
+    manifest()
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn release_profile_enables_overflow_checks() {
+    // Item 2. Without this the deployed SBF release binary WRAPS on integer
+    // overflow instead of reverting. Nothing relies on wrapping today — every
+    // accounting path uses checked_*/saturating_* or i128 widening — and this
+    // keeps that true by construction rather than by review.
+    let m = manifest_without_comments();
+    let profile = m
+        .split("[profile.release]")
+        .nth(1)
+        .expect("Cargo.toml must declare [profile.release]");
+    // Bound the search to the section, so a setting under some LATER table cannot
+    // satisfy it.
+    let section = profile.split("\n[").next().unwrap_or(profile);
+    assert!(
+        section
+            .lines()
+            .any(|l| l.split('#').next().unwrap_or("").replace(' ', "") == "overflow-checks=true"),
+        "[profile.release] must set overflow-checks = true; section was:{section}"
+    );
+}
+
+#[test]
+fn recover_flushed_insurance_binds_the_market_to_the_pool_slab() {
+    // Item 1. `process_flush_to_insurance` has always checked `pool.slab ==
+    // slab.key`; the recover path passed `market` straight through to the tag-57
+    // CPI. It was not exploitable — the vault_auth PDA is only that slab's
+    // insurance_operator, so the wrapper rejects a foreign market, and the CPI
+    // destination is hard-bound to pool.vault regardless — but relying on the far
+    // side of a CPI for a check this cheap is exactly what a wrapper change would
+    // silently invalidate.
+    let src = source();
+    let handler = src
+        .split("fn process_recover_flushed_insurance")
+        .nth(1)
+        .expect("the handler must exist");
+    // Scope to the handler, not the file: the same guard in FlushToInsurance would
+    // otherwise satisfy this and the test would prove nothing.
+    let body = handler.split("\nfn ").next().unwrap_or(handler);
+    assert!(
+        body.contains("pool.slab != market.key.to_bytes()"),
+        "process_recover_flushed_insurance must reject a market that is not this \
+         pool's slab, before the CPI"
+    );
+    let guard_at = body
+        .find("pool.slab != market.key.to_bytes()")
+        .expect("guard present");
+    let cpi_at = body.find("invoke_signed").unwrap_or(usize::MAX);
+    assert!(
+        guard_at < cpi_at,
+        "the slab guard must run BEFORE the CPI, not after it"
+    );
+}


### PR DESCRIPTION
Closes #271.

## Item 1 was already done — but untested

`process_recover_flushed_insurance` **already** carries the `pool.slab != market.key.to_bytes()` guard, with a `#254 / #271` comment. So the code half of item 1 needs nothing.

What it did not have is a test. A defence-in-depth guard with no coverage is one refactor away from being gone, and this one is specifically insurance against a *future wrapper change* — the scenario where nobody is looking at the stake side at all.

The test is scoped to that handler, not the file, because `process_flush_to_insurance` has an identical guard that would otherwise satisfy it and prove nothing. It also asserts the guard runs **before** the CPI, not merely that it exists somewhere in the function.

## Item 2 was genuinely open

`Cargo.toml` had no `[profile.release]`, so integer overflow checks were **off in the deployed SBF binary**. Nothing relies on wrapping today — every accounting path uses explicit `checked_*`/`saturating_*` or `i128` widening — so this changes no behaviour now. It makes that stay true by construction instead of by review.

CU cost is negligible: a handful of comparisons on paths already doing checked math.

## Test hygiene

The manifest assertion **strips `#`-comments before matching** and **bounds the search to the `[profile.release]` section**, so neither a mention in prose nor an `overflow-checks` under some later table can satisfy it. That precise mistake — a regex matching the phrase in the file's own comment — made an indexer migration test vacuous earlier this week.

## Verification

- Full suite green with overflow-checks enabled; SBF release binary builds.
- **Negative controls, independent:** flipping `overflow-checks` to `false` fails only the manifest test; deleting the slab guard fails only the handler test. Neither control disturbs the other, so the two assertions are testing two different things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgoNgagkvw7i5SSRC3FJ8D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Enabled integer overflow checks in deployed release builds to help detect arithmetic issues.
  - Added validation to ensure the expected market is associated with the pool before processing recovery actions.

- **Tests**
  - Added automated checks covering release-build overflow protection and market validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->