### PR TITLE
harden(#286): enforce tag-55 test re-enable at wrapper #455 boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,11 +194,29 @@ jobs:
           # Read the attributes attached to this exact test, including multi-line
           # attributes. Reset at function/source boundaries so an ignored neighboring
           # test cannot satisfy the check.
-          state=$(
+          detect_tag55_state() {
             awk '
               in_attr {
                 if ($0 ~ /\][[:space:]]*$/) {
                   in_attr = 0
+                }
+                next
+              }
+
+              in_block_comment {
+                if ($0 ~ /\*\//) {
+                  in_block_comment = 0
+                }
+                next
+              }
+
+              /^[[:space:]]*\/\// {
+                next
+              }
+
+              /^[[:space:]]*\/\*/ {
+                if ($0 !~ /\*\//) {
+                  in_block_comment = 1
                 }
                 next
               }
@@ -237,11 +255,37 @@ jobs:
               END {
                 if (!found) exit 3
               }
-            ' "$test_file"
-          ) || {
-            echo "::error::could not locate $test_name and determine its #[ignore] state"
-            exit 1
-          }
+            ' "$1"
+            }
+
+            # Regression fixture for the exact false-active case caught in PR #291:
+            # Rust comment trivia between #[ignore] and #[test] must preserve ignored state.
+            comment_fixture=$(mktemp)
+
+            cat >"$comment_fixture" <<'EOF'
+            #[ignore]
+            // Temporary deployment-transition note.
+            #[test]
+            fn tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it() {}
+             EOF
+
+            if ! fixture_state=$(detect_tag55_state "$comment_fixture"); then
+              rm -f "$comment_fixture"
+              echo "::error::tag-55 ignore-state parser comment fixture could not be evaluated"
+              exit 1
+            fi
+
+            rm -f "$comment_fixture"
+
+            if [ "$fixture_state" != "ignored" ]; then
+              echo "::error::tag-55 parser must preserve #[ignore] across Rust comment trivia"
+              exit 1
+            fi
+
+            state=$(detect_tag55_state "$test_file") || {
+              echo "::error::could not locate $test_name and determine its #[ignore] state"
+              exit 1
+            }
 
           if git -C percolator-prog-refs merge-base --is-ancestor "$boundary" "$want"; then
             if [ "$state" != "active" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,16 @@ jobs:
           ref: 15eb8b0c599e35a1c224bfa74f92b810c78fefb7
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
-      # A second, shallow checkout of prog's CURRENT main, used ONLY to read
-      # ci/deployed-refs.env for the drift guard below. Not built, not tested.
+      # A second checkout of prog's CURRENT main, used to read
+      # ci/deployed-refs.env for the drift guard below and to resolve whether
+      # WRAPPER_DEPLOYED contains wrapper #455. Full history is required for the
+      # ancestry check; this checkout is still not built or tested.
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: dcccrypto/percolator-prog
           path: percolator-prog-refs
           ref: main
-          fetch-depth: 1
+          fetch-depth: 0
           token: ${{ secrets.PERCOLATOR_PROG_TOKEN || github.token }}
 
       # percolator-prog has a path dependency on the engine
@@ -155,6 +157,109 @@ jobs:
             exit 1
           fi
           echo "wrapper pin is current"
+
+      # #286/#288 DEPLOYMENT-TRANSITION GUARD.
+      #
+      # #288 intentionally keeps the tag-55 proxy regression ignored while the
+      # deployed wrapper predates #455: the current stake signer (pool PDA / marketauth)
+      # is correct for post-#455 wrappers and intentionally incompatible with the
+      # currently deployed pre-#455 wrapper, which expects vault_auth.
+      #
+      # The source already documents the removal condition: when WRAPPER_DEPLOYED
+      # advances to a commit containing #455, delete #[ignore] in the same pin-bump
+      # commit. Make that condition mechanical so a reviewer cannot update the pin
+      # and accidentally leave this regression permanently skipped.
+      - name: Assert tag-55 regression state matches deployed wrapper
+        run: |
+          refs=percolator-prog-refs/ci/deployed-refs.env
+          test_file=percolator-stake/tests/task13_cpi_proxies_e2e.rs
+          boundary=0cc58c7ca1114b951133ec0960b96a565e33bb8e # percolator-prog #455
+          test_name=tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it
+
+          want=$(sed -n 's/^WRAPPER_DEPLOYED=//p' "$refs")
+          if [[ ! "$want" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::WRAPPER_DEPLOYED must be exactly one full 40-character SHA"
+            exit 1
+          fi
+
+          if ! git -C percolator-prog-refs cat-file -e "${want}^{commit}" 2>/dev/null; then
+            echo "::error::WRAPPER_DEPLOYED=$want is not present in the full prog history"
+            exit 1
+          fi
+          if ! git -C percolator-prog-refs cat-file -e "${boundary}^{commit}" 2>/dev/null; then
+            echo "::error::tag-55 boundary commit $boundary (#455) is not present in prog history"
+            exit 1
+          fi
+
+          # Read the attributes attached to this exact test, including multi-line
+          # attributes. Reset at function/source boundaries so an ignored neighboring
+          # test cannot satisfy the check.
+          state=$(
+            awk '
+              in_attr {
+                if ($0 ~ /\][[:space:]]*$/) {
+                  in_attr = 0
+                }
+                next
+              }
+
+              /^[[:space:]]*#\[/ {
+                if ($0 ~ /^[[:space:]]*#\[ignore([[:space:]=\]])/) {
+                  ignored = 1
+                }
+
+                if ($0 !~ /\][[:space:]]*$/) {
+                  in_attr = 1
+                }
+
+                next
+              }
+
+              /^[[:space:]]*fn[[:space:]]+tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it[[:space:]]*\(/ {
+                print ignored ? "ignored" : "active"
+                found = 1
+                exit
+              }
+
+              /^[[:space:]]*(pub[[:space:]]+)?fn[[:space:]]+/ {
+                ignored = 0
+                next
+              }
+
+              /^[[:space:]]*$/ {
+                next
+              }
+
+              {
+                ignored = 0
+              }
+
+              END {
+                if (!found) exit 3
+              }
+            ' "$test_file"
+          ) || {
+            echo "::error::could not locate $test_name and determine its #[ignore] state"
+            exit 1
+          }
+
+          if git -C percolator-prog-refs merge-base --is-ancestor "$boundary" "$want"; then
+            if [ "$state" != "active" ]; then
+              echo "::error::WRAPPER_DEPLOYED=$want contains #455 ($boundary),"
+              echo "::error::but $test_name is still #[ignore]."
+              echo "::error::Remove the ignore in the same commit that advances the wrapper pin"
+              echo "::error::so the tag-28 -> tag-55 coordinated-deploy regression is exercised."
+              exit 1
+            fi
+            echo "tag-55 guard: deployed wrapper contains #455; regression test is active"
+          else
+            rc=$?
+            if [ "$rc" -ne 1 ]; then
+              echo "::error::git merge-base failed while checking #455 ancestry (status $rc)"
+              exit 1
+            fi
+            echo "tag-55 guard: deployed wrapper predates #455; temporary #[ignore] is permitted"
+          fi
 
       - name: Build stake BPF program
         working-directory: percolator-stake

--- a/tests/task13_cpi_proxies_e2e.rs
+++ b/tests/task13_cpi_proxies_e2e.rs
@@ -1088,7 +1088,7 @@ fn tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it() {
             encode_proxy_trade_fee(POST_TRADE_FEE),
         ),
     )
-    .expect("stake tag 28 proxy must reach wrapper tag 55 by signing as vault_auth");
+    .expect("stake tag 28 proxy must reach wrapper tag 55 by signing as pool PDA (marketauth)");
 
     assert_eq!(
         read_u64_at(&e.svm, &market, OFF_TRADE_FEE_BASE_BPS),


### PR DESCRIPTION
## Summary

Follow-up hardening for #286 / #288.

#288 already fixed the actual tag-28 -> wrapper tag-55 authority mismatch by changing the stake proxy to sign with the pool PDA (`marketauth`) instead of `vault_auth`.

That fix intentionally leaves the tag-55 regression test ignored while the currently deployed wrapper is still pre-`dcccrypto/percolator-prog#455`, because the two wrapper generations require mutually exclusive authorities:

| Wrapper state | Tag 55 authority gate | Stake signer required |
|---|---|---|
| deployed `15eb8b0c599e35a1c224bfa74f92b810c78fefb7` — pre-#455 | per-asset `insurance_authority` | `vault_auth` |
| wrapper containing #455 | `cfg.marketauth` | pool PDA |

The removal condition is already documented in #288 and in `tests/task13_cpi_proxies_e2e.rs`: once `WRAPPER_DEPLOYED` advances to a wrapper containing #455, the tag-55 `#[ignore]` must be removed in the same wrapper pin-bump commit.

This PR does **not** change that deployment decision and does **not** modify any runtime or on-chain behavior.

Instead, it makes the existing deployment-transition condition mechanically enforced by CI, so a future wrapper pin bump cannot accidentally leave the tag-55 regression permanently skipped after the deployed wrapper has crossed the #455 authorization boundary.

---

## Context

`AdminUpdateTradeFeePolicy` is stake tag 28 and proxies wrapper tag 55 (`UpdateTradeFeePolicy`).

Before #288, stake tag 28 signed the CPI using `vault_auth`:

```text
stake tag 28
    -> vault_auth signs
    -> wrapper tag 55
```

That behavior matches the currently deployed wrapper `15eb8b0c599e35a1c224bfa74f92b810c78fefb7`, where tag 55 is gated by the per-asset insurance authority.

Wrapper #455 changed tag 55 to gate on:

```text
cfg.marketauth
```

rather than the per-asset insurance authority.

Because `InitPool` rotates `cfg.marketauth` to the stake pool PDA, #288 correctly changed the stake proxy to:

```text
stake tag 28
    -> pool PDA signs
    -> wrapper tag 55
```

The proxy presents a single authority account to wrapper tag 55. Therefore the two wrapper generations are mutually exclusive from the proxy's perspective:

```text
pre-#455 wrapper
    expects vault_auth

post-#455 wrapper
    expects pool PDA / marketauth
```

No single authority value can satisfy both wrapper generations.

For that reason, #288 deliberately keeps:

```rust
tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it
```

under `#[ignore]` while `WRAPPER_DEPLOYED` still points to the pre-#455 wrapper.

That behavior is correct for the current deployment.

The remaining concern is the **transition itself**.

The existing wrapper drift guard already forces the local wrapper pin to move when the canonical `WRAPPER_DEPLOYED` value changes, but removal of the tag-55 `#[ignore]` remains a reviewer-time/manual condition.

Without an additional invariant, the following future state is possible:

```text
wrapper containing #455 deployed
        |
        v
WRAPPER_DEPLOYED updated
        |
        v
stake wrapper pin updated
        |
        v
tag-55 #[ignore] accidentally retained
        |
        v
CI remains green while the tag-28 -> tag-55 regression stays skipped
```

This PR makes that final state fail CI.

---

## What changed

### 1. Make the wrapper reference checkout ancestry-aware

The secondary `percolator-prog-refs` checkout is used only to inspect the canonical deployment metadata and wrapper Git history.

It now uses:

```yaml
fetch-depth: 0
```

instead of a shallow checkout.

Full history is required because the deployment guard determines whether `WRAPPER_DEPLOYED` actually contains wrapper #455 using Git ancestry rather than assuming anything from SHA ordering or a specific future deployment hash.

The checkout remains separate from the wrapper binary used by the E2E suite.

---

### 2. Add a deployment-transition invariant for tag 55

CI reads the canonical deployed wrapper ref from:

```text
percolator-prog-refs/ci/deployed-refs.env
```

specifically:

```text
WRAPPER_DEPLOYED
```

The authorization transition boundary is the merge commit carrying wrapper #455:

```text
0cc58c7ca1114b951133ec0960b96a565e33bb8e
```

CI then evaluates:

```bash
git merge-base --is-ancestor \
  0cc58c7ca1114b951133ec0960b96a565e33bb8e \
  "$WRAPPER_DEPLOYED"
```

This intentionally uses Git ancestry.

It does **not** compare SHA strings, assume chronological ordering from hash values, or depend on one particular future wrapper deployment SHA.

The invariant enforced by the guard is:

```text
pre-#455 deployed wrapper
    + tag55 ignored
    -> allowed

pre-#455 deployed wrapper
    + tag55 active
    -> allowed

post-#455 deployed wrapper
    + tag55 active
    -> allowed

post-#455 deployed wrapper
    + tag55 ignored
    -> CI FAIL
```

Only the invalid deployment-transition state is rejected.

---

### 3. Fail closed if the deployment state cannot be proven

Before applying the transition rule, CI verifies the assumptions used by the guard.

It requires:

- `WRAPPER_DEPLOYED` to contain exactly one full 40-character hexadecimal SHA;
- the deployed wrapper commit to exist in the fetched `percolator-prog` history;
- the #455 boundary commit to exist in the fetched history;
- the exact tag-55 regression function to be locatable;
- the `#[ignore]` state of that exact test to be determinable.

If any of those conditions cannot be established, the guard fails instead of silently classifying the deployment as pre-#455.

This keeps the transition check fail-closed.

---

### 4. Scope ignore detection to the exact tag-55 regression

The CI guard inspects the specific test:

```rust
tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it
```

rather than globally searching the test file for an `#[ignore]` attribute.

The detector follows the attributes attached to the exact function and handles both ordinary and multi-line Rust attributes.

The parser was validated against the following forms:

```rust
#[test]
#[ignore = "..."]
fn tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it() {}
```

```rust
#[ignore = "..."]
#[test]
fn tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it() {}
```

and the multi-line form used by the repository:

```rust
#[test]
#[ignore = "GH#286: ... \
            ... \
            ..."]
fn tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it() {}
```

It also resets state across source/function boundaries so an unrelated ignored neighboring test cannot satisfy the tag-55 check.

---

### 5. Correct the stale tag-55 diagnostic

The tag-55 E2E assertion still described the pre-#288 signer:

```text
signing as vault_auth
```

even though #288 changed stake tag 28 to sign using the pool PDA.

The diagnostic is updated to:

```text
signing as pool PDA (marketauth)
```

This change is diagnostic-only and has no runtime effect.

---

## Why this belongs in CI

The deployment-transition rule already exists in #288.

The documented condition is effectively:

```text
when WRAPPER_DEPLOYED advances past #455,
remove the tag-55 #[ignore] in the same pin-bump commit
```

This PR does not introduce a new deployment policy.

It converts the existing rule from:

```text
reviewer must remember the removal condition
```

into:

```text
CI enforces the removal condition
```

That makes the wrapper pin and tag-55 regression state move together.

The existing drift guard answers:

```text
"Is stake testing against the canonical deployed wrapper ref?"
```

This follow-up guard additionally answers:

```text
"If that deployed wrapper contains #455, is the tag-55 regression actually enabled?"
```

Together they prevent a wrapper deployment transition from leaving the relevant regression path silently untested.

---

## Runtime / ABI impact

None.

This PR does not modify:

- stake instruction dispatch;
- instruction tags;
- CPI construction;
- CPI authority selection;
- signer seeds;
- PDA derivation;
- pool authority rules;
- vault authority rules;
- `marketauth` rotation;
- account ordering;
- account validation;
- serialized state;
- state layout;
- program IDs;
- wrapper behavior;
- canonical deployed refs;
- accounting behavior;
- insurance logic;
- tranche logic;
- balances;
- fees;
- user positions.

No on-chain program logic changes are introduced.

The functional change is limited to CI enforcement of the deployment condition already documented by #288.

---

## Validation

Validation was performed against the current `percolator-stake` upstream base:

```text
22e7fabfa0c2d639dc089b2b042142c3c09afd72
```

At final branch preparation:

```text
HEAD          = 22e7fabfa0c2d639dc089b2b042142c3c09afd72
upstream/main = 22e7fabfa0c2d639dc089b2b042142c3c09afd72
```

so the change was prepared directly against the current upstream structure.

---

### Git ancestry validation

The relevant wrapper commits were resolved from the actual `percolator-prog` history.

Currently deployed wrapper:

```text
15eb8b0c599e35a1c224bfa74f92b810c78fefb7
```

Wrapper #455 boundary:

```text
0cc58c7ca1114b951133ec0960b96a565e33bb8e
```

Both commits were confirmed present in the wrapper repository.

For the currently deployed wrapper:

```bash
git merge-base --is-ancestor \
  0cc58c7ca1114b951133ec0960b96a565e33bb8e \
  15eb8b0c599e35a1c224bfa74f92b810c78fefb7
```

returned:

```text
rc=1
```

which correctly classifies the current deployed wrapper as **pre-#455**.

The current wrapper main was separately verified to contain #455:

```text
#455 -> wrapper main
rc=0
```

---

### Current deployment control

With the actual deployment state:

```text
WRAPPER_DEPLOYED = 15eb8b0c599e35a1c224bfa74f92b810c78fefb7
tag55 state      = ignored
```

the guard produced:

```text
PASS: deployed wrapper predates #455; temporary ignore is permitted
```

This confirms that the PR does not make the current deployment red.

---

### Negative deployment control

A controlled post-#455 wrapper state was evaluated while deliberately leaving the tag-55 regression ignored.

Observed result:

```text
EXPECTED FAIL: post-#455 wrapper while tag55 is still ignored
negative-control rc=1
```

This is the exact state the new guard is intended to reject.

The temporary deployment fixture was restored afterward and the wrapper checkout returned clean.

---

### Attribute parser controls

The exact-test detector was independently checked against multiple Rust attribute layouts.

Results:

```text
#[test] + #[ignore]
-> ignored

#[ignore] + #[test]
-> ignored

multi-line #[ignore]
-> ignored

target without #[ignore]
-> active

ignored neighboring test +
active tag55 target
-> active

real repository tag55 source
-> ignored
```

These controls specifically verify that:

- attribute order does not change classification;
- the repository's multi-line `#[ignore]` is parsed correctly;
- an ignored neighboring test cannot create a false positive;
- an active target is not accidentally classified as ignored.

---

### SBF build validation

The stake program was built as an SBF artifact under WSL using the Anza toolchain.

Relevant toolchain observed during validation:

```text
solana-cli 4.2.2
cargo-build-sbf 4.1.0
platform-tools v1.54
```

Stake build:

```bash
cargo build-sbf -- --features devnet
```

completed successfully and produced:

```text
target/deploy/percolator_stake.so
```

The deployed wrapper lineage was assembled with the relevant engine sibling for runtime validation.

Wrapper ref:

```text
15eb8b0c599e35a1c224bfa74f92b810c78fefb7
```

Engine ref:

```text
f53be74aafcf5beda06890ffe3c4392637fe54bb
```

---

### LiteSVM binary-load smoke

The actual SBF artifacts were loaded through the v17 LiteSVM E2E environment.

Command:

```bash
cargo test \
  --features no-entrypoint \
  --test v17_stake_insurance_e2e \
  smoke_v17_binaries_load \
  -- --nocapture
```

Result:

```text
test smoke_v17_binaries_load ... ok

1 passed
0 failed
0 ignored
```

This confirms that validation reached the assembled SBF runtime environment rather than stopping at host-side compilation.

---

### Tag-28 / tag-55 CPI proxy suite

The targeted CPI proxy suite was run with the currently deployed pre-#455 wrapper environment:

```bash
cargo test \
  --features no-entrypoint \
  --test task13_cpi_proxies_e2e \
  -- --nocapture
```

Result:

```text
7 passed
0 failed
1 ignored
```

The one ignored test was exactly:

```text
tag55_trade_fee_direct_dies_after_bind_and_proxy_restores_it
```

with its existing GH#286 coordinated-deploy reason.

The remaining proxy tests executed successfully.

---

### Full stake suite

The full suite was then run:

```bash
cargo test \
  --features no-entrypoint \
  --no-fail-fast
```

Final status:

```text
full-suite rc=0
```

The tail included:

```text
v16_stake_insurance_e2e:
6 passed
0 failed
3 ignored
```

and:

```text
v17_stake_insurance_e2e:
10 passed
0 failed
0 ignored
```

No failures remained after the required SBF environment was assembled.

---

### Diff hygiene

Final diff validation:

```bash
git diff --check
```

completed cleanly.

Only these files are modified by the PR:

```text
.github/workflows/ci.yml
tests/task13_cpi_proxies_e2e.rs
```

No dependency, lockfile, runtime program source, generated SBF binary, local environment file, or unrelated source change is included.

---

## How to test

### Current deployed state

With `WRAPPER_DEPLOYED` still pointing to the pre-#455 wrapper:

```text
15eb8b0c599e35a1c224bfa74f92b810c78fefb7
```

and the tag-55 regression still ignored, CI should remain green.

Expected:

```text
pre-#455 wrapper + ignored tag55
-> PASS
```

### Deployment-transition negative control

Evaluate the guard against a wrapper commit containing #455 while leaving the tag-55 test ignored.

Expected:

```text
post-#455 wrapper + ignored tag55
-> FAIL
```

### Valid post-#455 state

After the deployed wrapper contains #455, remove the tag-55 `#[ignore]` in the same wrapper pin-bump change.

Expected:

```text
post-#455 wrapper + active tag55
-> PASS
```

At that point the tag-28 -> tag-55 regression becomes part of the normal suite again.

---

## Checklist

- [x] Based on current upstream `main`
- [x] Full Rust test suite passes
- [x] `cargo test --features no-entrypoint --no-fail-fast` returns `0`
- [x] Stake SBF build succeeds
- [x] Wrapper/stake SBF environment loads under LiteSVM
- [x] `smoke_v17_binaries_load` passes
- [x] Targeted CPI proxy suite passes
- [x] Current tag-55 deployment-dependent ignore remains intentional
- [x] Current pre-#455 deployment control passes
- [x] Post-#455 + ignored negative control fails as intended
- [x] Normal attribute-order detector control passes
- [x] Reversed attribute-order detector control passes
- [x] Multi-line `#[ignore]` detector control passes
- [x] Active-test detector control passes
- [x] Neighboring ignored-test false-positive control passes
- [x] Real repository tag-55 source is correctly classified as ignored
- [x] `git diff --check` clean
- [x] No runtime/on-chain program behavior changed
- [x] No ABI changes
- [x] No account-layout changes
- [x] No state-layout changes
- [x] No dependency changes
- [x] No lockfile changes
- [x] No generated SBF artifacts included
- [x] Kani not applicable: this PR does not modify math, proof logic, or runtime invariant code

---

## Related

Follow-up to #286.

Builds on the runtime/source fix merged in #288.

The authorization boundary is introduced by `dcccrypto/percolator-prog#455`.

This PR does **not** reopen, replace, or duplicate the resolution of #286.

Its scope is limited to making the deployment-transition condition already documented by #288 mechanically enforceable in CI, so the tag-55 regression cannot remain silently ignored after `WRAPPER_DEPLOYED` moves to a wrapper containing #455.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the tag 55 proxy test messaging to accurately describe the signing identity used by the proxy.
  - Added validation to ensure the regression test state matches the deployed wrapper version, preventing inconsistent test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->